### PR TITLE
Add directional edge markers and control toggle

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -110,6 +110,15 @@ export default Vue.extend({
         store.commit.setSelectNeighbors(value);
       },
     },
+
+    directionalEdges: {
+      get() {
+        return store.getters.directionalEdges;
+      },
+      set(value: boolean) {
+        store.commit.setDirectionalEdges(value);
+      },
+    },
   },
 
   methods: {
@@ -161,6 +170,20 @@ export default Vue.extend({
           Display charts
           <v-switch
             v-model="renderNested"
+            class="ma-0"
+            hide-details
+          />
+        </v-card-subtitle>
+
+        <v-divider class="mt-4" />
+
+        <v-card-subtitle
+          class="pb-0 pl-0"
+          style="display: flex; align-items: center; justify-content: space-between"
+        >
+          Directional Edges
+          <v-switch
+            v-model="directionalEdges"
             class="ma-0"
             hide-details
           />

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -374,10 +374,22 @@ export default Vue.extend({
           @mouseout="hideTooltip"
         >
           <path
+            :id="`${link._key}_path`"
             class="link"
             :d="arcPath(link)"
             :style="linkStyle(link)"
           />
+
+          <text
+            dominant-baseline="middle"
+          >
+            <textPath
+              :href="`#${link._key}_path`"
+              startOffset="50%"
+            >
+              ▶
+            </textPath>
+          </text>
         </g>
       </g>
 

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -498,15 +498,10 @@ export default Vue.extend({
   max-width: 400px
 }
 
-.links,
-.textpath,
+.links >>> path,
 .edgeLegend {
     fill: none;
     opacity: .8;
-}
-
-.textpath {
-    visibility: hidden;
 }
 
 .bar, .glyph, .nested {
@@ -548,14 +543,6 @@ export default Vue.extend({
 .selectBox,
 .labelBackground {
     pointer-events: none;
-}
-
-.pathLabel>textPath {
-    font-size: 14px;
-}
-
-.edgeArrow>textPath {
-    font-size: 10px;
 }
 
 .legendLabel,

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -161,6 +161,10 @@ export default Vue.extend({
     linkWidthScale() {
       return store.getters.linkWidthScale;
     },
+
+    directionalEdges() {
+      return store.getters.directionalEdges;
+    },
   },
 
   created() {
@@ -381,6 +385,7 @@ export default Vue.extend({
           />
 
           <text
+            v-if="directionalEdges"
             dominant-baseline="middle"
           >
             <textPath

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -53,6 +53,7 @@ const {
     nodeColorScale: scaleOrdinal(schemeCategory10),
     linkWidthScale: scaleLinear().range([1, 20]),
     provenance: null,
+    directionalEdges: false,
   } as State,
 
   getters: {
@@ -122,6 +123,10 @@ const {
 
     linkWidthScale(state: State) {
       return state.linkWidthScale;
+    },
+
+    directionalEdges(state: State) {
+      return state.directionalEdges;
     },
   },
   mutations: {
@@ -240,6 +245,10 @@ const {
         { loadFromUrl: false },
       );
       state.provenance.done();
+    },
+
+    setDirectionalEdges(state, directionalEdges: boolean) {
+      state.directionalEdges = directionalEdges;
     },
   },
   actions: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,7 @@ export interface State {
   nodeColorScale: ScaleOrdinal<string, string>;
   linkWidthScale: ScaleLinear<number, number>;
   provenance: Provenance<State, ProvenanceEventTypes, unknown> | null;
+  directionalEdges: boolean;
 }
 
 export type ProvenanceEventTypes = 'Select Node' | 'De-select Node';


### PR DESCRIPTION
Depends on #122 (since the type definition moved to types.ts from store/index.ts)

Closes #129 
Is a first step towards #131 

This adds a text path element onto the link by using an href and then moves the arrow along the path using an offset. I also added another switch for the control in the control panel. There was a type that needed to be updated, `State`, and I enabled a new getter and setter in the store for the `directionalEdges` variable. I also cleaned out some old CSS that was no longer needed.

Here's the relevant MDN docs for [textPath](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/textPath) and here is the documentation for [startOffset](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/startOffset)


