### PR TITLE
Set the svg dimensions dynamically by using this.$vuetify to check for size changes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -80,6 +80,18 @@ export default {
 </template>
 
 <style>
+html {
+  scrollbar-width: none;
+}
+
+html::-webkit-scrollbar {
+  display: none;
+}
+
+body {
+  overflow: hidden;
+}
+
 #app {
   font-family: "Blinker", Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -157,8 +157,8 @@ export default Vue.extend({
 
     svgDimensions() {
       return {
-        height: document.body.clientHeight,
-        width: document.body.clientWidth - 256,
+        height: this.$vuetify.breakpoint.height,
+        width: this.$vuetify.breakpoint.width - 256,
       };
     },
 

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -179,7 +179,7 @@ export default Vue.extend({
     if (this.network !== null) {
       // Make the simulation
       const simulation = forceSimulation<Node, SimulationLink>()
-        .force('center', forceCenter(this.el.clientWidth / 2, this.el.clientHeight / 2))
+        .force('center', forceCenter(this.svgDimensions.width / 2, this.svgDimensions.height / 2))
         .force('charge', forceManyBody().strength(-300))
         .force('link', forceLink().id((d) => { const datum = (d as Link); return datum._id; }))
         .force('collision', forceCollide(this.forceRadius));


### PR DESCRIPTION
This change allows the MultiLink svg to resize as the window changes size using a convenient vuetify binding. It also removes all the overflow and scroll bars that are there erroneously