### PR TITLE
Add UI and logic to set node color from the legend

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -130,6 +130,10 @@ export default Vue.extend({
       }
       return [];
     },
+
+    networkMetadata() {
+      return store.getters.networkMetadata;
+    },
   },
 
   methods: {
@@ -406,7 +410,7 @@ export default Vue.extend({
           Legend
         </v-subheader>
         <Legend
-          v-if="multiVariableList.has('_key')"
+          v-if="multiVariableList.has('_key') && networkMetadata"
           ref="legend"
           class="mt-4"
           v-bind="{

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -98,12 +98,12 @@ export default Vue.extend({
       },
     },
 
-    colorVariable: {
+    nodeColorVariable: {
       get() {
-        return store.getters.colorVariable;
+        return store.getters.nodeColorVariable;
       },
       set(value: string) {
-        store.commit.setColorVariable(value);
+        store.commit.setNodeColorVariable(value);
       },
     },
 

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -41,10 +41,6 @@ export default Vue.extend({
       return new Set();
     },
 
-    colorVariableList(): Set<string | null> {
-      return new Set(this.multiVariableList).add('table');
-    },
-
     linkVariableList(): Set<string | null> {
       if (this.graphStructure !== null) {
         // Loop through all links, flatten the 2d array, and turn it into a set
@@ -95,15 +91,6 @@ export default Vue.extend({
       },
       set(value: string) {
         store.commit.setLabelVariable(value);
-      },
-    },
-
-    nodeColorVariable: {
-      get() {
-        return store.getters.nodeColorVariable;
-      },
-      set(value: string) {
-        store.commit.setNodeColorVariable(value);
       },
     },
 
@@ -264,17 +251,6 @@ export default Vue.extend({
               v-model="labelVariable"
               label="Label Variable"
               :items="Array.from(multiVariableList)"
-              clearable
-              outlined
-              dense
-            />
-          </v-list-item>
-
-          <v-list-item class="px-0">
-            <v-select
-              v-model="colorVariable"
-              label="Color Variable"
-              :items="Array.from(colorVariableList)"
               clearable
               outlined
               dense

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -167,7 +167,7 @@ export default Vue.extend({
           // Add the bars
           const variableSvgEnter = (variableSvg
             .selectAll()
-            .data(currentData)
+            .data(binLabels)
             .enter()
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             .append('rect') as any)

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -102,11 +102,11 @@ export default Vue.extend({
   methods: {
     setUpPanel() {
       // For node and link variables
-      [this.multiVariableList as Set<string>, this.linkVariableList as Set<string>].forEach((list) => {
+      [this.cleanedNodeVariables as Set<string>, this.cleanedLinkVariables as Set<string>].forEach((list) => {
         // For each attribute
         list.forEach((attr) => {
           // Get the SVG element and its width
-          const type = list === this.multiVariableList ? 'node' : 'link';
+          const type = list === this.cleanedNodeVariables ? 'node' : 'link';
           const variableSvg = select(`#${type}${attr}`);
 
           const variableSvgWidth = (variableSvg

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -446,14 +446,14 @@ export default Vue.extend({
             dominant-baseline="hanging"
           >Size</text>
           <path
-            v-if="!nodeSizeVariable"
+            v-if="nodeSizeVariable === ''"
             class="plus"
             d="M0,-10 V10 M-10,0 H10"
             stroke="black"
             stroke-width="3px"
           />
           <text
-            :transform="`translate(0,${15})`"
+            transform="translate(0,15)"
             dominant-baseline="hanging"
             style="text-anchor: start;"
             font-size="9pt"

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -277,6 +277,8 @@ export default Vue.extend({
         store.commit.setNestedVariables(updatedNestedVars);
       } else if (type === 'node' && targetEl === 'nodeSizeElements') {
         store.commit.setNodeSizeVariable(droppedElText);
+      } else if (type === 'node' && targetEl === 'nodeColorElements') {
+        store.commit.setNodeColorVariable(droppedElText);
       } else if (type === 'link' && targetEl === 'widthElements') {
         const updatedLinkVars = {
           width: droppedElText,
@@ -457,6 +459,38 @@ export default Vue.extend({
             font-size="9pt"
           >{{ nodeSizeVariable }}</text>
         </g>
+
+        <!-- Glyph adding elements -->
+        <g
+          id="nodeColorElements"
+          @dragenter="(e) => e.preventDefault()"
+          @dragover="(e) => e.preventDefault()"
+          @drop="rectDrop"
+        >
+          <rect
+            width="10%"
+            height="40%"
+            fill="#EEEEEE"
+          />
+          <text
+            class="barLabel"
+            font-size="10pt"
+            dominant-baseline="hanging"
+          >Color</text>
+          <path
+            v-if="nodeColorVariable === ''"
+            class="plus"
+            d="M0,-10 V10 M-10,0 H10"
+            stroke="black"
+            stroke-width="3px"
+          />
+          <text
+            transform="translate(0,15)"
+            dominant-baseline="hanging"
+            style="text-anchor: start;"
+            font-size="9pt"
+          >{{ nodeColorVariable }}</text>
+        </g>
       </g>
 
       <!-- Link elements -->
@@ -630,7 +664,7 @@ svg >>> .selected{
 #barElements, #widthElements, #nodeSizeElements {
   transform: translate(-12%, -20%);
 }
-#glyphElements, #colorElements {
+#glyphElements, #colorElements, #nodeColorElements {
   transform: translate(2%, -20%);
 }
 .plus {

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -60,6 +60,10 @@ export default Vue.extend({
       return store.getters.nodeSizeVariable;
     },
 
+    nodeColorVariable() {
+      return store.getters.nodeColorVariable;
+    },
+
     nodeColorScale() {
       return store.getters.nodeColorScale;
     },

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -56,6 +56,10 @@ export default Vue.extend({
       return store.getters.linkVariables;
     },
 
+    nodeSizeVariable() {
+      return store.getters.nodeSizeVariable;
+    },
+
     nodeColorScale() {
       return store.getters.nodeColorScale;
     },
@@ -80,6 +84,10 @@ export default Vue.extend({
 
     cleanedLinkVariables(): Set<string> {
       return this.cleanVariableList(this.linkVariableList as Set<string>);
+    },
+
+    displayCharts() {
+      return store.getters.displayCharts;
     },
   },
 

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -226,7 +226,8 @@ export default Vue.extend({
       });
     },
 
-    // TODO: #176 use table name for var selection
+    // TODO: https://github.com/multinet-app/multilink/issues/176
+    // use table name for var selection
     isQuantitative(varName: string, type: 'node' | 'link') {
       if (Object.entries(this.columnTypes).length > 0) {
         return this.columnTypes[varName] === 'number';

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -229,7 +229,7 @@ export default Vue.extend({
     // TODO: https://github.com/multinet-app/multilink/issues/176
     // use table name for var selection
     isQuantitative(varName: string, type: 'node' | 'link') {
-      if (Object.entries(this.columnTypes).length > 0) {
+      if (Object.keys(this.columnTypes).length > 0) {
         return this.columnTypes[varName] === 'number';
       }
 

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -226,7 +226,12 @@ export default Vue.extend({
       });
     },
 
+    // TODO: #176 use table name for var selection
     isQuantitative(varName: string, type: 'node' | 'link') {
+      if (Object.entries(this.columnTypes).length > 0) {
+        return this.columnTypes[varName] === 'number';
+      }
+
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let nodesOrLinks: any[];
 

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -271,6 +271,8 @@ export default Vue.extend({
           glyph: [...this.nestedVariables.glyph, droppedElText],
         };
         store.commit.setNestedVariables(updatedNestedVars);
+      } else if (type === 'node' && targetEl === 'nodeSizeElements') {
+        store.commit.setNodeSizeVariable(droppedElText);
       } else if (type === 'link' && targetEl === 'widthElements') {
         const updatedLinkVars = {
           width: droppedElText,

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -321,8 +321,11 @@ export default Vue.extend({
         opacity="1"
       />
 
-      <!-- Node elements -->
-      <g id="nodeMapping">
+      <!-- Node elements when displayCharts === true -->
+      <g
+        v-if="displayCharts"
+        id="nodeMapping"
+      >
         <text
           font-size="16pt"
           y="-102"
@@ -399,6 +402,54 @@ export default Vue.extend({
             style="text-anchor: start;"
             font-size="9pt"
           >{{ glyphVar }}</text>
+        </g>
+      </g>
+
+      <!-- Node elements when displayCharts === false -->
+      <g
+        v-else
+        id="nodeMapping"
+      >
+        <text
+          font-size="16pt"
+          y="-102"
+          dominant-baseline="hanging"
+        >Node Mapping</text>
+        <circle
+          r="70"
+          fill="#82B1FF"
+        />
+
+        <!-- Bar adding elements -->
+        <g
+          id="nodeSizeElements"
+          @dragenter="(e) => e.preventDefault()"
+          @dragover="(e) => e.preventDefault()"
+          @drop="rectDrop"
+        >
+          <rect
+            width="10%"
+            height="40%"
+            fill="#EEEEEE"
+          />
+          <text
+            class="nodeSizeLabel"
+            font-size="10pt"
+            dominant-baseline="hanging"
+          >Size</text>
+          <path
+            v-if="!nodeSizeVariable"
+            class="plus"
+            d="M0,-10 V10 M-10,0 H10"
+            stroke="black"
+            stroke-width="3px"
+          />
+          <text
+            :transform="`translate(0,${15})`"
+            dominant-baseline="hanging"
+            style="text-anchor: start;"
+            font-size="9pt"
+          >{{ nodeSizeVariable }}</text>
         </g>
       </g>
 
@@ -561,7 +612,7 @@ svg >>> .selected{
 .sticky >>> text {
   text-anchor: middle;
 }
-.barLabel {
+.barLabel, .nodeSizeLabel {
   transform: translate(5%, 0);
 }
 #nodeMapping {
@@ -570,7 +621,7 @@ svg >>> .selected{
 #linkMapping {
   transform: translate(80%, 50%);
 }
-#barElements, #widthElements {
+#barElements, #widthElements, #nodeSizeElements {
   transform: translate(-12%, -20%);
 }
 #glyphElements, #colorElements {

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -109,8 +109,8 @@ export default Vue.extend({
       return store.getters.labelVariable;
     },
 
-    colorVariable() {
-      return store.getters.colorVariable;
+    nodeColorVariable() {
+      return store.getters.nodeColorVariable;
     },
 
     selectNeighbors() {
@@ -439,7 +439,7 @@ export default Vue.extend({
             :class="nodeClass(node)"
             :width="calculateNodeSize(node)"
             :height="calculateNodeSize(node)"
-            :fill="nodeColorScale(node[colorVariable])"
+            :fill="nodeColorScale(node[nodeColorVariable])"
             :rx="!displayCharts ? (calculateNodeSize(node) / 2) : 0"
             :ry="!displayCharts ? (calculateNodeSize(node) / 2) : 0"
             @click="selectNode(node)"

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -125,6 +125,10 @@ export default Vue.extend({
       return store.getters.linkVariables;
     },
 
+    nodeSizeVariable() {
+      return store.getters.nodeSizeVariable;
+    },
+
     attributeRanges() {
       return store.getters.attributeRanges;
     },
@@ -164,6 +168,15 @@ export default Vue.extend({
 
     controlsWidth(): number {
       return store.getters.controlsWidth;
+    },
+
+    nodeSizeScale(): ScaleLinear<number, number> | null {
+      if (this.network === null) { return null; }
+      const values = this.network.nodes.map((node) => node[this.nodeSizeVariable]);
+
+      return scaleLinear()
+        .domain([Math.min(...values), Math.max(...values)])
+        .range([10, 100]);
     },
   },
 

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -245,9 +245,9 @@ export default Vue.extend({
 
       const moveFn = (evt: Event) => {
         // eslint-disable-next-line no-param-reassign
-        node.x = (evt as MouseEvent).clientX - this.controlsWidth - (this.markerSize / 2);
+        node.x = (evt as MouseEvent).clientX - this.controlsWidth - (this.calculateNodeSize(node) / 2);
         // eslint-disable-next-line no-param-reassign
-        node.y = (evt as MouseEvent).clientY - (this.markerSize / 2);
+        node.y = (evt as MouseEvent).clientY - (this.calculateNodeSize(node) / 2);
         this.$forceUpdate();
       };
 
@@ -283,8 +283,8 @@ export default Vue.extend({
 
       const minimumX = svgEdgePadding;
       const minimumY = svgEdgePadding;
-      const maximumX = this.svgDimensions.width - this.markerSize - svgEdgePadding;
-      const maximumY = this.svgDimensions.height - this.markerSize - svgEdgePadding;
+      const maximumX = this.svgDimensions.width - this.calculateNodeSize(node) - svgEdgePadding;
+      const maximumY = this.svgDimensions.height - this.calculateNodeSize(node) - svgEdgePadding;
 
       // Ideally we would update node.x and node.y, but those variables are being changed
       // by the simulation. My solution was to use these forcedX and forcedY variables.
@@ -316,10 +316,10 @@ export default Vue.extend({
           throw new Error('_from or _to node didn\'t have an x or a y position.');
         }
 
-        const x1 = fromNode.x + this.markerSize / 2;
-        const y1 = fromNode.y + this.markerSize / 2;
-        const x2 = toNode.x + this.markerSize / 2;
-        const y2 = toNode.y + this.markerSize / 2;
+        const x1 = fromNode.x + this.calculateNodeSize(fromNode) / 2;
+        const y1 = fromNode.y + this.calculateNodeSize(fromNode) / 2;
+        const x2 = toNode.x + this.calculateNodeSize(toNode) / 2;
+        const y2 = toNode.y + this.calculateNodeSize(toNode) / 2;
 
         const dx = x2 - x1;
         const dy = y2 - y1;
@@ -376,6 +376,16 @@ export default Vue.extend({
     glyphStyle(value: string) {
       return `fill: ${this.nodeColorScale(value)};`;
     },
+
+    calculateNodeSize(node: Node) {
+      // Don't render dynamic node size if the size variable is empty or
+      // we want to display charts
+      if (this.nodeSizeVariable === '' || this.displayCharts || this.nodeSizeScale === null) {
+        return this.markerSize;
+      }
+
+      return this.nodeSizeScale(node[this.nodeSizeVariable]);
+    },
   },
 });
 </script>
@@ -427,11 +437,11 @@ export default Vue.extend({
         >
           <rect
             :class="nodeClass(node)"
-            :width="markerSize"
-            :height="markerSize"
+            :width="calculateNodeSize(node)"
+            :height="calculateNodeSize(node)"
             :fill="nodeColorScale(node[colorVariable])"
-            :rx="!displayCharts ? (markerSize / 2) : 0"
-            :ry="!displayCharts ? (markerSize / 2) : 0"
+            :rx="!displayCharts ? (calculateNodeSize(node) / 2) : 0"
+            :ry="!displayCharts ? (calculateNodeSize(node) / 2) : 0"
             @click="selectNode(node)"
             @mouseover="showTooltip(node, $event)"
             @mouseout="hideTooltip"
@@ -440,13 +450,13 @@ export default Vue.extend({
           <rect
             class="labelBackground"
             height="1em"
-            :y="!displayCharts ? (markerSize / 2) - 8 : 0"
-            :width="markerSize"
+            :y="!displayCharts ? (calculateNodeSize(node) / 2) - 8 : 0"
+            :width="calculateNodeSize(node)"
           />
           <text
             class="label"
-            :dy="!displayCharts ? markerSize / 2 + 2: 10"
-            :dx="markerSize / 2"
+            :dy="!displayCharts ? calculateNodeSize(node) / 2 + 2: 10"
+            :dx="calculateNodeSize(node) / 2"
             :style="nodeTextStyle"
           >{{ node[labelVariable] }}</text>
 

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -439,7 +439,7 @@ export default Vue.extend({
             :class="nodeClass(node)"
             :width="calculateNodeSize(node)"
             :height="calculateNodeSize(node)"
-            :fill="nodeColorScale(node[nodeColorVariable])"
+            :fill="!displayCharts ? nodeColorScale(node[nodeColorVariable]) : '1f77b4'"
             :rx="!displayCharts ? (calculateNodeSize(node) / 2) : 0"
             :ry="!displayCharts ? (calculateNodeSize(node) / 2) : 0"
             @click="selectNode(node)"

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -20,9 +20,12 @@ export function updateProvenanceState(vuexState: State, label: ProvenanceEventTy
     } else if (label === 'Set Label Variable') {
       // eslint-disable-next-line no-param-reassign
       provState.labelVariable = newProvState.labelVariable;
-    } else if (label === 'Set Color Variable') {
+    } else if (label === 'Set Node Color Variable') {
       // eslint-disable-next-line no-param-reassign
       provState.nodeColorVariable = newProvState.nodeColorVariable;
+    } else if (label === 'Set Node Size Variable') {
+      // eslint-disable-next-line no-param-reassign
+      provState.nodeSizeVariable = newProvState.nodeSizeVariable;
     } else if (label === 'Set Select Neighbors') {
       // eslint-disable-next-line no-param-reassign
       provState.selectNeighbors = newProvState.selectNeighbors;

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -22,7 +22,7 @@ export function updateProvenanceState(vuexState: State, label: ProvenanceEventTy
       provState.labelVariable = newProvState.labelVariable;
     } else if (label === 'Set Color Variable') {
       // eslint-disable-next-line no-param-reassign
-      provState.colorVariable = newProvState.colorVariable;
+      provState.nodeColorVariable = newProvState.nodeColorVariable;
     } else if (label === 'Set Select Neighbors') {
       // eslint-disable-next-line no-param-reassign
       provState.selectNeighbors = newProvState.selectNeighbors;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -54,6 +54,7 @@ const {
       width: '',
       color: '',
     },
+    nodeSizeVariable: '',
     attributeRanges: {},
     nodeColorScale: scaleOrdinal(schemeCategory10),
     linkWidthScale: scaleLinear().range([1, 20]),
@@ -122,6 +123,10 @@ const {
 
     linkVariables(state: State) {
       return state.linkVariables;
+    },
+
+    nodeSizeVariable(state: State) {
+      return state.nodeSizeVariable;
     },
 
     attributeRanges(state: State) {
@@ -286,6 +291,10 @@ const {
 
     setLinkVariables(state, linkVariables: LinkStyleVariables) {
       state.linkVariables = linkVariables;
+    },
+
+    setNodeSizeVariable(state, nodeSizeVariable: string) {
+      state.nodeSizeVariable = nodeSizeVariable;
     },
 
     addAttributeRange(state, attributeRange: { attr: string; min: number; max: number }) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -44,7 +44,6 @@ const {
     markerSize: 50,
     fontSize: 12,
     labelVariable: '_key',
-    colorVariable: '',
     selectNeighbors: true,
     nestedVariables: {
       bar: [],
@@ -55,6 +54,7 @@ const {
       color: '',
     },
     nodeSizeVariable: '',
+    nodeColorVariable: '',
     attributeRanges: {},
     nodeColorScale: scaleOrdinal(schemeCategory10),
     linkWidthScale: scaleLinear().range([1, 20]),
@@ -109,8 +109,8 @@ const {
       return state.labelVariable;
     },
 
-    colorVariable(state: State) {
-      return state.colorVariable;
+    nodeColorVariable(state: State) {
+      return state.nodeColorVariable;
     },
 
     selectNeighbors(state: State) {
@@ -260,8 +260,8 @@ const {
       }
     },
 
-    setColorVariable(state, colorVariable: string) {
-      state.colorVariable = colorVariable;
+    setNodeColorVariable(state, nodeColorVariable: string) {
+      state.nodeColorVariable = nodeColorVariable;
 
       if (state.provenance !== null) {
         updateProvenanceState(state, 'Set Color Variable');
@@ -461,7 +461,7 @@ const {
             'markerSize',
             'fontSize',
             'labelVariable',
-            'colorVariable',
+            'nodeColorVariable',
             'selectNeighbors',
             'directionalEdges',
           ].forEach((primitiveVariable) => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -264,7 +264,7 @@ const {
       state.nodeColorVariable = nodeColorVariable;
 
       if (state.provenance !== null) {
-        updateProvenanceState(state, 'Set Color Variable');
+        updateProvenanceState(state, 'Set Node Color Variable');
       }
     },
 
@@ -295,6 +295,10 @@ const {
 
     setNodeSizeVariable(state, nodeSizeVariable: string) {
       state.nodeSizeVariable = nodeSizeVariable;
+
+      if (state.provenance !== null) {
+        updateProvenanceState(state, 'Set Node Size Variable');
+      }
     },
 
     addAttributeRange(state, attributeRange: { attr: string; min: number; max: number }) {
@@ -461,6 +465,7 @@ const {
             'markerSize',
             'fontSize',
             'labelVariable',
+            'nodeSizeVariable',
             'nodeColorVariable',
             'selectNeighbors',
             'directionalEdges',

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,7 @@ export interface State {
   selectNeighbors: boolean;
   nestedVariables: NestedVariables;
   linkVariables: LinkStyleVariables;
+  nodeSizeVariable: string;
   attributeRanges: AttributeRanges;
   simulation: Simulation<Node, SimulationLink> | null;
   nodeColorScale: ScaleOrdinal<string, string>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,11 +73,11 @@ export interface State {
   markerSize: number;
   fontSize: number;
   labelVariable: string;
-  colorVariable: string;
   selectNeighbors: boolean;
   nestedVariables: NestedVariables;
   linkVariables: LinkStyleVariables;
   nodeSizeVariable: string;
+  nodeColorVariable: string;
   attributeRanges: AttributeRanges;
   simulation: Simulation<Node, SimulationLink> | null;
   nodeColorScale: ScaleOrdinal<string, string>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,7 @@ export type ProvenanceEventTypes =
   'Set Marker Size' |
   'Set Font Size' |
   'Set Label Variable' |
-  'Set Color Variable' |
+  'Set Node Color Variable' |
+  'Set Node Size Variable' |
   'Set Select Neighbors'|
   'Set Directional Edges';


### PR DESCRIPTION
Closes #171

This adds the remaining pieces of UI for adding a `nodeColorVairable` and a `nodeColorVariable` when the displayCharts variable is set to false. It removes the `v-select` from the controls panel in favor of this mechanism of setting the variables.

I also noticed that the legend was plotting far too many bars on each plot (one bar for each node/link), so I cleaned that up by using the `binLabels` as the bound data. That removes the duplicates.

We should open an issue to track potential performance issues from calculating size for each node on every tick of the simulation. We could refactor this code to write the size back to the node once and we'd read it from the node object. That would cut down on computation massively.

Through this work I noticed #176 