### PR TITLE
Refactor the provenance visualization to use a right side nav-draw

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,7 @@ import {
 
 import Controls from './components/Controls.vue';
 import MultiLink from './components/MultiLink/MultiLink.vue';
+import ProvVis from './components/ProvVis.vue';
 
 export default {
   name: 'App',
@@ -14,6 +15,7 @@ export default {
   components: {
     Controls,
     MultiLink,
+    ProvVis,
   },
 
   setup() {
@@ -39,12 +41,16 @@ export default {
       networkName: graph,
     }).then(() => store.dispatch.createProvenance());
 
+    // Provenance vis boolean
+    const showProvenanceVis = computed(() => store.getters.showProvenanceVis);
+
     return {
       network,
       selectedNodes,
       loadError,
       multilinkContainer,
       multilinkContainerDimensions,
+      showProvenanceVis,
     };
   },
 };
@@ -76,6 +82,8 @@ export default {
         </v-row>
       </v-alert>
     </v-main>
+
+    <prov-vis v-if="showProvenanceVis" />
   </v-app>
 </template>
 

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -1,7 +1,6 @@
 <script lang="ts">
 import Vue from 'vue';
 import Legend from '@/components/MultiLink/Legend.vue';
-import ProvVis from '@/components/ProvVis.vue';
 
 import store from '@/store';
 import { Node, Link, Network } from '@/types';
@@ -9,7 +8,6 @@ import { Node, Link, Network } from '@/types';
 export default Vue.extend({
   components: {
     Legend,
-    ProvVis,
   },
 
   data() {
@@ -195,6 +193,10 @@ export default Vue.extend({
 
     clearSelection() {
       store.commit.setSelected(new Set());
+    },
+
+    toggleProvVis() {
+      store.commit.toggleShowProvenanceVis();
     },
   },
 });
@@ -403,26 +405,14 @@ export default Vue.extend({
           </v-list-item>
 
           <v-list-item class="px-0">
-            <v-menu
-              :close-on-content-click="false"
-              :close-on-click="false"
-              :nudge-width="200"
-              offset-x
+            <v-btn
+              color="primary"
+              block
+              depressed
+              @click="toggleProvVis"
             >
-              <template #activator="{ on, attrs }">
-                <v-btn
-                  color="primary"
-                  block
-                  depressed
-                  v-bind="attrs"
-                  v-on="on"
-                >
-                  Provenance Vis
-                </v-btn>
-              </template>
-
-              <prov-vis />
-            </v-menu>
+              Provenance Vis
+            </v-btn>
           </v-list-item>
         </div>
 

--- a/src/components/ProvVis.vue
+++ b/src/components/ProvVis.vue
@@ -26,15 +26,32 @@ export default Vue.extend({
       }
     });
 
-    return { };
+    function toggleProvVis() {
+      store.commit.toggleShowProvenanceVis();
+    }
+
+    return { toggleProvVis };
   },
 });
 </script>
 
 <template>
-  <v-card>
+  <v-navigation-drawer
+    absolute
+    permanent
+    right
+    :width="450"
+  >
+    <v-btn
+      icon
+      class="ma-2"
+      @click="toggleProvVis"
+    >
+      <v-icon>mdi-close</v-icon>
+    </v-btn>
+
     <div id="provDiv" />
-  </v-card>
+  </v-navigation-drawer>
 </template>
 
 <style scoped>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -61,6 +61,7 @@ const {
     directionalEdges: false,
     controlsWidth: 256,
     simulationRunning: false,
+    showProvenanceVis: false,
   } as State,
 
   getters: {
@@ -150,6 +151,10 @@ const {
 
     simulationRunning(state: State) {
       return state.simulationRunning;
+    },
+
+    showProvenanceVis(state: State) {
+      return state.showProvenanceVis;
     },
   },
   mutations: {
@@ -324,6 +329,10 @@ const {
         const { forceType, forceValue } = payload;
         state.simulation.force(forceType, forceValue);
       }
+    },
+
+    toggleShowProvenanceVis(state: State) {
+      state.showProvenanceVis = !state.showProvenanceVis;
     },
   },
   actions: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,7 @@ export interface State {
   directionalEdges: boolean;
   controlsWidth: number;
   simulationRunning: boolean;
+  showProvenanceVis: boolean;
 }
 
 export type ProvenanceEventTypes =


### PR DESCRIPTION
Closes #163

Moves the provenance vis to a right side nav panel that can remain on the vis as the user is interacting with it. We could also reduce the size of the nodelink visualization area to just between the two panels when the provenance vis is rendering, but I'll check in with Alex to see his wishes for that.