### PR TITLE
Rename renderNested to displayCharts and track it in provenance (+ vis)

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -66,12 +66,12 @@ export default Vue.extend({
       return new Set();
     },
 
-    renderNested: {
+    displayCharts: {
       get() {
-        return store.getters.renderNested;
+        return store.getters.displayCharts;
       },
       set(value: boolean) {
-        return store.commit.setRenderNested(value);
+        return store.commit.setDisplayCharts(value);
       },
     },
 
@@ -279,7 +279,7 @@ export default Vue.extend({
           <v-list-item class="px-0">
             <v-list-item-action class="mr-3">
               <v-switch
-                v-model="renderNested"
+                v-model="displayCharts"
                 class="ma-0"
                 hide-details
               />

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -102,8 +102,8 @@ export default Vue.extend({
       return (this.markerSize / 2) * 1.5;
     },
 
-    renderNested() {
-      return store.getters.renderNested;
+    displayCharts() {
+      return store.getters.displayCharts;
     },
 
     markerSize() {
@@ -417,8 +417,8 @@ export default Vue.extend({
             :width="markerSize"
             :height="markerSize"
             :fill="nodeColorScale(node[colorVariable])"
-            :rx="!renderNested ? (markerSize / 2) : 0"
-            :ry="!renderNested ? (markerSize / 2) : 0"
+            :rx="!displayCharts ? (markerSize / 2) : 0"
+            :ry="!displayCharts ? (markerSize / 2) : 0"
             @click="selectNode(node)"
             @mouseover="showTooltip(node, $event)"
             @mouseout="hideTooltip"
@@ -427,18 +427,18 @@ export default Vue.extend({
           <rect
             class="labelBackground"
             height="1em"
-            :y="!renderNested ? (markerSize / 2) - 8 : 0"
+            :y="!displayCharts ? (markerSize / 2) - 8 : 0"
             :width="markerSize"
           />
           <text
             class="label"
-            :dy="!renderNested ? markerSize / 2 + 2: 10"
+            :dy="!displayCharts ? markerSize / 2 + 2: 10"
             :dx="markerSize / 2"
             :style="nodeTextStyle"
           >{{ node[labelVariable] }}</text>
 
           <g
-            v-if="renderNested"
+            v-if="displayCharts"
             class="nested"
           >
 

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -9,6 +9,11 @@ export function updateProvenanceState(vuexState: State, label: ProvenanceEventTy
       // eslint-disable-next-line no-param-reassign, @typescript-eslint/no-explicit-any
       provState.selectedNodes = [...newProvState.selectedNodes] as any;
     }
+
+    if (label === 'Set Display Charts') {
+      // eslint-disable-next-line no-param-reassign
+      provState.displayCharts = newProvState.displayCharts;
+    }
   })
     .setLabel(label);
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -201,6 +201,10 @@ const {
 
     setDisplayCharts(state, displayCharts: boolean) {
       state.displayCharts = displayCharts;
+
+      if (state.provenance !== null) {
+        updateProvenanceState(state, 'Set Display Charts');
+      }
     },
 
     setMarkerSize(state, markerSize: number) {
@@ -337,6 +341,8 @@ const {
     createProvenance(context) {
       const { commit } = rootActionContext(context);
 
+      const storeState = context.state;
+
       const stateForProv = JSON.parse(JSON.stringify(context.state));
       stateForProv.selectedNodes = [];
 
@@ -349,6 +355,8 @@ const {
       // enables undo/redo + navigating around provenance graph
       context.state.provenance.addGlobalObserver(
         () => {
+          const provenanceState = context.state.provenance.state;
+
           // TODO: #148 remove cast back to set
           const selectedNodes = new Set<string>(context.state.provenance.state.selectedNodes);
 
@@ -359,6 +367,10 @@ const {
           // update the store's selectedNodes to match the provenance state
           if (!setsAreEqual(selectedNodes, context.state.selectedNodes)) {
             commit.setSelected(selectedNodes);
+          }
+
+          if (provenanceState.displayCharts !== storeState.displayCharts) {
+            storeState.displayCharts = provenanceState.displayCharts;
           }
         },
       );

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -35,7 +35,7 @@ const {
       href: '',
     },
     simulation: null,
-    renderNested: false,
+    displayCharts: false,
     markerSize: 50,
     fontSize: 12,
     labelVariable: '_key',
@@ -82,8 +82,8 @@ const {
       return state.simulation;
     },
 
-    renderNested(state: State) {
-      return state.renderNested;
+    displayCharts(state: State) {
+      return state.displayCharts;
     },
 
     markerSize(state: State) {
@@ -199,8 +199,8 @@ const {
       }
     },
 
-    setRenderNested(state, renderNested: boolean) {
-      state.renderNested = renderNested;
+    setDisplayCharts(state, displayCharts: boolean) {
+      state.displayCharts = displayCharts;
     },
 
     setMarkerSize(state, markerSize: number) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -353,20 +353,20 @@ const {
 
       // Add a global observer to watch the state and update the tracked elements in the store
       // enables undo/redo + navigating around provenance graph
-      context.state.provenance.addGlobalObserver(
+      storeState.provenance.addGlobalObserver(
         () => {
           const provenanceState = context.state.provenance.state;
 
           // TODO: #148 remove cast back to set
-          const selectedNodes = new Set<string>(context.state.provenance.state.selectedNodes);
+          const selectedNodes = new Set<string>(provenanceState.selectedNodes);
 
           // Helper function
           const setsAreEqual = (a: Set<unknown>, b: Set<unknown>) => a.size === b.size && [...a].every((value) => b.has(value));
 
           // If the sets are not equal (happens when provenance is updated through provenance vis),
           // update the store's selectedNodes to match the provenance state
-          if (!setsAreEqual(selectedNodes, context.state.selectedNodes)) {
-            commit.setSelected(selectedNodes);
+          if (!setsAreEqual(selectedNodes, storeState.selectedNodes)) {
+            storeState.selectedNodes = selectedNodes;
           }
 
           if (provenanceState.displayCharts !== storeState.displayCharts) {
@@ -375,7 +375,7 @@ const {
         },
       );
 
-      context.state.provenance.done();
+      storeState.provenance.done();
     },
   },
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,4 +83,4 @@ export interface State {
   simulationRunning: boolean;
 }
 
-export type ProvenanceEventTypes = 'Select Node' | 'De-select Node';
+export type ProvenanceEventTypes = 'Select Node' | 'De-select Node' | 'Set Display Charts';

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,7 @@ export interface State {
   network: Network | null;
   selectedNodes: Set<string>;
   loadError: LoadError;
-  renderNested: boolean;
+  displayCharts: boolean;
   markerSize: number;
   fontSize: number;
   labelVariable: string;


### PR DESCRIPTION
A step towards #97

I decided to rename the renderNested variable to displayCharts so it matches the verbiage in the control panel. Then I added that to the provenance tracking and you can see it in the trrack-vis, too.