### PR TITLE
Filter column attributes using type metadata

### DIFF
--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -61,7 +61,7 @@ export default Vue.extend({
     },
 
     columnTypes() {
-      const typeMapping: { [key: string]: string} = {};
+      const typeMapping: { [key: string]: string } = {};
 
       if (store.getters.networkMetadata !== null) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -76,27 +76,11 @@ export default Vue.extend({
     },
 
     cleanedNodeVariables(): Set<string> {
-      const cleanedVariables = new Set<string>();
-
-      (this.multiVariableList as Set<string>).forEach((variable) => {
-        if (this.columnTypes[variable] !== 'label') {
-          cleanedVariables.add(variable);
-        }
-      });
-
-      return cleanedVariables;
+      return this.cleanVariableList(this.multiVariableList as Set<string>);
     },
 
     cleanedLinkVariables(): Set<string> {
-      const cleanedVariables = new Set<string>();
-
-      (this.linkVariableList as Set<string>).forEach((variable) => {
-        if (this.columnTypes[variable] !== 'label') {
-          cleanedVariables.add(variable);
-        }
-      });
-
-      return cleanedVariables;
+      return this.cleanVariableList(this.linkVariableList as Set<string>);
     },
   },
 
@@ -298,6 +282,18 @@ export default Vue.extend({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     dragStart(newEvent: any) {
       newEvent.dataTransfer.setData('attr_id', newEvent.target.id);
+    },
+
+    cleanVariableList(list: Set<string>): Set<string> {
+      const cleanedVariables = new Set<string>();
+
+      list.forEach((variable) => {
+        if (this.columnTypes[variable] !== 'label') {
+          cleanedVariables.add(variable);
+        }
+      });
+
+      return cleanedVariables;
     },
   },
 });

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -502,6 +502,10 @@ export default Vue.extend({
         <br>
       </div>
 
+      <div v-if="cleanedNodeVariables.size === 0">
+        No Node Attributes To Visualize
+      </div>
+
       <br>
       <br>
 
@@ -522,6 +526,10 @@ export default Vue.extend({
           width="100%"
         />
         <br>
+      </div>
+
+      <div v-if="cleanedLinkVariables.size === 0">
+        No Link Attributes To Visualize
       </div>
     </div>
   </div>

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -480,8 +480,14 @@ export default Vue.extend({
     <div :style="{'padding': `${varPadding}px`}">
       <h2>Node Attributes</h2>
       <br>
+
+      <div v-if="cleanedNodeVariables.size === 0">
+        No node attributes to visualize
+      </div>
+
       <div
         v-for="nodeAttr of cleanedNodeVariables"
+        v-else
         :id="`node${nodeAttr}div`"
         :key="`node${nodeAttr}`"
         class="draggable"
@@ -498,17 +504,19 @@ export default Vue.extend({
         <br>
       </div>
 
-      <div v-if="cleanedNodeVariables.size === 0">
-        No Node Attributes To Visualize
-      </div>
-
       <br>
       <br>
 
       <h2>Link Attributes</h2>
       <br>
+
+      <div v-if="cleanedLinkVariables.size === 0">
+        No link attributes to visualize
+      </div>
+
       <div
         v-for="linkAttr of cleanedLinkVariables"
+        v-else
         :id="`link${linkAttr}div`"
         :key="`link${linkAttr}`"
         class="draggable"
@@ -522,10 +530,6 @@ export default Vue.extend({
           width="100%"
         />
         <br>
-      </div>
-
-      <div v-if="cleanedLinkVariables.size === 0">
-        No Link Attributes To Visualize
       </div>
     </div>
   </div>

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -64,7 +64,6 @@ export default Vue.extend({
       const typeMapping: { [key: string]: string } = {};
 
       if (store.getters.networkMetadata !== null) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         Object.values(store.getters.networkMetadata).forEach((metadata) => {
           (metadata as TableMetadata).table.columns.forEach((columnType) => {
             typeMapping[columnType.key] = columnType.type;

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -65,7 +65,7 @@ export default Vue.extend({
 
       if (store.getters.networkMetadata !== null) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        Object.entries(store.getters.networkMetadata).forEach(([tableName, metadata]) => {
+        Object.values(store.getters.networkMetadata).forEach((metadata) => {
           (metadata as TableMetadata).table.columns.forEach((columnType) => {
             typeMapping[columnType.key] = columnType.type;
           });

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -5,6 +5,7 @@ import { select } from 'd3-selection';
 import { scaleLinear, scaleBand, ScaleBand } from 'd3-scale';
 import { axisBottom, axisLeft } from 'd3-axis';
 import { brushX } from 'd3-brush';
+import { TableMetadata } from 'multinet';
 
 import { Node, Link, Network } from '@/types';
 import store from '@/store';
@@ -57,6 +58,45 @@ export default Vue.extend({
 
     nodeColorScale() {
       return store.getters.nodeColorScale;
+    },
+
+    columnTypes() {
+      const typeMapping: { [key: string]: string} = {};
+
+      if (store.getters.networkMetadata !== null) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        Object.entries(store.getters.networkMetadata).forEach(([tableName, metadata]) => {
+          (metadata as TableMetadata).table.columns.forEach((columnType) => {
+            typeMapping[columnType.key] = columnType.type;
+          });
+        });
+      }
+
+      return typeMapping;
+    },
+
+    cleanedNodeVariables(): Set<string> {
+      const cleanedVariables = new Set<string>();
+
+      (this.multiVariableList as Set<string>).forEach((variable) => {
+        if (this.columnTypes[variable] !== 'label') {
+          cleanedVariables.add(variable);
+        }
+      });
+
+      return cleanedVariables;
+    },
+
+    cleanedLinkVariables(): Set<string> {
+      const cleanedVariables = new Set<string>();
+
+      (this.linkVariableList as Set<string>).forEach((variable) => {
+        if (this.columnTypes[variable] !== 'label') {
+          cleanedVariables.add(variable);
+        }
+      });
+
+      return cleanedVariables;
     },
   },
 
@@ -445,7 +485,7 @@ export default Vue.extend({
       <h2>Node Attributes</h2>
       <br>
       <div
-        v-for="nodeAttr of multiVariableList"
+        v-for="nodeAttr of cleanedNodeVariables"
         :id="`node${nodeAttr}div`"
         :key="`node${nodeAttr}`"
         class="draggable"
@@ -468,7 +508,7 @@ export default Vue.extend({
       <h2>Link Attributes</h2>
       <br>
       <div
-        v-for="linkAttr of linkVariableList"
+        v-for="linkAttr of cleanedLinkVariables"
         :id="`link${linkAttr}div`"
         :key="`link${linkAttr}`"
         class="draggable"


### PR DESCRIPTION
Depends on #159

Closes #158 

Removes and column with type label from the legend panel for data that have type.

I was trying to use `type: Set as PropType<Set<string>>` and it wasn't getting the type. My resolution was to just pass the type into the function, but that's not the most ideal way to get around the errors. Am I doing something wrong? Is there a better way to resolve this?

TODO:
- [x] Don't remove columns if the types don't exist (was already fixed because I'm checking !== 'label')
- [x] Show a message if no columns remain for visualization