### PR TITLE
Make a deep copy of the network for simulationLinks

### DIFF
--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -36,7 +36,11 @@ export default Vue.extend({
     simulationLinks(): SimulationLink[] | null {
       if (this.network !== null) {
         return this.network.edges.map((link: Link) => {
-          const newLink: SimulationLink = { ...link, source: link._from, target: link._to };
+          const newLink: SimulationLink = {
+            ...JSON.parse(JSON.stringify(link)),
+            source: link._from,
+            target: link._to,
+          };
           return newLink;
         });
       }


### PR DESCRIPTION
Closes #130

I decided to use a `JSON.parse(JSON.stringify())` since the data that we get from MultiNet is made of properties that are all JSON serializable, and there's no easier option that doesn't require importing more libraries.

This means that the simulation doesn't update the `source` and `target` properties on the links in the store with references to the nodes that are the source and target.