### PR TITLE
Enable eslint rules that were disabled before refactor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,8 +22,7 @@ module.exports = {
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'max-len': ['off'],
     'import/prefer-default-export': ['off'],
-    // Required for _to, _id, _key, etc. from Arango
-    'no-underscore-dangle': ['off'],
+    'no-underscore-dangle': ['error', { allow: ['_id', '_from', '_to'] }],
   },
 
   parserOptions: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,8 +24,6 @@ module.exports = {
     'import/prefer-default-export': ['off'],
     // Required for _to, _id, _key, etc. from Arango
     'no-underscore-dangle': ['off'],
-    // Required for data loading/processing and D3-style mutating callbacks
-    'no-param-reassign': ['error', { props: false }],
   },
 
   parserOptions: {

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -1,5 +1,4 @@
 <script lang="ts">
-/* eslint-disable vue/no-mutating-props */
 import Vue, { PropType } from 'vue';
 import { min, max } from 'd3-array';
 import { select } from 'd3-selection';

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -36,10 +36,8 @@ export default Vue.extend({
     simulationLinks(): SimulationLink[] | null {
       if (this.network !== null) {
         return this.network.edges.map((link: Link) => {
-          const newLink = link;
-          newLink.source = link._from;
-          newLink.target = link._to;
-          return (newLink as SimulationLink);
+          const newLink: SimulationLink = { ...link, source: link._from, target: link._to };
+          return newLink;
         });
       }
       return null;

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -36,9 +36,10 @@ export default Vue.extend({
     simulationLinks(): SimulationLink[] | null {
       if (this.network !== null) {
         return this.network.edges.map((link: Link) => {
-          link.source = link._from;
-          link.target = link._to;
-          return (link as SimulationLink);
+          const newLink = link;
+          newLink.source = link._from;
+          newLink.target = link._to;
+          return (newLink as SimulationLink);
         });
       }
       return null;
@@ -197,7 +198,9 @@ export default Vue.extend({
       nodes.forEach((node) => {
         // If the position is not defined for x or y, generate it
         if (node.x === undefined || node.y === undefined) {
+          // eslint-disable-next-line no-param-reassign
           node.x = Math.random() * this.svgDimensions.width;
+          // eslint-disable-next-line no-param-reassign
           node.y = Math.random() * this.svgDimensions.height;
         }
       });
@@ -215,7 +218,9 @@ export default Vue.extend({
       event.preventDefault();
 
       const moveFn = (evt: Event) => {
+        // eslint-disable-next-line no-param-reassign
         node.x = (evt as MouseEvent).clientX - this.svgOffset.x - (this.markerSize / 2);
+        // eslint-disable-next-line no-param-reassign
         node.y = (evt as MouseEvent).clientY - this.svgOffset.y - (this.markerSize / 2);
         this.$forceUpdate();
       };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -237,13 +237,14 @@ const {
     },
 
     setNestedVariables(state, nestedVariables: NestedVariables) {
-      const newNestedVars = nestedVariables;
-      // Remove duplicates from the nested variables
-      newNestedVars.bar = [...new Set(nestedVariables.bar)];
-      newNestedVars.glyph = [...new Set(nestedVariables.glyph)];
+      const newNestedVars = {
+        ...nestedVariables,
+        bar: [...new Set(nestedVariables.bar)],
+        glyph: [...new Set(nestedVariables.glyph)],
+      };
 
       // Allow only 2 variables for the glyphs
-      newNestedVars.glyph.length = newNestedVars.glyph.length > 2 ? 2 : newNestedVars.glyph.length;
+      newNestedVars.glyph.length = Math.min(2, newNestedVars.glyph.length);
 
       state.nestedVariables = newNestedVars;
     },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -237,14 +237,15 @@ const {
     },
 
     setNestedVariables(state, nestedVariables: NestedVariables) {
+      const newNestedVars = nestedVariables;
       // Remove duplicates from the nested variables
-      nestedVariables.bar = [...new Set(nestedVariables.bar)];
-      nestedVariables.glyph = [...new Set(nestedVariables.glyph)];
+      newNestedVars.bar = [...new Set(nestedVariables.bar)];
+      newNestedVars.glyph = [...new Set(nestedVariables.glyph)];
 
       // Allow only 2 variables for the glyphs
-      nestedVariables.glyph.length = nestedVariables.glyph.length > 2 ? 2 : nestedVariables.glyph.length;
+      newNestedVars.glyph.length = newNestedVars.glyph.length > 2 ? 2 : newNestedVars.glyph.length;
 
-      state.nestedVariables = nestedVariables;
+      state.nestedVariables = newNestedVars;
     },
 
     setLinkVariables(state, linkVariables: LinkStyleVariables) {
@@ -322,7 +323,9 @@ const {
 
       if (context.state.network !== null) {
         context.state.network.nodes.forEach((n: Node) => {
+          // eslint-disable-next-line no-param-reassign
           n.fx = null;
+          // eslint-disable-next-line no-param-reassign
           n.fy = null;
         });
         commit.startSimulation();


### PR DESCRIPTION
Depends on #121 

Closes #117 when we address my line length question
The error thrown for #116 is no longer an issue after #121. This removes the no-mutating-props exception, thus closes #116 

I've re-enabled `no-mutating-props` and `no-param-reassign` app wide, and have disabled the rule on the specific lines that need it. I also modified the `no-underscore-dangle` to explicitly allow `_id`, `_from`, and `_to`, since those are the actual values we need from arango, as opposed to disabling the rule entirely.

Also, we have no line length limit at the moment and it's not causing any issues. I think enforcing a line length limit just adds development overhead for refactoring long lines, without much added readability. I'd love to get your thoughts, though. Leaving no line length limits means that our configuration closely matches the same from the [multinet-client](https://github.com/multinet-app/multinet-client/blob/master/.eslintrc.js).