### PR TITLE
Add composition API and use it in App.vue

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@types/d3": "^5.7.2",
     "@visdesignlab/trrack": "^2.0.0-alpha.7",
+    "@vue/composition-api": "^1.0.0-beta.22",
     "core-js": "^3.4.3",
     "d3-array": "^2.8.0",
     "d3-axis": "^2.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,9 @@
 <script lang="ts">
 import store from '@/store';
 import { getUrlVars } from '@/lib/utils';
+import {
+  ref, computed, Ref,
+} from '@vue/composition-api';
 
 import Controls from './components/Controls.vue';
 import MultiLink from './components/MultiLink/MultiLink.vue';
@@ -13,29 +16,38 @@ export default {
     MultiLink,
   },
 
-  computed: {
-    network() {
-      return store.getters.network;
-    },
+  setup() {
+    const network = computed(() => store.getters.network);
+    const selectedNodes = computed(() => store.getters.selectedNodes);
+    const loadError = computed(() => store.getters.loadError);
 
-    selectedNodes() {
-      return store.getters.selectedNodes;
-    },
+    const multilinkContainer: Ref<Element | null> = ref(null);
+    const multilinkContainerDimensions = computed(() => {
+      if (multilinkContainer.value !== null) {
+        return {
+          width: multilinkContainer.value.clientWidth - 24,
+          height: multilinkContainer.value.clientHeight - 24,
+        };
+      }
+      return null;
+    });
 
-    loadError() {
-      return store.getters.loadError;
-    },
-  },
-
-  async mounted() {
     const { workspace, graph } = getUrlVars();
 
-    await store.dispatch.fetchNetwork({
+    store.dispatch.fetchNetwork({
       workspaceName: workspace,
       networkName: graph,
     });
 
     store.commit.createProvenance();
+
+    return {
+      network,
+      selectedNodes,
+      loadError,
+      multilinkContainer,
+      multilinkContainerDimensions,
+    };
   },
 };
 </script>
@@ -49,16 +61,13 @@ export default {
         </v-col>
 
         <v-col
-          ref="multilink_container"
+          ref="multilinkContainer"
           cols="9"
         >
           <v-row>
             <multi-link
-              v-if="network && selectedNodes"
-              :svg-dimensions="{
-                width: this.$refs.multilink_container.clientWidth - 24,
-                height: this.$refs.multilink_container.clientHeight - 24,
-              }"
+              v-if="network !== null && selectedNodes !== null"
+              :svg-dimensions="multilinkContainerDimensions"
             />
 
             <v-alert

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,11 @@
 import Vue from 'vue';
 import App from '@/App.vue';
+import VueCompositionApi from '@vue/composition-api';
 import vuetify from '@/plugins/vuetify';
 
 Vue.config.productionTip = false;
+
+Vue.use(VueCompositionApi);
 
 new Vue({
   vuetify,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,6 +2302,13 @@
   optionalDependencies:
     prettier "^1.18.2"
 
+"@vue/composition-api@^1.0.0-beta.22":
+  version "1.0.0-beta.22"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.0.0-beta.22.tgz#8b0046bda138820c6d79c91dc961839a52d853c7"
+  integrity sha512-KkTeHVWgsJbtoA5t6pUien/ARw7JhVM7QZh05ko/UdgzALYMGwJsBf4WlcvbpMKE5eAu4ONYJypQ+r8LwBIOhA==
+  dependencies:
+    tslib "^2.0.1"
+
 "@vue/eslint-config-airbnb@^5.0.2":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@vue/eslint-config-airbnb/-/eslint-config-airbnb-5.1.0.tgz#6a72e166af18ac821120ff36aae8b76b940f28aa"
@@ -10939,6 +10946,11 @@ tslib@^1.11.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
 tslint@^5.15.0:
   version "5.20.1"


### PR DESCRIPTION
A first step towards #125

This add the composition API as dependency, initializes it (With Vue.use()), and migrates App.vue to use it. I chose App.vue since it's the simplest component.