### PR TITLE
Add search bar that selects node from autocomplete element

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,7 @@ module.exports = {
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'max-len': ['off'],
     'import/prefer-default-export': ['off'],
-    'no-underscore-dangle': ['error', { allow: ['_id', '_from', '_to'] }],
+    'no-underscore-dangle': ['error', { allow: ['_id', '_from', '_to', '_key'] }],
   },
 
   parserOptions: {

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -3,11 +3,21 @@ import Vue from 'vue';
 import Legend from '@/components/MultiLink/Legend.vue';
 
 import store from '@/store';
-import { Node, Link } from '@/types';
+import { Node, Link, Network } from '@/types';
 
 export default Vue.extend({
   components: {
     Legend,
+  },
+
+  data(): {
+    searchTerm: string;
+    searchErrors: string[];
+    } {
+    return {
+      searchTerm: '',
+      searchErrors: [],
+    };
   },
 
   computed: {
@@ -119,6 +129,17 @@ export default Vue.extend({
         store.commit.setDirectionalEdges(value);
       },
     },
+
+    network(): Network | null {
+      return store.getters.network;
+    },
+
+    searchItems(): string[] {
+      if (this.network !== null) {
+        return this.network.nodes.map((node) => node._key);
+      }
+      return [];
+    },
   },
 
   methods: {
@@ -146,6 +167,20 @@ export default Vue.extend({
       a.click();
     },
 
+    search() {
+      const searchErrors: string[] = [];
+      if (this.network !== null) {
+        const nodeToSelect = this.network.nodes.find((node) => node._key === this.searchTerm);
+
+        if (nodeToSelect !== undefined) {
+          store.commit.addSelectedNode(nodeToSelect._id);
+        } else {
+          searchErrors.push('Enter a node to search');
+        }
+      }
+
+      this.searchErrors = searchErrors;
+    },
   },
 });
 </script>
@@ -189,6 +224,25 @@ export default Vue.extend({
         </v-subheader>
 
         <div class="pa-4">
+          <v-list-item class="px-0">
+            <v-autocomplete
+              v-model="searchTerm"
+              label="Search for Node"
+              :items="searchItems"
+              :error-messages="searchErrors"
+            />
+
+            <v-btn
+              class="ml-2"
+              color="primary"
+              depressed
+              small
+              @click="search"
+            >
+              Search
+            </v-btn>
+          </v-list-item>
+
           <v-list-item class="px-0">
             <v-select
               v-model="labelVariable"

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -10,13 +10,10 @@ export default Vue.extend({
     Legend,
   },
 
-  data(): {
-    searchTerm: string;
-    searchErrors: string[];
-    } {
+  data() {
     return {
-      searchTerm: '',
-      searchErrors: [],
+      searchTerm: '' as string,
+      searchErrors: [] as string[],
     };
   },
 

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -131,7 +131,7 @@ export default Vue.extend({
       return store.getters.network;
     },
 
-    searchItems(): string[] {
+    autocompleteItems(): string[] {
       if (this.network !== null) {
         return this.network.nodes.map((node) => node._key);
       }
@@ -225,7 +225,7 @@ export default Vue.extend({
             <v-autocomplete
               v-model="searchTerm"
               label="Search for Node"
-              :items="searchItems"
+              :items="autocompleteItems"
               :error-messages="searchErrors"
             />
 


### PR DESCRIPTION
Closes #48

Re-implements node searching by using an autocomplete vuetify element. The logic just takes the search term from the autocomplete and finds the right id to select in the nodes.

A possible logic issue we could bump into, is a node with the same key in 2 tables. I'm not sure how best to get around that, other than using id, which should be unique. That make the autocomplete really ugly and too wide though. I think this is a fine solution for now, but I'll open an issue to track this potential issue.

Here's a video of it in action:
https://user-images.githubusercontent.com/36867477/104361410-a483da00-54cf-11eb-8fc9-e2df2b577d14.mp4