### PR TITLE
Add remaining control panel elements to provenance (+ vis)

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -76,7 +76,7 @@ export default Vue.extend({
         return store.getters.markerSize || 0;
       },
       set(value: number) {
-        store.commit.setMarkerSize(value);
+        store.commit.setMarkerSize({ markerSize: value, updateProv: false });
       },
     },
 
@@ -85,7 +85,7 @@ export default Vue.extend({
         return store.getters.fontSize || 0;
       },
       set(value: number) {
-        store.commit.setFontSize(value);
+        store.commit.setFontSize({ fontSize: value, updateProv: false });
       },
     },
 
@@ -179,6 +179,16 @@ export default Vue.extend({
       }
 
       this.searchErrors = searchErrors;
+    },
+
+    updateSliderProv(value: number, type: 'markerSize' | 'fontSize') {
+      if (type === 'markerSize') {
+        store.commit.setMarkerSize({ markerSize: value, updateProv: true });
+      }
+
+      if (type === 'fontSize') {
+        store.commit.setFontSize({ fontSize: value, updateProv: true });
+      }
     },
   },
 });
@@ -307,6 +317,7 @@ export default Vue.extend({
             :label="String(markerSize)"
             inverse-label
             hide-details
+            @change="(value) => updateSliderProv(value, 'markerSize')"
           />
 
           <v-card-subtitle class="pb-0 pl-0">
@@ -319,6 +330,7 @@ export default Vue.extend({
             :label="String(fontSize)"
             inverse-label
             hide-details
+            @change="(value) => updateSliderProv(value, 'fontSize')"
           />
 
           <v-row>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -188,9 +188,7 @@ export default Vue.extend({
     updateSliderProv(value: number, type: 'markerSize' | 'fontSize') {
       if (type === 'markerSize') {
         store.commit.setMarkerSize({ markerSize: value, updateProv: true });
-      }
-
-      if (type === 'fontSize') {
+      } else if (type === 'fontSize') {
         store.commit.setFontSize({ fontSize: value, updateProv: true });
       }
     },

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -15,6 +15,16 @@ export function updateProvenanceState(vuexState: State, label: ProvenanceEventTy
       provState.displayCharts = newProvState.displayCharts;
     }
 
+    if (label === 'Set Marker Size') {
+      // eslint-disable-next-line no-param-reassign
+      provState.markerSize = newProvState.markerSize;
+    }
+
+    if (label === 'Set Font Size') {
+      // eslint-disable-next-line no-param-reassign
+      provState.fontSize = newProvState.fontSize;
+    }
+
     if (label === 'Set Select Neighbors') {
       // eslint-disable-next-line no-param-reassign
       provState.selectNeighbors = newProvState.selectNeighbors;

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -25,6 +25,16 @@ export function updateProvenanceState(vuexState: State, label: ProvenanceEventTy
       provState.fontSize = newProvState.fontSize;
     }
 
+    if (label === 'Set Label Variable') {
+      // eslint-disable-next-line no-param-reassign
+      provState.labelVariable = newProvState.labelVariable;
+    }
+
+    if (label === 'Set Color Variable') {
+      // eslint-disable-next-line no-param-reassign
+      provState.colorVariable = newProvState.colorVariable;
+    }
+
     if (label === 'Set Select Neighbors') {
       // eslint-disable-next-line no-param-reassign
       provState.selectNeighbors = newProvState.selectNeighbors;

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -39,6 +39,11 @@ export function updateProvenanceState(vuexState: State, label: ProvenanceEventTy
       // eslint-disable-next-line no-param-reassign
       provState.selectNeighbors = newProvState.selectNeighbors;
     }
+
+    if (label === 'Set Directional Edges') {
+      // eslint-disable-next-line no-param-reassign
+      provState.directionalEdges = newProvState.directionalEdges;
+    }
   })
     .setLabel(label);
 

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -14,6 +14,11 @@ export function updateProvenanceState(vuexState: State, label: ProvenanceEventTy
       // eslint-disable-next-line no-param-reassign
       provState.displayCharts = newProvState.displayCharts;
     }
+
+    if (label === 'Set Select Neighbors') {
+      // eslint-disable-next-line no-param-reassign
+      provState.selectNeighbors = newProvState.selectNeighbors;
+    }
   })
     .setLabel(label);
 

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -8,39 +8,25 @@ export function updateProvenanceState(vuexState: State, label: ProvenanceEventTy
       // TODO: #148 remove cast back to set
       // eslint-disable-next-line no-param-reassign, @typescript-eslint/no-explicit-any
       provState.selectedNodes = [...newProvState.selectedNodes] as any;
-    }
-
-    if (label === 'Set Display Charts') {
+    } else if (label === 'Set Display Charts') {
       // eslint-disable-next-line no-param-reassign
       provState.displayCharts = newProvState.displayCharts;
-    }
-
-    if (label === 'Set Marker Size') {
+    } else if (label === 'Set Marker Size') {
       // eslint-disable-next-line no-param-reassign
       provState.markerSize = newProvState.markerSize;
-    }
-
-    if (label === 'Set Font Size') {
+    } else if (label === 'Set Font Size') {
       // eslint-disable-next-line no-param-reassign
       provState.fontSize = newProvState.fontSize;
-    }
-
-    if (label === 'Set Label Variable') {
+    } else if (label === 'Set Label Variable') {
       // eslint-disable-next-line no-param-reassign
       provState.labelVariable = newProvState.labelVariable;
-    }
-
-    if (label === 'Set Color Variable') {
+    } else if (label === 'Set Color Variable') {
       // eslint-disable-next-line no-param-reassign
       provState.colorVariable = newProvState.colorVariable;
-    }
-
-    if (label === 'Set Select Neighbors') {
+    } else if (label === 'Set Select Neighbors') {
       // eslint-disable-next-line no-param-reassign
       provState.selectNeighbors = newProvState.selectNeighbors;
-    }
-
-    if (label === 'Set Directional Edges') {
+    } else if (label === 'Set Directional Edges') {
       // eslint-disable-next-line no-param-reassign
       provState.directionalEdges = newProvState.directionalEdges;
     }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -225,6 +225,10 @@ const {
 
     setSelectNeighbors(state, selectNeighbors: boolean) {
       state.selectNeighbors = selectNeighbors;
+
+      if (state.provenance !== null) {
+        updateProvenanceState(state, 'Set Select Neighbors');
+      }
     },
 
     setNestedVariables(state, nestedVariables: NestedVariables) {
@@ -369,9 +373,15 @@ const {
             storeState.selectedNodes = selectedNodes;
           }
 
-          if (provenanceState.displayCharts !== storeState.displayCharts) {
-            storeState.displayCharts = provenanceState.displayCharts;
-          }
+          // Iterate through vars with primitive data types
+          [
+            'displayCharts',
+            'selectNeighbors',
+          ].forEach((primitiveVariable) => {
+            if (storeState[primitiveVariable] !== provenanceState[primitiveVariable]) {
+              storeState[primitiveVariable] = provenanceState[primitiveVariable];
+            }
+          });
         },
       );
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -280,6 +280,10 @@ const {
 
     setDirectionalEdges(state, directionalEdges: boolean) {
       state.directionalEdges = directionalEdges;
+
+      if (state.provenance !== null) {
+        updateProvenanceState(state, 'Set Directional Edges');
+      }
     },
 
     goToProvenanceNode(state, node: string) {
@@ -397,6 +401,7 @@ const {
             'labelVariable',
             'colorVariable',
             'selectNeighbors',
+            'directionalEdges',
           ].forEach((primitiveVariable) => {
             if (storeState[primitiveVariable] !== provenanceState[primitiveVariable]) {
               storeState[primitiveVariable] = provenanceState[primitiveVariable];

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -225,10 +225,18 @@ const {
 
     setLabelVariable(state, labelVariable: string) {
       state.labelVariable = labelVariable;
+
+      if (state.provenance !== null) {
+        updateProvenanceState(state, 'Set Label Variable');
+      }
     },
 
     setColorVariable(state, colorVariable: string) {
       state.colorVariable = colorVariable;
+
+      if (state.provenance !== null) {
+        updateProvenanceState(state, 'Set Color Variable');
+      }
     },
 
     setSelectNeighbors(state, selectNeighbors: boolean) {
@@ -386,6 +394,8 @@ const {
             'displayCharts',
             'markerSize',
             'fontSize',
+            'labelVariable',
+            'colorVariable',
             'selectNeighbors',
           ].forEach((primitiveVariable) => {
             if (storeState[primitiveVariable] !== provenanceState[primitiveVariable]) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -207,12 +207,20 @@ const {
       }
     },
 
-    setMarkerSize(state, markerSize: number) {
-      state.markerSize = markerSize;
+    setMarkerSize(state, payload: { markerSize: number; updateProv: boolean }) {
+      state.markerSize = payload.markerSize;
+
+      if (state.provenance !== null && payload.updateProv) {
+        updateProvenanceState(state, 'Set Marker Size');
+      }
     },
 
-    setFontSize(state, fontSize: number) {
-      state.fontSize = fontSize;
+    setFontSize(state, payload: { fontSize: number; updateProv: boolean }) {
+      state.fontSize = payload.fontSize;
+
+      if (state.provenance !== null && payload.updateProv) {
+        updateProvenanceState(state, 'Set Font Size');
+      }
     },
 
     setLabelVariable(state, labelVariable: string) {
@@ -376,6 +384,8 @@ const {
           // Iterate through vars with primitive data types
           [
             'displayCharts',
+            'markerSize',
+            'fontSize',
             'selectNeighbors',
           ].forEach((primitiveVariable) => {
             if (storeState[primitiveVariable] !== provenanceState[primitiveVariable]) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,4 +91,5 @@ export type ProvenanceEventTypes =
   'Set Font Size' |
   'Set Label Variable' |
   'Set Color Variable' |
-  'Set Select Neighbors';
+  'Set Select Neighbors'|
+  'Set Directional Edges';

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,4 +89,6 @@ export type ProvenanceEventTypes =
   'Set Display Charts' |
   'Set Marker Size' |
   'Set Font Size' |
+  'Set Label Variable' |
+  'Set Color Variable' |
   'Set Select Neighbors';

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,4 +87,6 @@ export type ProvenanceEventTypes =
   'Select Node' |
   'De-select Node' |
   'Set Display Charts' |
+  'Set Marker Size' |
+  'Set Font Size' |
   'Set Select Neighbors';

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,4 +83,8 @@ export interface State {
   simulationRunning: boolean;
 }
 
-export type ProvenanceEventTypes = 'Select Node' | 'De-select Node' | 'Set Display Charts';
+export type ProvenanceEventTypes =
+  'Select Node' |
+  'De-select Node' |
+  'Set Display Charts' |
+  'Set Select Neighbors';


### PR DESCRIPTION
Depends on #156 for the fix to the v-selects

Closes #97

This tracks the remaining settings in the control panel in the provenance state. Most of them were pretty simple, aside from the 2 sliders. The sliders update their value constantly as they're dragged and that's undesirable for the provenance state (we instead want to know where the slider was dropped). Therefore I added a flag and a helper to update the provenance state for the sliders on `@change`.

There was a question of whether we should allow the MultiMatrix.vue component to modify the store directly (instead of through the vuex store), but I think that'll open us up to bugs and it means that the code for updating the provenance is dispersed throughout more files. This was the simplest change I could think of that kept all the relevant code together