### PR TITLE
Add clear selection button with relevant provenance changes

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -192,6 +192,10 @@ export default Vue.extend({
         store.commit.setFontSize({ fontSize: value, updateProv: true });
       }
     },
+
+    clearSelection() {
+      store.commit.setSelected(new Set());
+    },
   },
 });
 </script>
@@ -275,6 +279,18 @@ export default Vue.extend({
               outlined
               dense
             />
+          </v-list-item>
+
+          <v-list-item class="px-0">
+            <v-btn
+              color="primary"
+              depressed
+              small
+              block
+              @click="clearSelection"
+            >
+              Clear Selection
+            </v-btn>
           </v-list-item>
 
           <v-list-item class="px-0">

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -4,7 +4,7 @@ import { createAction } from '@visdesignlab/trrack';
 export function updateProvenanceState(vuexState: State, label: ProvenanceEventTypes) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const stateUpdateActions = createAction<State, any[], ProvenanceEventTypes>((provState, newProvState) => {
-    if (label === 'Select Node' || label === 'De-select Node') {
+    if (label === 'Select Node' || label === 'De-select Node' || label === 'Clear Selection') {
       // TODO: #148 remove cast back to set
       // eslint-disable-next-line no-param-reassign, @typescript-eslint/no-explicit-any
       provState.selectedNodes = [...newProvState.selectedNodes] as any;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -160,6 +160,12 @@ const {
 
     setSelected(state, selectedNodes: Set<string>) {
       state.selectedNodes = selectedNodes;
+
+      if (state.provenance !== null) {
+        if (selectedNodes.size === 0) {
+          updateProvenanceState(state, 'Clear Selection');
+        }
+      }
     },
 
     setLoadError(state, loadError: LoadError) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,7 @@ export interface State {
 export type ProvenanceEventTypes =
   'Select Node' |
   'De-select Node' |
+  'Clear Selection' |
   'Set Display Charts' |
   'Set Marker Size' |
   'Set Font Size' |


### PR DESCRIPTION
This was a feature requested by Alex. This button will eventually move to the always visible controls so I haven't put too much effort into styling it for now.

In the provenance, I added a check to see if we're trying to set an empty set for the selected nodes and if so, it adds a node to provenance called "Clear Selection"