### PR TITLE
Add global provenance observer so provenance updates sync with the store 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -37,7 +37,7 @@ export default {
     store.dispatch.fetchNetwork({
       workspaceName: workspace,
       networkName: graph,
-    }).then(() => store.commit.createProvenance());
+    }).then(() => store.dispatch.createProvenance());
 
     return {
       network,

--- a/src/components/ProvVis.vue
+++ b/src/components/ProvVis.vue
@@ -18,7 +18,7 @@ export default Vue.extend({
         ProvVisCreator(
           provDiv,
           provenance.value,
-          (newNode: string) => store.dispatch.goToProvenanceNode(newNode),
+          (newNode: string) => store.commit.goToProvenanceNode(newNode),
           true,
           true,
           provenance.value.root.id,


### PR DESCRIPTION
Closes #149

This PR moves a couple functions around and sets a global provenance observer on provenance creation. The observer checks the store state and the provenance state and if there is a mis-match (caused by manipulating the provenance visual) it will update the store state.

I was able to remove the updating logic from the goToProvenanceNode function in the store to not handle the updates. We're now using the observer instead.

In the future, the observer will grow larger as we add more possible variables to the provenance state. Or we might be able to refactor this.