### PR TITLE
Force nodes to stay on the svg

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -54,8 +54,8 @@ export default {
             <multi-link
               v-if="network && selectedNodes"
               :svg-dimensions="{
-                width: this.$refs.multilink_container.clientWidth,
-                height: this.$refs.multilink_container.clientHeight,
+                width: this.$refs.multilink_container.clientWidth - 24,
+                height: this.$refs.multilink_container.clientHeight - 24,
               }"
             />
 

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -264,7 +264,9 @@ export default Vue.extend({
       forcedY = forcedY > maximumY ? maximumY : forcedY;
 
       // Update the node position with this forced position
+      // eslint-disable-next-line no-param-reassign
       node.x = forcedX;
+      // eslint-disable-next-line no-param-reassign
       node.y = forcedY;
 
       // Use the forced position, because the node.x is updated by simulation

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -258,10 +258,12 @@ export default Vue.extend({
       const maximumX = this.svgDimensions.width - this.markerSize - svgEdgePadding;
       const maximumY = this.svgDimensions.height - this.markerSize - svgEdgePadding;
 
-      forcedX = forcedX < minimumX ? minimumX : forcedX;
-      forcedX = forcedX > maximumX ? maximumX : forcedX;
-      forcedY = forcedY < minimumY ? minimumY : forcedY;
-      forcedY = forcedY > maximumY ? maximumY : forcedY;
+      // Ideally we would update node.x and node.y, but those variables are being changed
+      // by the simulation. My solution was to use these forcedX and forcedY variables.
+      if (forcedX < minimumX) { forcedX = minimumX; }
+      if (forcedX > maximumX) { forcedX = maximumX; }
+      if (forcedY < minimumY) { forcedY = minimumY; }
+      if (forcedY > maximumY) { forcedY = maximumY; }
 
       // Update the node position with this forced position
       // eslint-disable-next-line no-param-reassign

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -245,7 +245,27 @@ export default Vue.extend({
     },
 
     nodeTranslate(node: Node): string {
-      return `translate(${node.x || 0}, ${node.y || 0})`;
+      let forcedX = node.x || 0;
+      let forcedY = node.y || 0;
+
+      const svgEdgePadding = 5;
+
+      const minimumX = svgEdgePadding;
+      const minimumY = svgEdgePadding;
+      const maximumX = this.svgDimensions.width - this.markerSize - svgEdgePadding;
+      const maximumY = this.svgDimensions.height - this.markerSize - svgEdgePadding;
+
+      forcedX = forcedX < minimumX ? minimumX : forcedX;
+      forcedX = forcedX > maximumX ? maximumX : forcedX;
+      forcedY = forcedY < minimumY ? minimumY : forcedY;
+      forcedY = forcedY > maximumY ? maximumY : forcedY;
+
+      // Update the node position with this forced position
+      node.x = forcedX;
+      node.y = forcedY;
+
+      // Use the forced position, because the node.x is updated by simulation
+      return `translate(${forcedX}, ${forcedY})`;
     },
 
     arcPath(link: Link): string {


### PR DESCRIPTION
Depends on #121.

This change forces the nodes to stay on the SVG by setting the x and y attributes to values that are on the SVG. 

I found that updating `node.x` and `node.y` and then doing `translate(node.x, node.y)` didn't work. I think that's because the simulation updates node.x and node.y before the node is drawn, so there's a bit of a race conditions. My solution was to set the translate to the forced values and assign those values back to `node.x` and `node.y`. That seems to keep everything settled.