### PR TITLE
Add provenance tracking to select and de-select nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@types/d3": "^5.7.2",
-    "@visdesignlab/trrack": "^1.2.0",
+    "@visdesignlab/trrack": "^2.0.0-alpha.5",
     "core-js": "^3.4.3",
     "d3-array": "^2.8.0",
     "d3-axis": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@types/d3": "^5.7.2",
-    "@visdesignlab/trrack": "^2.0.0-alpha.5",
+    "@visdesignlab/trrack": "^2.0.0-alpha.7",
     "core-js": "^3.4.3",
     "d3-array": "^2.8.0",
     "d3-axis": "^2.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -34,6 +34,8 @@ export default {
       workspaceName: workspace,
       networkName: graph,
     });
+
+    store.commit.createProvenance();
   },
 };
 </script>

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -5,6 +5,7 @@ export function updateProvenanceState(vuexState: State, label: ProvenanceEventTy
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const stateUpdateActions = createAction<State, any[], ProvenanceEventTypes>((provState, newProvState) => {
     if (label === 'Select Node' || label === 'De-select Node') {
+      // eslint-disable-next-line no-param-reassign
       provState.selectedNodes = newProvState.selectedNodes;
     }
   })

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -1,0 +1,16 @@
+import { ProvenanceEventTypes, State } from '@/types';
+import { createAction } from '@visdesignlab/trrack';
+
+export function updateProvenanceState(vuexState: State, label: ProvenanceEventTypes) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const stateUpdateActions = createAction<State, any[], ProvenanceEventTypes>((provState, newProvState) => {
+    if (label === 'Select Node' || label === 'De-select Node') {
+      provState.selectedNodes = newProvState.selectedNodes;
+    }
+  })
+    .setLabel(label);
+
+  if (vuexState.provenance !== null) {
+    vuexState.provenance.apply(stateUpdateActions(vuexState));
+  }
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -13,6 +13,7 @@ import {
 } from 'd3-scale';
 import { schemeCategory10 } from 'd3-scale-chromatic';
 import { initProvenance } from '@visdesignlab/trrack';
+import { updateProvenanceState } from '@/lib/provenanceUtils';
 
 Vue.use(Vuex);
 
@@ -167,11 +168,19 @@ const {
 
     addSelectedNode(state, nodeID: string) {
       state.selectedNodes = new Set(state.selectedNodes.add(nodeID));
+
+      if (state.provenance !== null) {
+        updateProvenanceState(state, 'Select Node');
+      }
     },
 
     removeSelectedNode(state, nodeID: string) {
       state.selectedNodes.delete(nodeID);
       state.selectedNodes = new Set(state.selectedNodes);
+
+      if (state.provenance !== null) {
+        updateProvenanceState(state, 'De-select Node');
+      }
     },
 
     setRenderNested(state, renderNested: boolean) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,56 +4,16 @@ import { createDirectStore } from 'direct-vuex';
 import { Simulation } from 'd3-force';
 
 import {
-  Link, Node, Network, SimulationLink,
+  Link, Node, Network, SimulationLink, State, LinkStyleVariables, LoadError, NestedVariables,
 } from '@/types';
 import api from '@/api';
 import { GraphSpec, RowsSpec, TableRow } from 'multinet';
 import {
-  scaleLinear, ScaleLinear, scaleOrdinal, ScaleOrdinal,
+  scaleLinear, scaleOrdinal,
 } from 'd3-scale';
 import { schemeCategory10 } from 'd3-scale-chromatic';
 
 Vue.use(Vuex);
-
-interface LoadError {
-  message: string;
-  buttonText: string;
-  href: string;
-}
-
-interface NestedVariables {
-  bar: string[];
-  glyph: string[];
-}
-
-interface LinkStyleVariables {
-  width: string;
-  color: string;
-}
-
-interface AttributeRanges {
-  [key: string]: {attr: string; min: number; max: number};
-}
-
-export interface State {
-  workspaceName: string | null;
-  networkName: string | null;
-  network: Network | null;
-  selectedNodes: Set<string>;
-  loadError: LoadError;
-  simulation: Simulation<Node, SimulationLink> | null;
-  renderNested: boolean;
-  markerSize: number;
-  fontSize: number;
-  labelVariable: string;
-  colorVariable: string;
-  selectNeighbors: boolean;
-  nestedVariables: NestedVariables;
-  linkVariables: LinkStyleVariables;
-  attributeRanges: AttributeRanges;
-  nodeColorScale: ScaleOrdinal<string, string>;
-  linkWidthScale: ScaleLinear<number, number>;
-}
 
 const {
   store,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,7 +4,7 @@ import { createDirectStore } from 'direct-vuex';
 import { Simulation } from 'd3-force';
 
 import {
-  Link, Node, Network, SimulationLink, State, LinkStyleVariables, LoadError, NestedVariables,
+  Link, Node, Network, SimulationLink, State, LinkStyleVariables, LoadError, NestedVariables, ProvenanceEventTypes,
 } from '@/types';
 import api from '@/api';
 import { GraphSpec, RowsSpec, TableRow } from 'multinet';
@@ -12,6 +12,7 @@ import {
   scaleLinear, scaleOrdinal,
 } from 'd3-scale';
 import { schemeCategory10 } from 'd3-scale-chromatic';
+import { initProvenance } from '@visdesignlab/trrack';
 
 Vue.use(Vuex);
 
@@ -50,6 +51,7 @@ const {
     attributeRanges: {},
     nodeColorScale: scaleOrdinal(schemeCategory10),
     linkWidthScale: scaleLinear().range([1, 20]),
+    provenance: null,
   } as State,
 
   getters: {
@@ -219,6 +221,14 @@ const {
       if (domain.length === 2) {
         state.linkWidthScale.domain(domain).range([1, 20]);
       }
+    },
+
+    createProvenance(state) {
+      state.provenance = initProvenance<State, ProvenanceEventTypes, unknown>(
+        JSON.parse(JSON.stringify(state)),
+        { loadFromUrl: false },
+      );
+      state.provenance.done();
     },
   },
   actions: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { Simulation } from 'd3-force';
+import { ScaleLinear, ScaleOrdinal } from 'd3-scale';
 import { TableRow } from 'multinet';
 
 export interface Dimensions {
@@ -35,4 +37,44 @@ export interface Cell {
   colID: string;
   cellName: string;
   correspondingCell: string;
+}
+
+export interface LoadError {
+  message: string;
+  buttonText: string;
+  href: string;
+}
+
+export interface NestedVariables {
+  bar: string[];
+  glyph: string[];
+}
+
+export interface LinkStyleVariables {
+  width: string;
+  color: string;
+}
+
+export interface AttributeRanges {
+  [key: string]: {attr: string; min: number; max: number};
+}
+
+export interface State {
+  workspaceName: string | null;
+  networkName: string | null;
+  network: Network | null;
+  selectedNodes: Set<string>;
+  loadError: LoadError;
+  renderNested: boolean;
+  markerSize: number;
+  fontSize: number;
+  labelVariable: string;
+  colorVariable: string;
+  selectNeighbors: boolean;
+  nestedVariables: NestedVariables;
+  linkVariables: LinkStyleVariables;
+  attributeRanges: AttributeRanges;
+  simulation: Simulation<Node, SimulationLink> | null;
+  nodeColorScale: ScaleOrdinal<string, string>;
+  linkWidthScale: ScaleLinear<number, number>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { Provenance } from '@visdesignlab/trrack';
 import { Simulation } from 'd3-force';
 import { ScaleLinear, ScaleOrdinal } from 'd3-scale';
 import { TableRow } from 'multinet';
@@ -77,4 +78,7 @@ export interface State {
   simulation: Simulation<Node, SimulationLink> | null;
   nodeColorScale: ScaleOrdinal<string, string>;
   linkWidthScale: ScaleLinear<number, number>;
+  provenance: Provenance<State, ProvenanceEventTypes, unknown> | null;
 }
+
+export type ProvenanceEventTypes = 'Select Node' | 'De-select Node';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1701,6 +1701,11 @@
     "@types/d3-voronoi" "*"
     "@types/d3-zoom" "*"
 
+"@types/deep-diff@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/deep-diff/-/deep-diff-1.0.0.tgz#7eba3202a99b3a207f758f351f7f86387269fc40"
+  integrity sha512-ENsJcujGbCU/oXhDfQ12mSo/mCBWodT2tpARZKmatoSrf8+cGRCPi0KVj3I0FORhYZfLXkewXu7AoIWqiBLkNw==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -1990,11 +1995,12 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@visdesignlab/trrack@^2.0.0-alpha.5":
-  version "2.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@visdesignlab/trrack/-/trrack-2.0.0-alpha.5.tgz#c6b4cdfd6abf34198228cc5c32d55361cc618f59"
-  integrity sha512-iDPgQLGYbtfe2FTEi7GT4kMBrkfS4VFj4b3GCHLMzGnePM+tapySKJBnXRs2x6IT3y/xdvm4u/NWNdkC5GUCCg==
+"@visdesignlab/trrack@^2.0.0-alpha.7":
+  version "2.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/@visdesignlab/trrack/-/trrack-2.0.0-alpha.7.tgz#90d6931caafd90b641f07532590c15bb97330389"
+  integrity sha512-zSCiX1PMvDCWuATjyvuhj6ef8QtZYPWsuqwH5/MU+vmkHSaqhLjZzBWB8e17Btp8bXByQCCSl8dqiKO0JzC89A==
   dependencies:
+    "@types/deep-diff" "^1.0.0"
     deep-diff "^1.0.2"
     firebase "^7.15.5"
     lz-string "^1.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1985,15 +1985,15 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@visdesignlab/trrack@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@visdesignlab/trrack/-/trrack-1.2.0.tgz#e475883c10e34af03f9d17b7e48eecb92104e82b"
-  integrity sha512-Le08bgAO2+jqcD5ao5X7tfiw8/mWRA7U0oZ8RnQtvYsemgc3g0u0zSMRhIwGCoBX2vfWzCho9Xwc5aPmaZeeog==
+"@visdesignlab/trrack@^2.0.0-alpha.5":
+  version "2.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@visdesignlab/trrack/-/trrack-2.0.0-alpha.5.tgz#c6b4cdfd6abf34198228cc5c32d55361cc618f59"
+  integrity sha512-iDPgQLGYbtfe2FTEi7GT4kMBrkfS4VFj4b3GCHLMzGnePM+tapySKJBnXRs2x6IT3y/xdvm4u/NWNdkC5GUCCg==
   dependencies:
     deep-diff "^1.0.2"
     firebase "^7.15.5"
-    immer "^5.1.0"
     lz-string "^1.4.4"
+    mobx "^6.0.1"
 
 "@vue/babel-helper-vue-jsx-merge-props@^1.0.0":
   version "1.0.0"
@@ -6214,11 +6214,6 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-immer@^5.1.0:
-  version "5.3.6"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-5.3.6.tgz#51eab8cbbeb13075fe2244250f221598818cac04"
-  integrity sha512-pqWQ6ozVfNOUDjrLfm4Pt7q4Q12cGw2HUZgry4Q5+Myxu9nmHRkWBpI0J4+MK0AxbdFtdMTwEGVl7Vd+vEiK+A==
-
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
@@ -7848,6 +7843,11 @@ mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+mobx@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-6.0.4.tgz#8fc3e3629a3346f8afddf5bd954411974744dad1"
+  integrity sha512-wT2QJT9tW19VSHo9x7RPKU3z/I2Ps6wUS8Kb1OO+kzmg7UY3n4AkcaYG6jq95Lp1R9ohjC/NGYuT2PtuvBjhFg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Depends on #121, I'll retarget this branch to master once it's merged (this just helps with seeing the changes).

Adds the most recent version of the provenance library that I've been told "will be released without changes to the API". That means the logic won't have to change for us to use the 2.0.0 release of the library.

I think the provenance library cannot track objects that are vue reactive, because it will get into an infinite loop. To get around that problem, I read the state in with `JSON.parse(JSON.stringify(state))` to get rid of the reactivity and then I make sure when I update, I don't pass a reactive object. Kiran told me "Deep-diff and trrack both work with only pure JSON objects... I added serialization support for Sets", so passing a set through as I have done, should be okay.

You'll find that the first thing that I added to the provenance is selecting and deselecting nodes. I figured I'd keep this change small, and I'll address the other pieces that we would want to update with provenance in a follow up. We can also implement a provenance visualization that has been created by our team at Utah that works on Trrack.

We can also support loading an entire state from a provenance querystring, if we'd like. So that's something to consider for additional follow ups.