### PR TITLE
Rework the v-select styling, the list logic for v-select items, and update default color value

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -41,12 +41,8 @@ export default Vue.extend({
       return new Set();
     },
 
-    variableList(): Set<string | null> {
-      return this.multiVariableList.add(null);
-    },
-
     colorVariableList(): Set<string | null> {
-      return this.variableList.add('table');
+      return new Set(this.multiVariableList).add('table');
     },
 
     linkVariableList(): Set<string | null> {
@@ -250,7 +246,7 @@ export default Vue.extend({
             <v-select
               v-model="labelVariable"
               label="Label Variable"
-              :items="Array.from(variableList)"
+              :items="Array.from(multiVariableList)"
               clearable
               outlined
               dense

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -251,13 +251,9 @@ export default Vue.extend({
               v-model="labelVariable"
               label="Label Variable"
               :items="Array.from(variableList)"
-              multiple
+              clearable
               outlined
-              chips
               dense
-              deletable-chips
-              small-chips
-              persistent-hint
             />
           </v-list-item>
 
@@ -266,13 +262,9 @@ export default Vue.extend({
               v-model="colorVariable"
               label="Color Variable"
               :items="Array.from(colorVariableList)"
-              multiple
+              clearable
               outlined
-              chips
               dense
-              deletable-chips
-              small-chips
-              persistent-hint
             />
           </v-list-item>
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -39,7 +39,7 @@ const {
     markerSize: 50,
     fontSize: 12,
     labelVariable: '_key',
-    colorVariable: '_key',
+    colorVariable: '',
     selectNeighbors: true,
     nestedVariables: {
       bar: [],


### PR DESCRIPTION
This is from a problem I noticed in #155 

The v-select elements were set to allow multiple selections and thus were returning arrays instead of just strings as expected. In order to fix the problem, I refactored the v-select style to not include `multiple`. I also added `clearable`, since we should be able to have no variable mapped to it, and removed unnecessary props: `chips`, `deletable-chips`, `small-chips`. and `persistent-hint`.

After dealing with that problem, I noticed some unnecessary logic in the logic that creates the list items and an incorrect default values for the color variable. As such, I removed the logic and update the default value to `''`