### PR TITLE
Nested bars

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -175,6 +175,7 @@ export default {
             </v-card-subtitle>
 
             <v-select
+              v-if="renderNested"
               v-model="nestedBarVariables"
               :items="variableList"
               label="Bar Variables"
@@ -185,6 +186,7 @@ export default {
             />
 
             <v-select
+              v-if="renderNested"
               v-model="nestedGlyphVariables"
               :items="variableList"
               label="Glyph Variables"

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -116,7 +116,7 @@ export default {
           <v-card-text>
             <v-card-subtitle class="pb-0 pl-0">Marker Type</v-card-subtitle>
             <v-radio-group v-model="nodeMarkerType">
-              <v-radio name="active" label="Circle" value="Circle"></v-radio>
+              <v-radio name="active" label="Circle" value="Circle" @click="renderNested = false; nodeMarkerType = 'Circle'"></v-radio>
               <v-radio name="active" label="Rectangle" value="Rectangle"></v-radio>                
             </v-radio-group>
 

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -130,6 +130,7 @@ export default {
               <v-switch
                 class="ma-0"
                 v-model="renderNested"
+                :disabled="nodeMarkerType === 'Circle'"
                 hide-details
               />
             </v-card-subtitle>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -191,7 +191,9 @@ export default {
               :items="variableList"
               label="Glyph Variables"
               multiple
+              counter=2
               chips
+              deletable-chips="true"
               hint="Choose the variables you'd like to model as glyphs"
               persistent-hint
             />

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -37,6 +37,8 @@ export default {
       graph: null,
       selectNeighbors: true,
       renderNested: false,
+      nestedBarVariables: [],
+      nestedGlyphVariables: [],
       labelVariable: "_key",
       colorVariable: "table",
     };
@@ -172,6 +174,26 @@ export default {
               />
             </v-card-subtitle>
 
+            <v-select
+              v-model="nestedBarVariables"
+              :items="variableList"
+              label="Bar Variables"
+              multiple
+              chips
+              hint="Choose the variables you'd like to model as bars"
+              persistent-hint
+            />
+
+            <v-select
+              v-model="nestedGlyphVariables"
+              :items="variableList"
+              label="Glyph Variables"
+              multiple
+              chips
+              hint="Choose the variables you'd like to model as glyphs"
+              persistent-hint
+            />
+
             <v-divider class="mt-4" />
 
             <v-card-subtitle class="pb-0 px-0" style="display: flex; align-items: center; justify-content: space-between">
@@ -221,6 +243,8 @@ export default {
               renderNested,
               labelVariable,
               colorVariable,
+              nestedBarVariables,
+              nestedGlyphVariables,
             }"
             @restart-simulation="hello()"
             />

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -36,6 +36,7 @@ export default {
       workspace: null,
       graph: null,
       selectNeighbors: true,
+      renderNested: false,
     };
   },
 
@@ -98,6 +99,8 @@ export default {
               <v-radio name="active" label="Rectangle" value="Rectangle"></v-radio>                
             </v-radio-group>
 
+            <v-divider class="mt-4" />
+
             <v-card-subtitle class="pb-0 pl-0">Marker Size</v-card-subtitle>
             <v-slider
               v-model="nodeMarkerSize"
@@ -119,6 +122,17 @@ export default {
               inverse-label
               hide-details
             />
+
+            <v-divider class="mt-4" />
+
+            <v-card-subtitle class="pb-0 px-0" style="display: flex; align-items: center; justify-content: space-between">
+              Render Nested Elements
+              <v-switch
+                class="ma-0"
+                v-model="renderNested"
+                hide-details
+              />
+            </v-card-subtitle>
 
             <v-divider class="mt-4" />
 
@@ -166,6 +180,7 @@ export default {
               nodeMarkerType: nodeMarkerType,
               nodeFontSize,
               selectNeighbors,
+              renderNested,
             }"
             @restart-simulation="hello()"
             />

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -31,6 +31,7 @@ export default {
         links: []
       },
       nodeMarkerSize: 50,
+      nodeMarkerType: "Circle",
       nodeFontSize: 14,
       workspace: null,
       graph: null,
@@ -91,6 +92,12 @@ export default {
           <v-card-title class="pb-6">MultiNet Node Link Controls</v-card-title>
 
           <v-card-text>
+            <v-card-subtitle class="pb-0 pl-0">Marker Type</v-card-subtitle>
+            <v-radio-group v-model="nodeMarkerType">
+              <v-radio name="active" label="Circle" value="Circle"></v-radio>
+              <v-radio name="active" label="Rectangle" value="Rectangle"></v-radio>                
+            </v-radio-group>
+
             <v-card-subtitle class="pb-0 pl-0">Marker Size</v-card-subtitle>
             <v-slider
               v-model="nodeMarkerSize"
@@ -156,6 +163,7 @@ export default {
               app,
               nodeMarkerHeight: nodeMarkerSize,
               nodeMarkerLength: nodeMarkerSize,
+              nodeMarkerType: nodeMarkerType,
               nodeFontSize,
               selectNeighbors,
             }"

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -269,7 +269,7 @@ export default {
               app,
               nodeMarkerHeight: nodeMarkerSize,
               nodeMarkerLength: nodeMarkerSize,
-              nodeMarkerType: nodeMarkerType,
+              nodeMarkerType,
               nodeFontSize,
               selectNeighbors,
               renderNested,

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -181,6 +181,7 @@ export default {
               label="Bar Variables"
               multiple
               chips
+              deletable-chips="true"
               hint="Choose the variables you'd like to model as bars"
               persistent-hint
             />

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -208,7 +208,7 @@ export default {
               label="Bar Variables"
               multiple
               chips
-              deletable-chips="true"
+              deletable-chips
               hint="Choose the variables you'd like to model as bars"
               persistent-hint
             />
@@ -221,7 +221,7 @@ export default {
               multiple
               counter=2
               chips
-              deletable-chips="true"
+              deletable-chips
               hint="Choose the variables you'd like to model as glyphs"
               persistent-hint
             />

--- a/src/components/NodeLink/NodeLink.vue
+++ b/src/components/NodeLink/NodeLink.vue
@@ -95,7 +95,6 @@ export default {
       nodeColors: ["#66c2a5", "#fc8d62", "#8da0cb", "#e78ac3", "#a6d854"],
       edgeColor: "#888888",
       nodeSizeAttr: undefined,
-      drawBars: undefined,
       barPadding: 3,
       straightEdges: false,
       // distinguish a drag from a click

--- a/src/components/NodeLink/NodeLink.vue
+++ b/src/components/NodeLink/NodeLink.vue
@@ -78,11 +78,11 @@ export default {
       default: false
     },
     nestedBarVariables: {
-      type: Array[String],
+      type: Array,
       default: () => []
     },
     nestedGlyphVariables: {
-      type: Array[String],
+      type: Array,
       default: () => []
     },
   },

--- a/src/components/NodeLink/NodeLink.vue
+++ b/src/components/NodeLink/NodeLink.vue
@@ -62,6 +62,10 @@ export default {
         nodeFill: "table"
       })
     },
+    renderNested: {
+      type: Boolean,
+      default: false
+    },
   },
 
   data() {
@@ -111,6 +115,7 @@ export default {
         isDirected,
         isMultiEdge,
         attributes,
+        renderNested,
       } = this;
       return {
         graphStructure,
@@ -122,6 +127,7 @@ export default {
         isDirected,
         isMultiEdge,
         attributes,
+        renderNested,
       };
     }
   },

--- a/src/components/NodeLink/NodeLink.vue
+++ b/src/components/NodeLink/NodeLink.vue
@@ -69,6 +69,14 @@ export default {
       type: Boolean,
       default: false
     },
+    nestedBarVariables: {
+      type: Array[Object],
+      default: () => []
+    },
+    nestedGlyphVariables: {
+      type: Array[Object],
+      default: () => []
+    },
   },
 
   data() {
@@ -120,6 +128,8 @@ export default {
         renderNested,
         labelVariable,
         colorVariable,
+        nestedBarVariables,
+        nestedGlyphVariables,
       } = this;
       return {
         graphStructure,
@@ -133,6 +143,8 @@ export default {
         renderNested,
         labelVariable,
         colorVariable,
+        nestedBarVariables,
+        nestedGlyphVariables,
       };
     }
   },

--- a/src/components/NodeLink/NodeLink.vue
+++ b/src/components/NodeLink/NodeLink.vue
@@ -78,11 +78,11 @@ export default {
       default: false
     },
     nestedBarVariables: {
-      type: Array[Object],
+      type: Array[String],
       default: () => []
     },
     nestedGlyphVariables: {
-      type: Array[Object],
+      type: Array[String],
       default: () => []
     },
   },

--- a/src/components/NodeLink/NodeLink.vue
+++ b/src/components/NodeLink/NodeLink.vue
@@ -79,11 +79,13 @@ export default {
     },
     nestedBarVariables: {
       type: Array,
-      default: () => []
+      default: () => [],
+      validator: (prop) => prop.every((item) => typeof item === 'string'),
     },
     nestedGlyphVariables: {
       type: Array,
-      default: () => []
+      default: () => [],
+      validator: (prop) => prop.every((item) => typeof item === 'string'),
     },
   },
 

--- a/src/components/NodeLink/NodeLink.vue
+++ b/src/components/NodeLink/NodeLink.vue
@@ -39,6 +39,10 @@ export default {
       type: Number,
       default: 50
     },
+    nodeMarkerType: {
+      type: String,
+      default: "Circle"
+    },
     selectNeighbors: {
       type: Boolean,
       default: true
@@ -103,6 +107,7 @@ export default {
         nodeFontSize,
         nodeMarkerLength,
         nodeMarkerHeight,
+        nodeMarkerType,
         isDirected,
         isMultiEdge,
         attributes,
@@ -113,6 +118,7 @@ export default {
         nodeFontSize,
         nodeMarkerLength,
         nodeMarkerHeight,
+        nodeMarkerType,
         isDirected,
         isMultiEdge,
         attributes,

--- a/src/components/NodeLink/functionUi.js
+++ b/src/components/NodeLink/functionUi.js
@@ -1,3 +1,6 @@
+import * as d3 from "d3";
+import { getForceRadii } from "./functionUpdateVis";
+
 function clearSelections() {
   const { app, provenance } = this;
   let selected = [];
@@ -122,6 +125,14 @@ function releaseNodes() {
 }
 
 function startSimulation() {
+  // Update the force radii
+  this.simulation.force("collision", 
+    d3.forceCollide()
+    .radius(getForceRadii(this.nodeMarkerLength, this.nodeMarkerHeight, this.nodeMarkerType))
+    .strength(0.7)
+    .iterations(10)
+  );
+
   this.simulation.alpha(0.5);
   this.simulation.alphaTarget(0.02).restart();
 }

--- a/src/components/NodeLink/functionUpdateVis.js
+++ b/src/components/NodeLink/functionUpdateVis.js
@@ -400,7 +400,7 @@ function drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale, ne
       .attr("height", d => `${(nodeMarkerHeight - 16 - 5 - 5) * d[barVar] / maxValue}px`)
       .attr("y", d => `${nodeMarkerHeight - 5 - ((nodeMarkerHeight - 16 - 5 - 5) * d[barVar] / maxValue)}px`)
       .attr("x", `${5 + (i * barWidth)}px`)
-      .style("fill", d => nodeColorScale(barVar))
+      .style("fill", d => "#82b1ff")
     
     // Update i
     i++

--- a/src/components/NodeLink/functionUpdateVis.js
+++ b/src/components/NodeLink/functionUpdateVis.js
@@ -376,40 +376,54 @@ function drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale, ne
   node.selectAll(".glyph").remove()
 
   // Append bar elements
-  node.append("rect")
-    .attr("class", "bar")
-    .attr("width", `${(nodeMarkerLength / 2) - 5 - 5}px`)
-    .attr("height", `${nodeMarkerHeight - 16 - 5 - 5}px`)
-    .attr("y", `${16 +  5}px`)
-    .attr("x", `5px`)
-    .style("fill", "#FFFFFF")
-
-  node.append("rect")
-    .attr("class", "bar")
-    .attr("width", `${(nodeMarkerLength / 2) - 5 - 5}px`)
-    .attr("height", d => `${(nodeMarkerHeight - 16 - 5 - 5) * d[nestedBarVariables[0]]}px`)
-    .attr("y", `${16 +  5}px`)
-    .attr("x", `5px`)
-    .style("fill", d => nodeColorScale(nestedBarVariables[0]))
-
-  // Append glyphs
-  node.append("rect")
-    .attr("class", "glyph")
-    .attr("width", `${(nodeMarkerLength / 2) - 5 - 5 - 5}px`)
-    .attr("height", `${(nodeMarkerHeight / 2) - 5 - 5 - 5}px`)
-    .attr("y", `${16 +  5}px`)
-    .attr("x", `${5 + ((nodeMarkerLength / 2) - 5 - 5) + 5 + 5}px`)
-    .style("fill", d => nodeColorScale(d[nestedGlyphVariables[0]]))
+  let i = 0;
+  let barWidth = nestedGlyphVariables.length === 0 ? 
+    nodeMarkerLength / nestedBarVariables.length : 
+    (nodeMarkerLength / 2) / nestedBarVariables.length / nestedBarVariables.length;
+  for (let barVar of nestedBarVariables) {
+    node.append("rect")
+      .attr("class", "bar")
+      .attr("width", `${barWidth - 10}px`)
+      .attr("height", `${nodeMarkerHeight - 16 - 5 - 5}px`)
+      .attr("y", `${16 +  5}px`)
+      .attr("x", `${5 + (i * barWidth)}px`)
+      .style("fill", "#FFFFFF")
 
     node.append("rect")
-    .attr("class", "glyph")
-    .attr("width", `${(nodeMarkerLength / 2) - 5 - 5 - 5}px`)
-    .attr("height", `${(nodeMarkerHeight / 2) - 5 - 5 - 5}px`)
-    .attr("y", `${16 +  5 + (nodeMarkerHeight / 2) - 5 - 5}px`)
-    .attr("x", `${5 + ((nodeMarkerLength / 2) - 5 - 5) + 5 + 5}px`)
-    .attr("ry", `${((nodeMarkerHeight / 2) - 5 - 5) / 2}px`)
-    .attr("rx", `${((nodeMarkerLength / 2) - 5 - 5) / 2}px`)
-    .style("fill", d => nodeColorScale(d[nestedGlyphVariables[1]]))
+      .attr("class", "bar")
+      .attr("width", `${barWidth - 10}px`)
+      .attr("height", d => `${(nodeMarkerHeight - 16 - 5 - 5) * d[barVar] / 10}px`)
+      .attr("y", d => `${nodeMarkerHeight - 5 - ((nodeMarkerHeight - 16 - 5 - 5) * d[barVar] / 10)}px`)
+      .attr("x", `${5 + (i * barWidth)}px`)
+      .style("fill", d => nodeColorScale(barVar))
+    
+    // Update i
+    i++
+  }
+
+  // Append glyphs
+  i = 0;
+  for (let glyphVar of nestedGlyphVariables) {
+    node.append("rect")
+      .attr("class", "glyph")
+      .attr("width", `${(nodeMarkerLength / 2) - 5 - 5 - 5}px`)
+      .attr("height", `${(nodeMarkerHeight / 2) - 5 - 5 - 5}px`)
+      .attr("y", `${16 +  5}px`)
+      .attr("x", `${5 + ((nodeMarkerLength / 2) - 5 - 5) + 5 + 5}px`)
+      .style("fill", d => nodeColorScale(d[nestedGlyphVariables[0]]))
+
+    node.append("rect")
+      .attr("class", "glyph")
+      .attr("width", `${(nodeMarkerLength / 2)- 5 - 5 - 5}px`)
+      .attr("height", `${(nodeMarkerHeight / 2) - 5 - 5 - 5}px`)
+      .attr("y", `${16 +  5 + (nodeMarkerHeight / 2) - 5 - 5}px`)
+      .attr("x", `${5 + ((nodeMarkerLength / 2) - 5 - 5) + 5 + 5}px`)
+      .attr("ry", `${((nodeMarkerHeight / 2) - 5 - 5) / 2}px`)
+      .attr("rx", `${((nodeMarkerLength / 2) - 5 - 5) / 2}px`)
+      .style("fill", d => nodeColorScale(d[nestedGlyphVariables[1]]))
+    
+    i++
+  }
 }
 
 

--- a/src/components/NodeLink/functionUpdateVis.js
+++ b/src/components/NodeLink/functionUpdateVis.js
@@ -172,7 +172,7 @@ function makeSimulation() {
   return simulation;
 }
 
-export function getForceRadii(nodeMarkerLength, nodeMarkerHeight, nodeMarkerType) {
+function getForceRadii(nodeMarkerLength, nodeMarkerHeight, nodeMarkerType) {
   if (nodeMarkerType === "Circle") {
     return d3.max([nodeMarkerLength / 2, nodeMarkerHeight / 2]) * 1.5
   } else {
@@ -180,12 +180,16 @@ export function getForceRadii(nodeMarkerLength, nodeMarkerHeight, nodeMarkerType
   }
 }
 
-function nodeFill(node) {
-  const { attributes, colorClasses, nodeColors } = this;
-  if (attributes.nodeFill === "table") {
-    const index = colorClasses.findIndex(d => { return d === node.id.split("/")[0] }) % 5
-    return nodeColors[index]
-  }
+function nodeFill(node, renderNested) {
+  if (renderNested) {
+    return "#DDDDDD"
+  } else {
+    const { attributes, colorClasses, nodeColors } = this;
+    if (attributes.nodeFill === "table") {
+      const index = colorClasses.findIndex(d => { return d === node.id.split("/")[0] }) % 5
+      return nodeColors[index]
+    }
+}
 }
 
 function showTooltip(data, delay = 200) {
@@ -210,7 +214,10 @@ function updateVis() {
     svg,
     visMargins,
     visDimensions,
+    renderNested
   } = this;
+
+  console.log(renderNested)
 
   let node = svg
     .select(".nodes")
@@ -261,7 +268,7 @@ function updateVis() {
     });
 
   node.select('.node')
-    .style("fill", d => this.nodeFill(d))
+    .style("fill", d => this.nodeFill(d, renderNested))
     .on("click", (d) => this.nodeClick(d))
     .on("mouseover", (d) => {
       this.showTooltip(d.id);
@@ -354,4 +361,5 @@ export {
   nodeFill,
   showTooltip,
   updateVis,
+  getForceRadii,
 };

--- a/src/components/NodeLink/functionUpdateVis.js
+++ b/src/components/NodeLink/functionUpdateVis.js
@@ -217,8 +217,6 @@ function updateVis() {
     renderNested
   } = this;
 
-  console.log(renderNested)
-
   let node = svg
     .select(".nodes")
     .selectAll(".nodeGroup")
@@ -279,12 +277,26 @@ function updateVis() {
     .select("text")
     .text(d => d[nodeLabel])
     .style("font-size", nodeFontSize + "pt")
-    .attr("dx", () => nodeMarkerLength / 2)
-    .attr("dy", () => (nodeMarkerHeight / 2) + 2)
+    .attr("dx", () => {
+      return nodeMarkerLength / 2
+    })
+    .attr("dy", () => {
+      if (nodeMarkerType === "Circle") {
+        return (nodeMarkerHeight / 2) + 2
+      } else {
+        return 8
+      }
+    })
 
   node
     .select(".labelBackground")
-    .attr("y", () => nodeMarkerHeight / 2 - 8)
+    .attr("y", () => {
+      if (nodeMarkerType === "Circle") {
+        return (nodeMarkerHeight / 2) - 8
+      } else {
+        return 0
+      }
+    })
     .attr("width", () => nodeMarkerLength)
     .attr('height', //config.nodeLink.drawBars ? 16 : 
       "1em")

--- a/src/components/NodeLink/functionUpdateVis.js
+++ b/src/components/NodeLink/functionUpdateVis.js
@@ -205,7 +205,11 @@ function updateVis() {
     renderNested,
     colorVariable,
     nodeColorScale,
+    nestedBarVariables,
+    nestedGlyphVariables,
   } = this;
+
+  console.log("bar and glyph vars", nestedBarVariables, nestedGlyphVariables)
 
   let node = svg
     .select(".nodes")
@@ -300,7 +304,7 @@ function updateVis() {
     .attr('height', "1em")
 
   if (renderNested) {
-    drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale)
+    drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale, nestedBarVariables, nestedGlyphVariables,)
   } else {
     node.selectAll(".bar").remove()
     node.selectAll(".glyph").remove()
@@ -366,7 +370,7 @@ function updateVis() {
   // drawLegend();
 }
 
-function drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale) {
+function drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale, nestedBarVariables, nestedGlyphVariables) {
   // Delete past renders
   node.selectAll(".bar").remove()
   node.selectAll(".glyph").remove()
@@ -378,7 +382,15 @@ function drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale) {
     .attr("height", `${nodeMarkerHeight - 16 - 5 - 5}px`)
     .attr("y", `${16 +  5}px`)
     .attr("x", `5px`)
-    .style("fill", d => nodeColorScale(0))
+    .style("fill", "#FFFFFF")
+
+  node.append("rect")
+    .attr("class", "bar")
+    .attr("width", `${(nodeMarkerLength / 2) - 5 - 5}px`)
+    .attr("height", d => `${(nodeMarkerHeight - 16 - 5 - 5) * d[nestedBarVariables[0]]}px`)
+    .attr("y", `${16 +  5}px`)
+    .attr("x", `5px`)
+    .style("fill", d => nodeColorScale(nestedBarVariables[0]))
 
   // Append glyphs
   node.append("rect")
@@ -387,7 +399,7 @@ function drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale) {
     .attr("height", `${(nodeMarkerHeight / 2) - 5 - 5 - 5}px`)
     .attr("y", `${16 +  5}px`)
     .attr("x", `${5 + ((nodeMarkerLength / 2) - 5 - 5) + 5 + 5}px`)
-    .style("fill", d => nodeColorScale(1))
+    .style("fill", d => nodeColorScale(d[nestedGlyphVariables[0]]))
 
     node.append("rect")
     .attr("class", "glyph")
@@ -397,7 +409,7 @@ function drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale) {
     .attr("x", `${5 + ((nodeMarkerLength / 2) - 5 - 5) + 5 + 5}px`)
     .attr("ry", `${((nodeMarkerHeight / 2) - 5 - 5) / 2}px`)
     .attr("rx", `${((nodeMarkerLength / 2) - 5 - 5) / 2}px`)
-    .style("fill", d => nodeColorScale(2))
+    .style("fill", d => nodeColorScale(d[nestedGlyphVariables[1]]))
 }
 
 

--- a/src/components/NodeLink/functionUpdateVis.js
+++ b/src/components/NodeLink/functionUpdateVis.js
@@ -299,9 +299,11 @@ function updateVis() {
     .attr("width", () => nodeMarkerLength)
     .attr('height', "1em")
 
-  console.log(renderNested)
   if (renderNested) {
-    drawNested(node, nodeMarkerHeight, nodeMarkerLength)
+    drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale)
+  } else {
+    node.selectAll(".bar").remove()
+    node.selectAll(".glyph").remove()
   }
 
   node.call(
@@ -364,7 +366,7 @@ function updateVis() {
   // drawLegend();
 }
 
-function drawNested(node, nodeMarkerHeight, nodeMarkerLength) {
+function drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale) {
   // Delete past renders
   node.selectAll(".bar").remove()
   node.selectAll(".glyph").remove()
@@ -376,6 +378,7 @@ function drawNested(node, nodeMarkerHeight, nodeMarkerLength) {
     .attr("height", `${nodeMarkerHeight - 16 - 5 - 5}px`)
     .attr("y", `${16 +  5}px`)
     .attr("x", `5px`)
+    .style("fill", d => nodeColorScale(0))
 
   // Append glyphs
   node.append("rect")
@@ -384,6 +387,7 @@ function drawNested(node, nodeMarkerHeight, nodeMarkerLength) {
     .attr("height", `${(nodeMarkerHeight / 2) - 5 - 5 - 5}px`)
     .attr("y", `${16 +  5}px`)
     .attr("x", `${5 + ((nodeMarkerLength / 2) - 5 - 5) + 5 + 5}px`)
+    .style("fill", d => nodeColorScale(1))
 
     node.append("rect")
     .attr("class", "glyph")
@@ -393,6 +397,7 @@ function drawNested(node, nodeMarkerHeight, nodeMarkerLength) {
     .attr("x", `${5 + ((nodeMarkerLength / 2) - 5 - 5) + 5 + 5}px`)
     .attr("ry", `${((nodeMarkerHeight / 2) - 5 - 5) / 2}px`)
     .attr("rx", `${((nodeMarkerLength / 2) - 5 - 5) / 2}px`)
+    .style("fill", d => nodeColorScale(2))
 }
 
 

--- a/src/components/NodeLink/functionUpdateVis.js
+++ b/src/components/NodeLink/functionUpdateVis.js
@@ -408,7 +408,11 @@ function drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale, ne
 
   // Append glyphs
   i = 0;
-  for (let glyphVar of nestedGlyphVariables) {
+  while (i < 2) {
+    let glyphVar = nestedGlyphVariables[i]
+    if (glyphVar === undefined) {
+      break
+    }
     // Draw glyph
     node.append("rect")
       .attr("class", "glyph")

--- a/src/components/NodeLink/functionUpdateVis.js
+++ b/src/components/NodeLink/functionUpdateVis.js
@@ -201,6 +201,7 @@ function updateVis() {
     nodeLabel,
     nodeMarkerLength,
     nodeMarkerHeight,
+    nodeMarkerType,
     svg,
     visMargins,
     visDimensions,
@@ -239,8 +240,20 @@ function updateVis() {
     .selectAll(".nodeBox")
     .attr("width", () => nodeMarkerLength)
     .attr("height", () => nodeMarkerHeight)
-    .attr("rx", () => nodeMarkerLength / 2)
-    .attr("ry", () => nodeMarkerHeight / 2);
+    .attr("rx", () => { 
+      if (nodeMarkerType === "Circle") {
+        return nodeMarkerLength / 2 
+      } else {
+        return 0
+      }
+    })
+    .attr("ry", () => { 
+      if (nodeMarkerType === "Circle") {
+        return nodeMarkerLength / 2 
+      } else {
+        return 0
+      }
+    });
 
   node.select('.node')
     .style("fill", d => this.nodeFill(d))

--- a/src/components/NodeLink/functionUpdateVis.js
+++ b/src/components/NodeLink/functionUpdateVis.js
@@ -133,6 +133,7 @@ function makeSimulation() {
     graphStructure,
     nodeMarkerLength,
     nodeMarkerHeight,
+    nodeMarkerType,
   } = this;
 
   const simulation = d3
@@ -156,13 +157,9 @@ function makeSimulation() {
 
   simulation.on("tick", () => this.dragNode());
 
-  simulation.force("collision", d3.forceCollide()
-    .radius(() => {
-      return (
-        d3.max([nodeMarkerLength / 2, nodeMarkerHeight / 2]) *
-        1.5
-      );
-    })
+  simulation.force("collision", 
+    d3.forceCollide()
+    .radius(getForceRadii(nodeMarkerLength, nodeMarkerHeight, nodeMarkerType))
     .strength(0.7)
     .iterations(10)
   );
@@ -173,6 +170,14 @@ function makeSimulation() {
   simulation.alphaTarget(0.02).restart();
 
   return simulation;
+}
+
+export function getForceRadii(nodeMarkerLength, nodeMarkerHeight, nodeMarkerType) {
+  if (nodeMarkerType === "Circle") {
+    return d3.max([nodeMarkerLength / 2, nodeMarkerHeight / 2]) * 1.5
+  } else {
+    return d3.max([nodeMarkerLength , nodeMarkerHeight]) * 0.8
+  }
 }
 
 function nodeFill(node) {

--- a/src/components/NodeLink/functionUpdateVis.js
+++ b/src/components/NodeLink/functionUpdateVis.js
@@ -212,8 +212,6 @@ function updateVis() {
     linkColorVariable,
   } = this;
 
-  console.log("bar and glyph vars", nestedBarVariables, nestedGlyphVariables)
-
   let node = svg
     .select(".nodes")
     .selectAll(".nodeGroup")
@@ -247,26 +245,12 @@ function updateVis() {
     .selectAll(".nodeBox")
     .attr("width", () => nodeMarkerLength)
     .attr("height", () => nodeMarkerHeight)
-    .attr("rx", () => { 
-      if (nodeMarkerType === "Circle") {
-        return nodeMarkerLength / 2 
-      } else {
-        return 0
-      }
-    })
-    .attr("ry", () => { 
-      if (nodeMarkerType === "Circle") {
-        return nodeMarkerLength / 2 
-      } else {
-        return 0
-      }
-    });
+    .attr("rx", nodeMarkerType === "Circle" ? nodeMarkerLength / 2 : 0)
+    .attr("ry", nodeMarkerType === "Circle" ? nodeMarkerHeight / 2 : 0)
 
   node.select('.node')
     .style("fill", d => {
-      if (renderNested) {
-        return "#DDDDDD"
-      } else if (colorVariable === "table") {
+      if (colorVariable === "table") {
         let table = d["id"].split("/")[0]
         return nodeColorScale(table)
       } else {
@@ -397,7 +381,6 @@ function drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale, ne
 
   for (let barVar of nestedBarVariables) {
     let maxValue = d3.max(graphStructure.nodes.map(o => parseFloat(o[barVar])));
-    console.log(maxValue)
     // Draw white, background bar
     node.append("rect")
       .attr("class", "bar")

--- a/src/components/NodeLink/functionUpdateVis.js
+++ b/src/components/NodeLink/functionUpdateVis.js
@@ -304,7 +304,7 @@ function updateVis() {
     .attr('height', "1em")
 
   if (renderNested) {
-    drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale, nestedBarVariables, nestedGlyphVariables,)
+    drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale, nestedBarVariables, nestedGlyphVariables, graphStructure)
   } else {
     node.selectAll(".bar").remove()
     node.selectAll(".glyph").remove()
@@ -370,17 +370,21 @@ function updateVis() {
   // drawLegend();
 }
 
-function drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale, nestedBarVariables, nestedGlyphVariables) {
+function drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale, nestedBarVariables, nestedGlyphVariables, graphStructure) {
   // Delete past renders
   node.selectAll(".bar").remove()
   node.selectAll(".glyph").remove()
 
-  // Append bar elements
+  // Set some bar specific variables that we'll need for tracking position and sizes
   let i = 0;
   let barWidth = nestedGlyphVariables.length === 0 ? 
     nodeMarkerLength / nestedBarVariables.length : 
-    (nodeMarkerLength / 2) / nestedBarVariables.length / nestedBarVariables.length;
+    (nodeMarkerLength / 2) / nestedBarVariables.length;
+
   for (let barVar of nestedBarVariables) {
+    let maxValue = d3.max(graphStructure.nodes.map(o => parseFloat(o[barVar])));
+    console.log(maxValue)
+    // Draw white, background bar
     node.append("rect")
       .attr("class", "bar")
       .attr("width", `${barWidth - 10}px`)
@@ -389,11 +393,12 @@ function drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale, ne
       .attr("x", `${5 + (i * barWidth)}px`)
       .style("fill", "#FFFFFF")
 
+    // Draw the color bar with height based on data
     node.append("rect")
       .attr("class", "bar")
       .attr("width", `${barWidth - 10}px`)
-      .attr("height", d => `${(nodeMarkerHeight - 16 - 5 - 5) * d[barVar] / 10}px`)
-      .attr("y", d => `${nodeMarkerHeight - 5 - ((nodeMarkerHeight - 16 - 5 - 5) * d[barVar] / 10)}px`)
+      .attr("height", d => `${(nodeMarkerHeight - 16 - 5 - 5) * d[barVar] / maxValue}px`)
+      .attr("y", d => `${nodeMarkerHeight - 5 - ((nodeMarkerHeight - 16 - 5 - 5) * d[barVar] / maxValue)}px`)
       .attr("x", `${5 + (i * barWidth)}px`)
       .style("fill", d => nodeColorScale(barVar))
     
@@ -404,24 +409,18 @@ function drawNested(node, nodeMarkerHeight, nodeMarkerLength, nodeColorScale, ne
   // Append glyphs
   i = 0;
   for (let glyphVar of nestedGlyphVariables) {
+    // Draw glyph
     node.append("rect")
       .attr("class", "glyph")
       .attr("width", `${(nodeMarkerLength / 2) - 5 - 5 - 5}px`)
       .attr("height", `${(nodeMarkerHeight / 2) - 5 - 5 - 5}px`)
-      .attr("y", `${16 +  5}px`)
-      .attr("x", `${5 + ((nodeMarkerLength / 2) - 5 - 5) + 5 + 5}px`)
-      .style("fill", d => nodeColorScale(d[nestedGlyphVariables[0]]))
-
-    node.append("rect")
-      .attr("class", "glyph")
-      .attr("width", `${(nodeMarkerLength / 2)- 5 - 5 - 5}px`)
-      .attr("height", `${(nodeMarkerHeight / 2) - 5 - 5 - 5}px`)
-      .attr("y", `${16 +  5 + (nodeMarkerHeight / 2) - 5 - 5}px`)
+      .attr("y", `${16 +  5 + (i * ((nodeMarkerHeight / 2) - 5 - 5 - 5)) + 5*(i)}px`)
       .attr("x", `${5 + ((nodeMarkerLength / 2) - 5 - 5) + 5 + 5}px`)
       .attr("ry", `${((nodeMarkerHeight / 2) - 5 - 5) / 2}px`)
       .attr("rx", `${((nodeMarkerLength / 2) - 5 - 5) / 2}px`)
-      .style("fill", d => nodeColorScale(d[nestedGlyphVariables[1]]))
+      .style("fill", d => nodeColorScale(d[glyphVar]))
     
+    // Update i
     i++
   }
 }

--- a/src/components/NodeLink/functionUpdateVis.js
+++ b/src/components/NodeLink/functionUpdateVis.js
@@ -299,8 +299,9 @@ function updateVis() {
     .attr("width", () => nodeMarkerLength)
     .attr('height', "1em")
 
+  console.log(renderNested)
   if (renderNested) {
-    drawNested(node, nodeMarkerHeight)
+    drawNested(node, nodeMarkerHeight, nodeMarkerLength)
   }
 
   node.call(
@@ -363,31 +364,35 @@ function updateVis() {
   // drawLegend();
 }
 
-function drawNested(node, nodeMarkerHeight) {
+function drawNested(node, nodeMarkerHeight, nodeMarkerLength) {
+  // Delete past renders
+  node.selectAll(".bar").remove()
+  node.selectAll(".glyph").remove()
+
   // Append bar elements
   node.append("rect")
     .attr("class", "bar")
-    .attr("width", "20px")
-    .attr("height", `${nodeMarkerHeight - 26}px`)
-    .attr("y", `20px`)
+    .attr("width", `${(nodeMarkerLength / 2) - 5 - 5}px`)
+    .attr("height", `${nodeMarkerHeight - 16 - 5 - 5}px`)
+    .attr("y", `${16 +  5}px`)
     .attr("x", `5px`)
 
   // Append glyphs
   node.append("rect")
     .attr("class", "glyph")
-    .attr("width", "20px")
-    .attr("height", `20px`)
-    .attr("y", `20px`)
-    .attr("x", `50px`)
+    .attr("width", `${(nodeMarkerLength / 2) - 5 - 5 - 5}px`)
+    .attr("height", `${(nodeMarkerHeight / 2) - 5 - 5 - 5}px`)
+    .attr("y", `${16 +  5}px`)
+    .attr("x", `${5 + ((nodeMarkerLength / 2) - 5 - 5) + 5 + 5}px`)
 
     node.append("rect")
     .attr("class", "glyph")
-    .attr("width", "20px")
-    .attr("height", `20px`)
-    .attr("y", `70px`)
-    .attr("x", `50px`)
-    .attr("ry", `10px`)
-    .attr("rx", `10px`)
+    .attr("width", `${(nodeMarkerLength / 2) - 5 - 5 - 5}px`)
+    .attr("height", `${(nodeMarkerHeight / 2) - 5 - 5 - 5}px`)
+    .attr("y", `${16 +  5 + (nodeMarkerHeight / 2) - 5 - 5}px`)
+    .attr("x", `${5 + ((nodeMarkerLength / 2) - 5 - 5) + 5 + 5}px`)
+    .attr("ry", `${((nodeMarkerHeight / 2) - 5 - 5) / 2}px`)
+    .attr("rx", `${((nodeMarkerLength / 2) - 5 - 5) / 2}px`)
 }
 
 

--- a/src/components/NodeLink/functionUpdateVis.js
+++ b/src/components/NodeLink/functionUpdateVis.js
@@ -281,7 +281,7 @@ function updateVis() {
       return nodeMarkerLength / 2
     })
     .attr("dy", () => {
-      if (nodeMarkerType === "Circle") {
+      if (nodeMarkerType === "Circle" || !renderNested) {
         return (nodeMarkerHeight / 2) + 2
       } else {
         return 8
@@ -291,15 +291,14 @@ function updateVis() {
   node
     .select(".labelBackground")
     .attr("y", () => {
-      if (nodeMarkerType === "Circle") {
+      if (nodeMarkerType === "Circle" || !renderNested) {
         return (nodeMarkerHeight / 2) - 8
       } else {
         return 0
       }
     })
     .attr("width", () => nodeMarkerLength)
-    .attr('height', //config.nodeLink.drawBars ? 16 : 
-      "1em")
+    .attr('height', "1em")
 
   node.call(
     d3

--- a/src/components/NodeLink/functionUpdateVis.js
+++ b/src/components/NodeLink/functionUpdateVis.js
@@ -299,6 +299,10 @@ function updateVis() {
     .attr("width", () => nodeMarkerLength)
     .attr('height', "1em")
 
+  if (renderNested) {
+    drawNested(node, nodeMarkerHeight)
+  }
+
   node.call(
     d3
       .drag()
@@ -357,6 +361,33 @@ function updateVis() {
   })
 
   // drawLegend();
+}
+
+function drawNested(node, nodeMarkerHeight) {
+  // Append bar elements
+  node.append("rect")
+    .attr("class", "bar")
+    .attr("width", "20px")
+    .attr("height", `${nodeMarkerHeight - 26}px`)
+    .attr("y", `20px`)
+    .attr("x", `5px`)
+
+  // Append glyphs
+  node.append("rect")
+    .attr("class", "glyph")
+    .attr("width", "20px")
+    .attr("height", `20px`)
+    .attr("y", `20px`)
+    .attr("x", `50px`)
+
+    node.append("rect")
+    .attr("class", "glyph")
+    .attr("width", "20px")
+    .attr("height", `20px`)
+    .attr("y", `70px`)
+    .attr("x", `50px`)
+    .attr("ry", `10px`)
+    .attr("rx", `10px`)
 }
 
 


### PR DESCRIPTION
Closes #33. 

Todo:
- [x] Move node labels
- [x] Add bars
- [x] Add glyphs
- [x] Make everything resize correctly
- [x] Support zero, one, or multiple bars
- [x] Support zero, one, or multiple glyphs (currently at most 2)
- [x] Map the variables from data to the visuals
- [x] Dynamically assign variables
- [ ] Restrict categorical vars to glyphs and numeric to bars
- [ ] Automatically bump up the size of the node if it's too small to render what's requested
- [ ] Fix bug where you can switch to circle with renderNested set to true (only fixed when clicking the radio button, not the text)