### PR TITLE
Use one button for simulation start/stop in the controls

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -277,9 +277,8 @@ export default Vue.extend({
           />
 
           <v-row>
-            <v-col cols="5">
+            <v-col cols="6">
               <v-btn
-                class="px-2"
                 color="grey darken-3"
                 depressed
                 text
@@ -294,14 +293,13 @@ export default Vue.extend({
             </v-col>
 
             <v-col
-              cols="3"
-              class="px-0"
+              cols="6"
             >
               <v-btn
-                class="ml-2 px-1"
                 color="primary"
                 depressed
                 small
+                block
                 @click="stopSimulation"
               >
                 <v-icon small>
@@ -312,14 +310,13 @@ export default Vue.extend({
             </v-col>
 
             <v-col
-              cols="3"
-              class="px-0"
+              cols="6"
             >
               <v-btn
-                class="ml-4 px-1"
                 color="primary"
                 depressed
                 small
+                block
                 @click="startSimulation"
               >
                 <v-icon small>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -119,6 +119,10 @@ export default Vue.extend({
         store.commit.setDirectionalEdges(value);
       },
     },
+
+    simulationRunning() {
+      return store.getters.simulationRunning;
+    },
   },
 
   methods: {
@@ -293,6 +297,7 @@ export default Vue.extend({
             </v-col>
 
             <v-col
+              v-if="simulationRunning"
               cols="6"
             >
               <v-btn
@@ -310,6 +315,7 @@ export default Vue.extend({
             </v-col>
 
             <v-col
+              v-else
               cols="6"
             >
               <v-btn

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -299,37 +299,20 @@ export default Vue.extend({
               </v-btn>
             </v-col>
             <v-spacer />
-            <v-col v-if="simulationRunning">
+            <v-col>
               <v-btn
                 color="primary"
                 depressed
                 small
-                @click="stopSimulation"
+                @click="simulationRunning ? stopSimulation() : startSimulation()"
               >
                 <v-icon
                   left
                   small
                 >
-                  mdi-stop
+                  {{ simulationRunning ? 'mdi-stop' : 'mdi-play' }}
                 </v-icon>
-                Stop
-              </v-btn>
-            </v-col>
-
-            <v-col v-else>
-              <v-btn
-                color="primary"
-                depressed
-                small
-                @click="startSimulation"
-              >
-                <v-icon
-                  left
-                  small
-                >
-                  mdi-play
-                </v-icon>
-                Start
+                {{ simulationRunning ? 'Stop' : 'Start' }}
               </v-btn>
             </v-col>
           </v-row>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -304,6 +304,7 @@ export default Vue.extend({
                 color="primary"
                 depressed
                 small
+                width="85"
                 @click="simulationRunning ? stopSimulation() : startSimulation()"
               >
                 <v-icon

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -302,12 +302,12 @@ export default Vue.extend({
                 color="primary"
                 depressed
                 small
-                @click="startSimulation"
+                @click="stopSimulation"
               >
                 <v-icon small>
-                  mdi-play
+                  mdi-stop
                 </v-icon>
-                Start
+                Stop
               </v-btn>
             </v-col>
 
@@ -320,12 +320,12 @@ export default Vue.extend({
                 color="primary"
                 depressed
                 small
-                @click="stopSimulation"
+                @click="startSimulation"
               >
                 <v-icon small>
-                  mdi-stop
+                  mdi-play
                 </v-icon>
-                Stop
+                Start
               </v-btn>
             </v-col>
           </v-row>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -316,10 +316,7 @@ export default Vue.extend({
               </v-btn>
             </v-col>
 
-            <v-col
-              v-else
-              cols="6"
-            >
+            <v-col v-else>
               <v-btn
                 color="primary"
                 depressed

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -281,7 +281,7 @@ export default Vue.extend({
           />
 
           <v-row>
-            <v-col cols="6">
+            <v-col>
               <v-btn
                 color="grey darken-3"
                 depressed
@@ -289,25 +289,27 @@ export default Vue.extend({
                 small
                 @click="releaseNodes"
               >
-                <v-icon small>
+                <v-icon
+                  left
+                  small
+                >
                   mdi-pin-off
                 </v-icon>
                 Release
               </v-btn>
             </v-col>
-
-            <v-col
-              v-if="simulationRunning"
-              cols="6"
-            >
+            <v-spacer />
+            <v-col v-if="simulationRunning">
               <v-btn
                 color="primary"
                 depressed
                 small
-                block
                 @click="stopSimulation"
               >
-                <v-icon small>
+                <v-icon
+                  left
+                  small
+                >
                   mdi-stop
                 </v-icon>
                 Stop
@@ -322,10 +324,12 @@ export default Vue.extend({
                 color="primary"
                 depressed
                 small
-                block
                 @click="startSimulation"
               >
-                <v-icon small>
+                <v-icon
+                  left
+                  small
+                >
                   mdi-play
                 </v-icon>
                 Start

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -202,6 +202,7 @@ export default Vue.extend({
         });
 
       store.commit.setSimulation(simulation);
+      store.commit.startSimulation();
     }
   },
 

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -191,9 +191,15 @@ export default Vue.extend({
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .force('link') as any).links(this.simulationLinks);
 
-      simulation.on('tick', () => {
-        this.$forceUpdate();
-      });
+      simulation
+        .on('tick', () => {
+          this.$forceUpdate();
+        })
+        // The next line handles the start stop button change in the controls.
+        // It's not explicitly necessary for the simulation to work
+        .on('end', () => {
+          store.commit.stopSimulation();
+        });
 
       store.commit.setSimulation(simulation);
     }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -54,6 +54,7 @@ const {
     linkWidthScale: scaleLinear().range([1, 20]),
     provenance: null,
     directionalEdges: false,
+    simulationRunning: false,
   } as State,
 
   getters: {
@@ -128,6 +129,10 @@ const {
     directionalEdges(state: State) {
       return state.directionalEdges;
     },
+
+    simulationRunning(state: State) {
+      return state.simulationRunning;
+    },
   },
   mutations: {
     setWorkspaceName(state, workspaceName: string) {
@@ -162,12 +167,14 @@ const {
       if (state.simulation !== null) {
         state.simulation.alpha(0.5);
         state.simulation.restart();
+        state.simulationRunning = true;
       }
     },
 
     stopSimulation(state) {
       if (state.simulation !== null) {
         state.simulation.stop();
+        state.simulationRunning = false;
       }
     },
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,7 @@ export interface State {
   linkWidthScale: ScaleLinear<number, number>;
   provenance: Provenance<State, ProvenanceEventTypes, unknown> | null;
   directionalEdges: boolean;
+  simulationRunning: boolean;
 }
 
 export type ProvenanceEventTypes = 'Select Node' | 'De-select Node';


### PR DESCRIPTION
Closes #141

Reduces the visual clutter by making the start and stop buttons into just one button that changes based on the simulation status.

My initial route was to try and use a component level data variable, but that didn't work. When the simulation stopped naturally, it wouldn't update the button. The solution was to refactor the start stop logic to the store and to have the simulation tell the store when it had finished/started. Now the buttons are in sync.
