### PR TITLE
Initialize provenance after the data has loaded in

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -37,9 +37,7 @@ export default {
     store.dispatch.fetchNetwork({
       workspaceName: workspace,
       networkName: graph,
-    });
-
-    store.commit.createProvenance();
+    }).then(() => store.commit.createProvenance());
 
     return {
       network,


### PR DESCRIPTION
A bug I noticed in #147.

We were initializing the provenance before the data had loaded so it was technically missing from the root node. Now it shouldn't be.