### PR TITLE
Add publicPath config

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  "transpileDependencies": [
+  transpileDependencies: [
     "vuetify"
   ]
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,10 @@
+const process = require('process');
+
+const publicPath = process.env.PUBLIC_PATH || '/';
+
 module.exports = {
   transpileDependencies: [
     "vuetify"
-  ]
-}
+  ],
+  publicPath: process.env.NODE_ENV === 'production' ? publicPath : '/',
+};


### PR DESCRIPTION
This change allows `yarn build` to use the `PUBLIC_PATH` environment variable to control the application's deployment path.