### PR TITLE
Add undo/redo event listener for provenance

### DIFF
--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -37,3 +37,26 @@ export function updateProvenanceState(vuexState: State, label: ProvenanceEventTy
     vuexState.provenance.apply(stateUpdateActions(vuexState));
   }
 }
+
+export function undoRedoKeyHandler(event: KeyboardEvent, storeState: State) {
+  // If provenance doesn't exist, exit
+  if (storeState.provenance == null) { return; }
+
+  if (
+    (event.ctrlKey && event.code === 'KeyZ' && !event.shiftKey) // ctrl + z (no shift)
+    || (event.metaKey && event.code === 'KeyZ' && !event.shiftKey) // meta + z (no shift)
+  ) {
+    if (storeState.provenance.current.id !== storeState.provenance.root.id) {
+      storeState.provenance.undo();
+    }
+  } else if (
+    (event.ctrlKey && event.code === 'KeyY') // ctrl + y
+    || (event.ctrlKey && event.code === 'KeyZ' && event.shiftKey) // ctrl + shift + z
+    || (event.metaKey && event.code === 'KeyY') // meta + y
+    || (event.metaKey && event.code === 'KeyZ' && event.shiftKey) // meta + shift + z
+  ) {
+    if (storeState.provenance.current.children.length > 0) {
+      storeState.provenance.redo();
+    }
+  }
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -428,6 +428,23 @@ const {
       );
 
       storeState.provenance.done();
+
+      // Add keydown listener for undo/redo
+      document.addEventListener('keydown', (event) => {
+        if (
+          (event.ctrlKey && event.code === 'KeyZ' && !event.shiftKey) // ctrl + z (no shift)
+          || (event.metaKey && event.code === 'KeyZ' && !event.shiftKey) // meta + z (no shift)
+        ) {
+          storeState.provenance.undo();
+        } else if (
+          (event.ctrlKey && event.code === 'KeyY') // ctrl + y
+          || (event.ctrlKey && event.code === 'KeyZ' && event.shiftKey) // ctrl + shift + z
+          || (event.metaKey && event.code === 'KeyY') // meta + y
+          || (event.metaKey && event.code === 'KeyZ' && event.shiftKey) // meta + shift + z
+        ) {
+          storeState.provenance.redo();
+        }
+      });
     },
   },
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -435,14 +435,18 @@ const {
           (event.ctrlKey && event.code === 'KeyZ' && !event.shiftKey) // ctrl + z (no shift)
           || (event.metaKey && event.code === 'KeyZ' && !event.shiftKey) // meta + z (no shift)
         ) {
-          storeState.provenance.undo();
+          if (storeState.provenance.current.id !== storeState.provenance.root.id) {
+            storeState.provenance.undo();
+          }
         } else if (
           (event.ctrlKey && event.code === 'KeyY') // ctrl + y
           || (event.ctrlKey && event.code === 'KeyZ' && event.shiftKey) // ctrl + shift + z
           || (event.metaKey && event.code === 'KeyY') // meta + y
           || (event.metaKey && event.code === 'KeyZ' && event.shiftKey) // meta + shift + z
         ) {
-          storeState.provenance.redo();
+          if (storeState.provenance.current.children.length > 0) {
+            storeState.provenance.redo();
+          }
         }
       });
     },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -15,7 +15,7 @@ import {
 } from 'd3-scale';
 import { schemeCategory10 } from 'd3-scale-chromatic';
 import { initProvenance, Provenance } from '@visdesignlab/trrack';
-import { updateProvenanceState } from '@/lib/provenanceUtils';
+import { undoRedoKeyHandler, updateProvenanceState } from '@/lib/provenanceUtils';
 
 Vue.use(Vuex);
 
@@ -430,25 +430,7 @@ const {
       storeState.provenance.done();
 
       // Add keydown listener for undo/redo
-      document.addEventListener('keydown', (event) => {
-        if (
-          (event.ctrlKey && event.code === 'KeyZ' && !event.shiftKey) // ctrl + z (no shift)
-          || (event.metaKey && event.code === 'KeyZ' && !event.shiftKey) // meta + z (no shift)
-        ) {
-          if (storeState.provenance.current.id !== storeState.provenance.root.id) {
-            storeState.provenance.undo();
-          }
-        } else if (
-          (event.ctrlKey && event.code === 'KeyY') // ctrl + y
-          || (event.ctrlKey && event.code === 'KeyZ' && event.shiftKey) // ctrl + shift + z
-          || (event.metaKey && event.code === 'KeyY') // meta + y
-          || (event.metaKey && event.code === 'KeyZ' && event.shiftKey) // meta + shift + z
-        ) {
-          if (storeState.provenance.current.children.length > 0) {
-            storeState.provenance.redo();
-          }
-        }
-      });
+      document.addEventListener('keydown', (event) => undoRedoKeyHandler(event, storeState));
     },
   },
 });


### PR DESCRIPTION
Closes #157

Add back the key bindings for undoing/redoing provenance steps. This uses similar code to the one used previously, except the syntax has changed slightly (`undo(provenance)` => `provenance.undo()`)