### PR TITLE
Update simulation center force as window resizes

### DIFF
--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -180,8 +180,8 @@ export default Vue.extend({
       // Make the simulation
       const simulation = forceSimulation<Node, SimulationLink>()
         .force('center', forceCenter(this.svgDimensions.width / 2, this.svgDimensions.height / 2))
-        .force('charge', forceManyBody().strength(-300))
-        .force('link', forceLink().id((d) => { const datum = (d as Link); return datum._id; }))
+        .force('charge', forceManyBody<Node>().strength(-300))
+        .force('link', forceLink<Node, SimulationLink>().id((d) => { const datum = (d as Link); return datum._id; }))
         .force('collision', forceCollide(this.forceRadius));
 
       simulation

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -150,6 +150,8 @@ export default Vue.extend({
       const { height } = this.$vuetify.breakpoint;
       const width = this.$vuetify.breakpoint.width - this.controlsWidth;
 
+      store.commit.updateSimulationForce({ forceType: 'center', forceValue: forceCenter<Node>(width / 2, height / 2) });
+
       return {
         height,
         width,

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -147,9 +147,12 @@ export default Vue.extend({
     },
 
     svgDimensions(): Dimensions {
+      const { height } = this.$vuetify.breakpoint;
+      const width = this.$vuetify.breakpoint.width - this.controlsWidth;
+
       return {
-        height: this.$vuetify.breakpoint.height,
-        width: this.$vuetify.breakpoint.width - this.controlsWidth,
+        height,
+        width,
       };
     },
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,7 +1,9 @@
 import Vue from 'vue';
 import Vuex, { Store } from 'vuex';
 import { createDirectStore } from 'direct-vuex';
-import { Simulation } from 'd3-force';
+import {
+  ForceCenter, ForceCollide, ForceLink, ForceManyBody, Simulation,
+} from 'd3-force';
 
 import {
   Link, Node, Network, SimulationLink, State, LinkStyleVariables, LoadError, NestedVariables, ProvenanceEventTypes,
@@ -270,6 +272,16 @@ const {
     goToProvenanceNode(state, node: string) {
       if (state.provenance !== null) {
         state.provenance.goToNode(node);
+      }
+    },
+
+    updateSimulationForce(state: State, payload: {
+      forceType: 'center' | 'charge' | 'link' | 'collision';
+      forceValue: ForceCenter<Node> | ForceManyBody<Node> | ForceLink<Node, SimulationLink> | ForceCollide<Node>;
+    }) {
+      if (state.simulation !== null) {
+        const { forceType, forceValue } = payload;
+        state.simulation.force(forceType, forceValue);
       }
     },
   },


### PR DESCRIPTION
Depends on #151 

Adds a helper function to update the forces on the simulation, with the main use being that we can update the center force when the window resizes. I've set the helper to be automatically called as the `svgDimensions` variable updates.