### PR TITLE
Refactor the legend UI to show the values for selected variables

### DIFF
--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -33,14 +33,16 @@ export default Vue.extend({
     return {
       svgHeight: 50,
       yAxisPadding: 25, // Gives enough width for hundreds on the y axis
-      stickyBarHeight: 100,
-      stickyBarHorizSpacing: 60,
-      stickyBarWidth: 30,
-      stickyColorMapSquareSize: 15,
-      stickyPadding: 15,
-      stickyPlusBackgroundSize: 30,
-      stickyRowHeight: 50,
-      stickyVarNameIndent: 50,
+      sticky: {
+        barHeight: 100,
+        barHorizSpacing: 60,
+        barWidth: 30,
+        colorMapSquareSize: 15,
+        padding: 15,
+        plusBackgroundSize: 30,
+        rowHeight: 50,
+        varNameIndent: 50,
+      },
       varPadding: 10,
     };
   },
@@ -334,7 +336,7 @@ export default Vue.extend({
 
       const scale = scaleLinear()
         .domain([varMin, varMax])
-        .range([this.stickyBarHeight, 0]);
+        .range([this.sticky.barHeight, 0]);
       const axis = axisRight(scale).ticks(4, 's');
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -366,7 +368,7 @@ export default Vue.extend({
     <!-- Sticky SVG to drag variables onto -->
     <svg
       class="sticky"
-      :height="displayCharts ? 9 * stickyRowHeight : 6 * stickyRowHeight"
+      :height="displayCharts ? 9 * sticky.rowHeight : 6 * sticky.rowHeight"
       width="100%"
     >
       <rect
@@ -382,8 +384,8 @@ export default Vue.extend({
       >
         <text
           font-size="16pt"
-          :y="stickyPadding"
-          :x="stickyPadding"
+          :y="sticky.padding"
+          :x="sticky.padding"
           dominant-baseline="hanging"
           text-anchor="start"
         >Node Mapping</text>
@@ -393,28 +395,28 @@ export default Vue.extend({
         >
           <!-- Bar adding elements -->
           <g
-            :transform="`translate(${stickyPadding}, ${stickyRowHeight})`"
+            :transform="`translate(${sticky.padding}, ${sticky.rowHeight})`"
           >
             <g
               v-for="(barVar, index) of nestedVariables.bar"
               :key="barVar"
             >
               <rect
-                :x="index * stickyBarHorizSpacing"
-                :width="stickyBarWidth"
-                :height="stickyBarHeight"
+                :x="index * sticky.barHorizSpacing"
+                :width="sticky.barWidth"
+                :height="sticky.barHeight"
                 fill="#FFFFFF"
               />
               <rect
-                :x="index * stickyBarHorizSpacing"
+                :x="index * sticky.barHorizSpacing"
                 y="50"
-                :width="stickyBarWidth"
+                :width="sticky.barWidth"
                 height="50"
                 :fill="nodeBarColorScale(barVar)"
               />
               <foreignObject
-                :x="index * stickyBarHorizSpacing"
-                :y="stickyBarHeight"
+                :x="index * sticky.barHorizSpacing"
+                :y="sticky.barHeight"
                 width="50"
                 height="20"
               >
@@ -427,33 +429,33 @@ export default Vue.extend({
               </foreignObject>
               <g
                 :id="`node_${barVar}_scale`"
-                :transform="`translate(${stickyBarWidth + (index * stickyBarHorizSpacing)}, 0)`"
+                :transform="`translate(${sticky.barWidth + (index * sticky.barHorizSpacing)}, 0)`"
               />
             </g>
             <g
               id="barElements"
-              :transform="`translate(${nestedVariables.bar.length * stickyBarHorizSpacing}, 0)`"
+              :transform="`translate(${nestedVariables.bar.length * sticky.barHorizSpacing}, 0)`"
               @dragenter="(e) => e.preventDefault()"
               @dragover="(e) => e.preventDefault()"
               @drop="rectDrop"
             >
               <rect
-                :width="stickyPlusBackgroundSize"
-                :height="stickyBarHeight"
+                :width="sticky.plusBackgroundSize"
+                :height="sticky.barHeight"
                 fill="#FFFFFF"
               />
               <path
                 d="M0,-10 V10 M-10,0 H10"
                 stroke="black"
                 stroke-width="2px"
-                :transform="`translate(${stickyPlusBackgroundSize / 2}, 50)`"
+                :transform="`translate(${sticky.plusBackgroundSize / 2}, 50)`"
               />
             </g>
           </g>
 
           <!-- Glyph adding elements -->
           <g
-            :transform="`translate(${stickyPadding}, 180)`"
+            :transform="`translate(${sticky.padding}, 180)`"
           >
             <text dominant-baseline="hanging">Glyph:</text>
             <g
@@ -461,8 +463,8 @@ export default Vue.extend({
               :key="glyphVar"
             >
               <text
-                :x="stickyVarNameIndent"
-                :y="stickyPadding + outerIndex * (stickyRowHeight + 10)"
+                :x="sticky.varNameIndent"
+                :y="sticky.padding + outerIndex * (sticky.rowHeight + 10)"
               >
                 {{ glyphVar }}
               </text>
@@ -471,16 +473,16 @@ export default Vue.extend({
                 :key="glyphDatum"
               >
                 <rect
-                  :x="stickyVarNameIndent + innerIndex * (stickyColorMapSquareSize + 5)"
-                  :y="(stickyColorMapSquareSize + 5) + outerIndex * (stickyRowHeight + 10)"
-                  :width="stickyColorMapSquareSize"
-                  :height="stickyColorMapSquareSize"
+                  :x="sticky.varNameIndent + innerIndex * (sticky.colorMapSquareSize + 5)"
+                  :y="(sticky.colorMapSquareSize + 5) + outerIndex * (sticky.rowHeight + 10)"
+                  :width="sticky.colorMapSquareSize"
+                  :height="sticky.colorMapSquareSize"
                   :fill="nodeGlyphColorScale(glyphDatum)"
                 />
                 <foreignObject
-                  :x="stickyVarNameIndent + innerIndex * (stickyColorMapSquareSize + 5)"
-                  :y="30 + outerIndex * (stickyRowHeight + 10)"
-                  :width="stickyColorMapSquareSize"
+                  :x="sticky.varNameIndent + innerIndex * (sticky.colorMapSquareSize + 5)"
+                  :y="30 + outerIndex * (sticky.rowHeight + 10)"
+                  :width="sticky.colorMapSquareSize"
                   height="20"
                 >
                   <p
@@ -495,21 +497,21 @@ export default Vue.extend({
             <g
               v-if="nestedVariables.glyph.length !== 2"
               id="glyphElements"
-              :transform="`translate(${stickyVarNameIndent}, ${nestedVariables.glyph.length * (stickyRowHeight + 10)})`"
+              :transform="`translate(${sticky.varNameIndent}, ${nestedVariables.glyph.length * (sticky.rowHeight + 10)})`"
               @dragenter="(e) => e.preventDefault()"
               @dragover="(e) => e.preventDefault()"
               @drop="rectDrop"
             >
               <rect
-                :width="stickyPlusBackgroundSize"
-                :height="stickyPlusBackgroundSize"
+                :width="sticky.plusBackgroundSize"
+                :height="sticky.plusBackgroundSize"
                 fill="#FFFFFF"
               />
               <path
                 d="M0,-10 V10 M-10,0 H10"
                 stroke="black"
                 stroke-width="2px"
-                :transform="`translate(${stickyPlusBackgroundSize / 2}, ${stickyPlusBackgroundSize / 2})`"
+                :transform="`translate(${sticky.plusBackgroundSize / 2}, ${sticky.plusBackgroundSize / 2})`"
               />
             </g>
           </g>
@@ -520,33 +522,33 @@ export default Vue.extend({
         >
           <!-- Node size elements -->
           <g
-            :transform="`translate(${stickyPadding}, ${stickyRowHeight})`"
+            :transform="`translate(${sticky.padding}, ${sticky.rowHeight})`"
           >
             <text dominant-baseline="hanging">Size:</text>
             <g
               v-if="nodeSizeVariable === ''"
               id="nodeSizeElements"
-              :transform="`translate(${stickyVarNameIndent}, 0)`"
+              :transform="`translate(${sticky.varNameIndent}, 0)`"
               @dragenter="(e) => e.preventDefault()"
               @dragover="(e) => e.preventDefault()"
               @drop="rectDrop"
             >
               <rect
-                :width="stickyPlusBackgroundSize"
-                :height="stickyPlusBackgroundSize"
+                :width="sticky.plusBackgroundSize"
+                :height="sticky.plusBackgroundSize"
                 fill="#FFFFFF"
               />
               <path
                 d="M0,-10 V10 M-10,0 H10"
                 stroke="black"
                 stroke-width="2px"
-                :transform="`translate(${stickyPlusBackgroundSize / 2}, ${stickyPlusBackgroundSize / 2})`"
+                :transform="`translate(${sticky.plusBackgroundSize / 2}, ${sticky.plusBackgroundSize / 2})`"
               />
             </g>
 
             <g v-else>
               <text
-                :transform="`translate(${stickyVarNameIndent}, 0)`"
+                :transform="`translate(${sticky.varNameIndent}, 0)`"
                 dominant-baseline="hanging"
               >
                 {{ nodeSizeVariable }}
@@ -556,33 +558,33 @@ export default Vue.extend({
 
           <!-- Node color elements -->
           <g
-            :transform="`translate(${stickyPadding}, ${2 * stickyRowHeight})`"
+            :transform="`translate(${sticky.padding}, ${2 * sticky.rowHeight})`"
           >
             <text dominant-baseline="hanging">Color:</text>
             <g
               v-if="nodeColorVariable === ''"
               id="nodeColorElements"
-              :transform="`translate(${stickyVarNameIndent}, 0)`"
+              :transform="`translate(${sticky.varNameIndent}, 0)`"
               @dragenter="(e) => e.preventDefault()"
               @dragover="(e) => e.preventDefault()"
               @drop="rectDrop"
             >
               <rect
-                :width="stickyPlusBackgroundSize"
-                :height="stickyPlusBackgroundSize"
+                :width="sticky.plusBackgroundSize"
+                :height="sticky.plusBackgroundSize"
                 fill="#FFFFFF"
               />
               <path
                 d="M0,-10 V10 M-10,0 H10"
                 stroke="black"
                 stroke-width="2px"
-                :transform="`translate(${stickyPlusBackgroundSize / 2}, ${stickyPlusBackgroundSize / 2})`"
+                :transform="`translate(${sticky.plusBackgroundSize / 2}, ${sticky.plusBackgroundSize / 2})`"
               />
             </g>
 
             <g v-else>
               <text
-                :transform="`translate(${stickyVarNameIndent}, 0)`"
+                :transform="`translate(${sticky.varNameIndent}, 0)`"
                 dominant-baseline="hanging"
               >
                 {{ nodeColorVariable }}
@@ -592,16 +594,16 @@ export default Vue.extend({
                 :key="glyphDatum"
               >
                 <rect
-                  :x="stickyVarNameIndent + innerIndex * (stickyColorMapSquareSize + 5)"
-                  :y="stickyColorMapSquareSize + 5"
-                  :width="stickyColorMapSquareSize"
-                  :height="stickyColorMapSquareSize"
+                  :x="sticky.varNameIndent + innerIndex * (sticky.colorMapSquareSize + 5)"
+                  :y="sticky.colorMapSquareSize + 5"
+                  :width="sticky.colorMapSquareSize"
+                  :height="sticky.colorMapSquareSize"
                   :fill="nodeGlyphColorScale(glyphDatum)"
                 />
                 <foreignObject
-                  :x="stickyVarNameIndent + innerIndex * (stickyColorMapSquareSize + 5)"
+                  :x="sticky.varNameIndent + innerIndex * (sticky.colorMapSquareSize + 5)"
                   :y="30"
-                  :width="stickyColorMapSquareSize"
+                  :width="sticky.colorMapSquareSize"
                   height="20"
                 >
                   <p
@@ -621,8 +623,8 @@ export default Vue.extend({
       <g
         id="linkMapping"
         :transform="displayCharts ?
-          `translate(${stickyPadding}, ${6 * stickyRowHeight})` :
-          `translate(${stickyPadding}, ${3 * stickyRowHeight})`"
+          `translate(${sticky.padding}, ${6 * sticky.rowHeight})` :
+          `translate(${sticky.padding}, ${3 * sticky.rowHeight})`"
       >
         <text
           font-size="16pt"
@@ -631,32 +633,32 @@ export default Vue.extend({
         >Link Mapping</text>
 
         <!-- Link width elements -->
-        <g :transform="`translate(0, ${stickyVarNameIndent - stickyPadding})`">
+        <g :transform="`translate(0, ${sticky.varNameIndent - sticky.padding})`">
           <text dominant-baseline="hanging">Width:</text>
           <g
             v-if="linkVariables.width === ''"
             id="widthElements"
-            :transform="`translate(${stickyVarNameIndent}, 0)`"
+            :transform="`translate(${sticky.varNameIndent}, 0)`"
             @dragenter="(e) => e.preventDefault()"
             @dragover="(e) => e.preventDefault()"
             @drop="rectDrop"
           >
             <rect
-              :width="stickyPlusBackgroundSize"
-              :height="stickyPlusBackgroundSize"
+              :width="sticky.plusBackgroundSize"
+              :height="sticky.plusBackgroundSize"
               fill="#FFFFFF"
             />
             <path
               d="M0,-10 V10 M-10,0 H10"
               stroke="black"
               stroke-width="2px"
-              :transform="`translate(${stickyPlusBackgroundSize / 2}, ${stickyPlusBackgroundSize / 2})`"
+              :transform="`translate(${sticky.plusBackgroundSize / 2}, ${sticky.plusBackgroundSize / 2})`"
             />
           </g>
 
           <g v-else>
             <text
-              :transform="`translate(${stickyVarNameIndent}, 0)`"
+              :transform="`translate(${sticky.varNameIndent}, 0)`"
               dominant-baseline="hanging"
             >
               {{ linkVariables.width }}
@@ -665,19 +667,19 @@ export default Vue.extend({
         </g>
 
         <!-- Link color elements -->
-        <g :transform="`translate(0, ${2 * stickyVarNameIndent - stickyPadding})`">
+        <g :transform="`translate(0, ${2 * sticky.varNameIndent - sticky.padding})`">
           <text dominant-baseline="hanging">Color:</text>
           <g
             v-if="linkVariables.color === ''"
             id="colorElements"
-            :transform="`translate(${stickyVarNameIndent}, 0)`"
+            :transform="`translate(${sticky.varNameIndent}, 0)`"
             @dragenter="(e) => e.preventDefault()"
             @dragover="(e) => e.preventDefault()"
             @drop="rectDrop"
           >
             <rect
-              :width="stickyPlusBackgroundSize"
-              :height="stickyPlusBackgroundSize"
+              :width="sticky.plusBackgroundSize"
+              :height="sticky.plusBackgroundSize"
               fill="#FFFFFF"
             />
             <path
@@ -690,7 +692,7 @@ export default Vue.extend({
 
           <g v-else>
             <text
-              :transform="`translate(${stickyVarNameIndent}, 0)`"
+              :transform="`translate(${sticky.varNameIndent}, 0)`"
               dominant-baseline="hanging"
             >
               {{ linkVariables.color }}
@@ -700,16 +702,16 @@ export default Vue.extend({
               :key="glyphDatum"
             >
               <rect
-                :x="stickyVarNameIndent + innerIndex * (stickyColorMapSquareSize + 5)"
+                :x="sticky.varNameIndent + innerIndex * (sticky.colorMapSquareSize + 5)"
                 :y="20"
-                :width="stickyColorMapSquareSize"
-                :height="stickyColorMapSquareSize"
+                :width="sticky.colorMapSquareSize"
+                :height="sticky.colorMapSquareSize"
                 :fill="nodeGlyphColorScale(glyphDatum)"
               />
               <foreignObject
-                :x="stickyVarNameIndent + innerIndex * (stickyColorMapSquareSize + 5)"
+                :x="sticky.varNameIndent + innerIndex * (sticky.colorMapSquareSize + 5)"
                 :y="30"
-                :width="stickyColorMapSquareSize"
+                :width="sticky.colorMapSquareSize"
                 height="20"
               >
                 <p

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -358,12 +358,12 @@ export default Vue.extend({
     <!-- Sticky SVG to drag variables onto -->
     <svg
       class="sticky"
-      :height="displayCharts ? 400 : 270"
+      :height="displayCharts ? 420 : 290"
       width="100%"
     >
       <rect
         width="100%"
-        height="400"
+        height="420"
         fill="#DDDDDD"
         opacity="1"
       />

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -375,165 +375,217 @@ export default Vue.extend({
 
       <!-- Node elements when displayCharts === true -->
       <g
-        v-if="displayCharts"
         id="nodeMapping"
       >
         <text
           font-size="16pt"
-          y="-102"
+          y="15"
+          x="15"
           dominant-baseline="hanging"
+          text-anchor="start"
         >Node Mapping</text>
-        <circle
-          r="70"
-          fill="#82B1FF"
-        />
 
-        <!-- Bar adding elements -->
         <g
-          id="barElements"
-          @dragenter="(e) => e.preventDefault()"
-          @dragover="(e) => e.preventDefault()"
-          @drop="rectDrop"
+          v-if="displayCharts"
         >
-          <rect
-            width="10%"
-            height="40%"
-            fill="#EEEEEE"
-          />
-          <text
-            class="barLabel"
-            font-size="10pt"
-            dominant-baseline="hanging"
-          >Bars</text>
-          <path
-            v-if="nestedVariables.bar.length === 0"
-            class="plus"
-            d="M0,-10 V10 M-10,0 H10"
-            stroke="black"
-            stroke-width="3px"
-          />
-          <text
-            v-for="(barVar, i) of nestedVariables.bar"
-            :key="barVar"
-            :transform="`translate(0,${i * 15 + 15})`"
-            dominant-baseline="hanging"
-            style="text-anchor: start;"
-            font-size="9pt"
-          >{{ barVar }}</text>
+          <!-- Bar adding elements -->
+          <g
+            transform="translate(15, 50)"
+          >
+            <g
+              v-for="(barVar, index) of nestedVariables.bar"
+              :key="barVar"
+            >
+              <rect
+                :x="index * 60"
+                width="30"
+                height="100"
+                fill="#FFFFFF"
+              />
+              <rect
+                :x="index * 60"
+                y="50"
+                width="30"
+                height="50"
+                :fill="nodeBarColorScale(barVar)"
+              />
+              <foreignObject
+                :x="index * 60"
+                y="100"
+                width="50"
+                height="20"
+              >
+                <xhtml:p
+                  class="barLabel"
+                  :title="barVar"
+                >
+                  {{ barVar }}
+                </xhtml:p>
+              </foreignObject>
+              <g
+                :id="`node_${barVar}_scale`"
+                :transform="`translate(${30 + (index * 60)}, 0)`"
+              />
+            </g>
+            <g
+              id="barElements"
+              :transform="`translate(${nestedVariables.bar.length * 60}, 0)`"
+              @dragenter="(e) => e.preventDefault()"
+              @dragover="(e) => e.preventDefault()"
+              @drop="rectDrop"
+            >
+              <rect
+                width="30"
+                height="100"
+                fill="#FFFFFF"
+              />
+              <path
+                d="M0,-10 V10 M-10,0 H10"
+                stroke="black"
+                stroke-width="2px"
+                transform="translate(15,50)"
+              />
+            </g>
+          </g>
+
+          <!-- Glyph adding elements -->
+          <g
+            transform="translate(15, 180)"
+          >
+            <text dominant-baseline="hanging">Glyph:</text>
+            <g
+              v-for="(glyphVar, outerIndex) of nestedVariables.glyph"
+              :key="glyphVar"
+            >
+              <text
+                x="50"
+                :y="15 + outerIndex * 60"
+              >
+                {{ glyphVar }}
+              </text>
+              <g
+                v-for="(glyphDatum, innerIndex) of attributeRanges[glyphVar].binLabels"
+                :key="glyphDatum"
+              >
+                <rect
+                  :x="50 + innerIndex * 20"
+                  :y="20 + outerIndex * 60"
+                  width="15"
+                  height="15"
+                  :fill="nodeGlyphColorScale(glyphDatum)"
+                />
+                <foreignObject
+                  :x="50 + innerIndex * 20"
+                  :y="30 + outerIndex * 60"
+                  width="15"
+                  height="20"
+                >
+                  <xhtml:p
+                    class="glyphLabel"
+                    :title="glyphDatum"
+                  >
+                    {{ glyphDatum }}
+                  </xhtml:p>
+                </foreignObject>
+              </g>
+            </g>
+            <g
+              v-if="nestedVariables.glyph.length !== 2"
+              id="glyphElements"
+              :transform="`translate(50, ${nestedVariables.glyph.length * 60})`"
+              @dragenter="(e) => e.preventDefault()"
+              @dragover="(e) => e.preventDefault()"
+              @drop="rectDrop"
+            >
+              <rect
+                width="30"
+                height="30"
+                fill="#FFFFFF"
+              />
+              <path
+                d="M0,-10 V10 M-10,0 H10"
+                stroke="black"
+                stroke-width="2px"
+                transform="translate(15,15)"
+              />
+            </g>
+          </g>
         </g>
 
-        <!-- Glyph adding elements -->
         <g
-          id="glyphElements"
-          @dragenter="(e) => e.preventDefault()"
-          @dragover="(e) => e.preventDefault()"
-          @drop="rectDrop"
+          v-else
         >
-          <rect
-            width="10%"
-            height="40%"
-            fill="#EEEEEE"
-          />
-          <text
-            class="barLabel"
-            font-size="10pt"
-            dominant-baseline="hanging"
-          >Glyphs</text>
-          <path
-            v-if="nestedVariables.glyph.length === 0"
-            class="plus"
-            d="M0,-10 V10 M-10,0 H10"
-            stroke="black"
-            stroke-width="3px"
-          />
-          <text
-            v-for="(glyphVar, i) of nestedVariables.glyph"
-            :key="glyphVar"
-            :transform="`translate(0,${i * 15 + 15})`"
-            dominant-baseline="hanging"
-            style="text-anchor: start;"
-            font-size="9pt"
-          >{{ glyphVar }}</text>
-        </g>
-      </g>
+          <!-- Node size elements -->
+          <g
+            transform="translate(15, 50)"
+          >
+            <text dominant-baseline="hanging">Size:</text>
+            <g
+              v-if="nodeSizeVariable === ''"
+              id="nodeSizeElements"
+              transform="translate(50, 0)"
+              @dragenter="(e) => e.preventDefault()"
+              @dragover="(e) => e.preventDefault()"
+              @drop="rectDrop"
+            >
+              <rect
+                width="30"
+                height="30"
+                fill="#FFFFFF"
+              />
+              <path
+                d="M0,-10 V10 M-10,0 H10"
+                stroke="black"
+                stroke-width="2px"
+                transform="translate(15,15)"
+              />
+            </g>
 
-      <!-- Node elements when displayCharts === false -->
-      <g
-        v-else
-        id="nodeMapping"
-      >
-        <text
-          font-size="16pt"
-          y="-102"
-          dominant-baseline="hanging"
-        >Node Mapping</text>
-        <circle
-          r="70"
-          fill="#82B1FF"
-        />
+            <g v-else>
+              <text
+                transform="translate(50, 0)"
+                dominant-baseline="hanging"
+              >
+                {{ nodeSizeVariable }}
+              </text>
+            </g>
+          </g>
 
-        <!-- Bar adding elements -->
-        <g
-          id="nodeSizeElements"
-          @dragenter="(e) => e.preventDefault()"
-          @dragover="(e) => e.preventDefault()"
-          @drop="rectDrop"
-        >
-          <rect
-            width="10%"
-            height="40%"
-            fill="#EEEEEE"
-          />
-          <text
-            class="nodeSizeLabel"
-            font-size="10pt"
-            dominant-baseline="hanging"
-          >Size</text>
-          <path
-            v-if="nodeSizeVariable === ''"
-            class="plus"
-            d="M0,-10 V10 M-10,0 H10"
-            stroke="black"
-            stroke-width="3px"
-          />
-          <text
-            transform="translate(0,15)"
-            dominant-baseline="hanging"
-            style="text-anchor: start;"
-            font-size="9pt"
-          >{{ nodeSizeVariable }}</text>
-        </g>
+          <!-- Node size elements -->
+          <g
+            transform="translate(15, 100)"
+          >
+            <text dominant-baseline="hanging">Color:</text>
+            <g
+              v-if="nodeColorVariable === ''"
+              id="nodeColorElements"
+              transform="translate(50, 0)"
+              @dragenter="(e) => e.preventDefault()"
+              @dragover="(e) => e.preventDefault()"
+              @drop="rectDrop"
+            >
+              <rect
+                width="30"
+                height="30"
+                fill="#FFFFFF"
+              />
+              <path
+                d="M0,-10 V10 M-10,0 H10"
+                stroke="black"
+                stroke-width="2px"
+                transform="translate(15,15)"
+              />
+            </g>
 
-        <!-- Glyph adding elements -->
-        <g
-          id="nodeColorElements"
-          @dragenter="(e) => e.preventDefault()"
-          @dragover="(e) => e.preventDefault()"
-          @drop="rectDrop"
-        >
-          <rect
-            width="10%"
-            height="40%"
-            fill="#EEEEEE"
-          />
-          <text
-            class="barLabel"
-            font-size="10pt"
-            dominant-baseline="hanging"
-          >Color</text>
-          <path
-            v-if="nodeColorVariable === ''"
-            class="plus"
-            d="M0,-10 V10 M-10,0 H10"
-            stroke="black"
-            stroke-width="3px"
-          />
-          <text
-            transform="translate(0,15)"
-            dominant-baseline="hanging"
-            style="text-anchor: start;"
-            font-size="9pt"
-          >{{ nodeColorVariable }}</text>
+            <g v-else>
+              <text
+                transform="translate(50, 0)"
+                dominant-baseline="hanging"
+              >
+                {{ nodeColorVariable }}
+              </text>
+            </g>
+          </g>
         </g>
       </g>
 

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -7,7 +7,7 @@ import { select } from 'd3-selection';
 import {
   scaleLinear, scaleBand, ScaleBand,
 } from 'd3-scale';
-import { axisBottom, axisLeft } from 'd3-axis';
+import { axisBottom, axisLeft, axisRight } from 'd3-axis';
 import { TableMetadata } from 'multinet';
 
 import { Node, Link, Network } from '@/types';
@@ -297,6 +297,9 @@ export default Vue.extend({
           glyph: this.nestedVariables.glyph,
         };
         store.commit.setNestedVariables(updatedNestedVars);
+
+        // Render the scales
+        Vue.nextTick(() => this.renderScales(droppedElText));
       } else if (type === 'node' && targetEl === 'glyphElements') {
         const updatedNestedVars = {
           bar: this.nestedVariables.bar,
@@ -320,6 +323,19 @@ export default Vue.extend({
         };
         store.commit.setLinkVariables(updatedLinkVars);
       }
+    },
+
+    renderScales(barVar: string) {
+      const varMin = this.attributeRanges[barVar].min;
+      const varMax = this.attributeRanges[barVar].max;
+
+      const scale = scaleLinear()
+        .domain([varMin, varMax])
+        .range([100, 0]);
+      const axis = axisRight(scale);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      select(`#node_${barVar}_scale`).call((axis as any));
     },
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -584,6 +584,31 @@ export default Vue.extend({
               >
                 {{ nodeColorVariable }}
               </text>
+              <g
+                v-for="(glyphDatum, innerIndex) of attributeRanges[nodeColorVariable].binLabels"
+                :key="glyphDatum"
+              >
+                <rect
+                  :x="50 + innerIndex * 20"
+                  :y="20"
+                  width="15"
+                  height="15"
+                  :fill="nodeGlyphColorScale(glyphDatum)"
+                />
+                <foreignObject
+                  :x="50 + innerIndex * 20"
+                  :y="30"
+                  width="15"
+                  height="20"
+                >
+                  <xhtml:p
+                    class="glyphLabel"
+                    :title="glyphDatum"
+                  >
+                    {{ glyphDatum }}
+                  </xhtml:p>
+                </foreignObject>
+              </g>
             </g>
           </g>
         </g>
@@ -665,6 +690,31 @@ export default Vue.extend({
             >
               {{ linkVariables.color }}
             </text>
+            <g
+              v-for="(glyphDatum, innerIndex) of attributeRanges[linkVariables.color].binLabels"
+              :key="glyphDatum"
+            >
+              <rect
+                :x="50 + innerIndex * 20"
+                :y="20"
+                width="15"
+                height="15"
+                :fill="nodeGlyphColorScale(glyphDatum)"
+              />
+              <foreignObject
+                :x="50 + innerIndex * 20"
+                :y="30"
+                width="15"
+                height="20"
+              >
+                <xhtml:p
+                  class="glyphLabel"
+                  :title="glyphDatum"
+                >
+                  {{ glyphDatum }}
+                </xhtml:p>
+              </foreignObject>
+            </g>
           </g>
         </g>
       </g>

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -410,12 +410,12 @@ export default Vue.extend({
                 width="50"
                 height="20"
               >
-                <xhtml:p
+                <p
                   class="barLabel"
                   :title="barVar"
                 >
                   {{ barVar }}
-                </xhtml:p>
+                </p>
               </foreignObject>
               <g
                 :id="`node_${barVar}_scale`"
@@ -475,12 +475,12 @@ export default Vue.extend({
                   width="15"
                   height="20"
                 >
-                  <xhtml:p
+                  <p
                     class="glyphLabel"
                     :title="glyphDatum"
                   >
                     {{ glyphDatum }}
-                  </xhtml:p>
+                  </p>
                 </foreignObject>
               </g>
             </g>
@@ -596,12 +596,12 @@ export default Vue.extend({
                   width="15"
                   height="20"
                 >
-                  <xhtml:p
+                  <p
                     class="glyphLabel"
                     :title="glyphDatum"
                   >
                     {{ glyphDatum }}
-                  </xhtml:p>
+                  </p>
                 </foreignObject>
               </g>
             </g>
@@ -702,12 +702,12 @@ export default Vue.extend({
                 width="15"
                 height="20"
               >
-                <xhtml:p
+                <p
                   class="glyphLabel"
                   :title="glyphDatum"
                 >
                   {{ glyphDatum }}
-                </xhtml:p>
+                </p>
               </foreignObject>
             </g>
           </g>

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -67,8 +67,12 @@ export default Vue.extend({
       return store.getters.nodeColorVariable;
     },
 
-    nodeColorScale() {
-      return store.getters.nodeColorScale;
+    nodeBarColorScale() {
+      return store.getters.nodeBarColorScale;
+    },
+
+    nodeGlyphColorScale() {
+      return store.getters.nodeGlyphColorScale;
     },
 
     columnTypes() {
@@ -227,7 +231,7 @@ export default Vue.extend({
               .attr('y', (d: string) => yScale(bins.get(d) || 0))
               .attr('height', (d: string) => this.svgHeight - yScale(bins.get(d) || 0))
               .attr('width', xScale.bandwidth())
-              .attr('fill', (d: string) => this.nodeColorScale(d));
+              .attr('fill', (d: string) => this.nodeGlyphColorScale(d));
 
             // Add the axis scales onto the chart
             variableSvg

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -153,16 +153,13 @@ export default Vue.extend({
 
             const bins = binGenerator(currentData);
 
-            if (type === 'node') {
-              console.log(xScale);
-              store.commit.addAttributeRange({
-                attr,
-                min: xScale.domain()[0] || 0,
-                max: xScale.domain()[1] || 0,
-                binLabels: xScale.domain().map((label) => label.toString()),
-                binValues: xScale.range(),
-              });
-            }
+            store.commit.addAttributeRange({
+              attr,
+              min: xScale.domain()[0] || 0,
+              max: xScale.domain()[1] || 0,
+              binLabels: xScale.domain().map((label) => label.toString()),
+              binValues: xScale.range(),
+            });
 
             const yScale = scaleLinear()
               .domain([0, max(bins, (d) => d.length) || 0])
@@ -203,15 +200,13 @@ export default Vue.extend({
             const binLabels: string[] = Array.from(bins.keys());
             const binValues: number[] = Array.from(bins.values());
 
-            if (type === 'node') {
-              store.commit.addAttributeRange({
-                attr,
-                min: parseFloat(min(binLabels) || '0'),
-                max: parseFloat(max(binLabels) || '0'),
-                binLabels,
-                binValues,
-              });
-            }
+            store.commit.addAttributeRange({
+              attr,
+              min: parseFloat(min(binLabels) || '0'),
+              max: parseFloat(max(binLabels) || '0'),
+              binLabels,
+              binValues,
+            });
 
             // Generate axis scales
             const yScale = scaleLinear()

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -347,12 +347,12 @@ export default Vue.extend({
     <!-- Sticky SVG to drag variables onto -->
     <svg
       class="sticky"
-      height="33%"
+      :height="displayCharts ? 400 : 270"
       width="100%"
     >
       <rect
         width="100%"
-        height="100%"
+        height="400"
         fill="#DDDDDD"
         opacity="1"
       />

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -96,6 +96,10 @@ export default Vue.extend({
     displayCharts() {
       return store.getters.displayCharts;
     },
+
+    attributeRanges() {
+      return store.getters.attributeRanges;
+    },
   },
 
   mounted() {
@@ -146,7 +150,14 @@ export default Vue.extend({
             const bins = binGenerator(currentData);
 
             if (type === 'node') {
-              store.commit.addAttributeRange({ attr, min: parseFloat(min(currentData) || '0'), max: parseFloat(max(currentData) || '0') });
+              console.log(xScale);
+              store.commit.addAttributeRange({
+                attr,
+                min: xScale.domain()[0] || 0,
+                max: xScale.domain()[1] || 0,
+                binLabels: xScale.domain().map((label) => label.toString()),
+                binValues: xScale.range(),
+              });
             }
 
             const yScale = scaleLinear()
@@ -187,6 +198,16 @@ export default Vue.extend({
 
             const binLabels: string[] = Array.from(bins.keys());
             const binValues: number[] = Array.from(bins.values());
+
+            if (type === 'node') {
+              store.commit.addAttributeRange({
+                attr,
+                min: parseFloat(min(binLabels) || '0'),
+                max: parseFloat(max(binLabels) || '0'),
+                binLabels,
+                binValues,
+              });
+            }
 
             // Generate axis scales
             const yScale = scaleLinear()

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -339,8 +339,7 @@ export default Vue.extend({
         .range([this.sticky.barHeight, 0]);
       const axis = axisRight(scale).ticks(4, 's');
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      select(`#node_${barVar}_scale`).call((axis as any));
+      select(`#node_${barVar}_scale`).append('g').call(axis);
     },
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -726,41 +726,18 @@ export default Vue.extend({
 </template>
 
 <style scoped>
-.v-card {
-    height: calc(66vh - 24px);
-    overflow-y: scroll
-}
-svg >>> .selected{
-  stroke: "#000000";
-}
 .sticky {
-   position: sticky;
-   top: 0;
-   z-index: 2;
-}
-.sticky >>> text {
-  text-anchor: middle;
-}
-.barLabel, .nodeSizeLabel {
-  transform: translate(5%, 0);
-}
-#nodeMapping {
-  transform: translate(20%, 50%);
-}
-#linkMapping {
-  transform: translate(80%, 50%);
-}
-#barElements, #widthElements, #nodeSizeElements {
-  transform: translate(-12%, -20%);
-}
-#glyphElements, #colorElements, #nodeColorElements {
-  transform: translate(2%, -20%);
-}
-.plus {
-  transform: translate(5%, 20%);
-  width: 5%;
+  position: sticky;
+  top: 0;
+  z-index: 2;
 }
 .draggable {
   cursor: pointer;
+}
+.barLabel, .glyphLabel{
+  display: block;
+  max-width: 50px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 </style>

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -538,82 +538,82 @@ export default Vue.extend({
       </g>
 
       <!-- Link elements -->
-      <g id="linkMapping">
+      <g
+        id="linkMapping"
+        :transform="displayCharts ? `translate(15, 280)` : `translate(15, 150)`"
+      >
         <text
           font-size="16pt"
-          y="-102"
           dominant-baseline="hanging"
+          text-anchor="start"
         >Link Mapping</text>
-        <rect
-          x="-70"
-          y="-70"
-          width="140"
-          height="140"
-          fill="#82B1FF"
-        />
 
-        <!-- Width adding elements -->
-        <g
-          id="widthElements"
-          @dragenter="(e) => e.preventDefault()"
-          @dragover="(e) => e.preventDefault()"
-          @drop="rectDrop"
-        >
-          <rect
-            width="10%"
-            height="40%"
-            fill="#EEEEEE"
-          />
-          <text
-            class="barLabel"
-            font-size="10pt"
-            dominant-baseline="hanging"
-          >Width</text>
-          <path
-            v-if="!linkVariables.width"
-            class="plus"
-            d="M0,-10 V10 M-10,0 H10"
-            stroke="black"
-            stroke-width="3px"
-          />
-          <text
-            transform="translate(0,15)"
-            dominant-baseline="hanging"
-            style="text-anchor: start;"
-            font-size="9pt"
-          >{{ linkVariables.width }}</text>
+        <!-- Link width elements -->
+        <g transform="translate(0, 30)">
+          <text dominant-baseline="hanging">Width:</text>
+          <g
+            v-if="linkVariables.width === ''"
+            id="widthElements"
+            transform="translate(50, 0)"
+            @dragenter="(e) => e.preventDefault()"
+            @dragover="(e) => e.preventDefault()"
+            @drop="rectDrop"
+          >
+            <rect
+              width="30"
+              height="30"
+              fill="#FFFFFF"
+            />
+            <path
+              d="M0,-10 V10 M-10,0 H10"
+              stroke="black"
+              stroke-width="2px"
+              transform="translate(15,15)"
+            />
+          </g>
+
+          <g v-else>
+            <text
+              transform="translate(50, 0)"
+              dominant-baseline="hanging"
+            >
+              {{ linkVariables.width }}
+            </text>
+          </g>
         </g>
 
-        <!-- Color adding elements -->
-        <g
-          id="colorElements"
-          @dragenter="(e) => e.preventDefault()"
-          @dragover="(e) => e.preventDefault()"
-          @drop="rectDrop"
-        >
-          <rect
-            width="10%"
-            height="40%"
-            fill="#EEEEEE"
-          />
-          <text
-            class="barLabel"
-            font-size="10pt"
-            dominant-baseline="hanging"
-          >Color</text>
-          <path
-            v-if="!linkVariables.color"
-            class="plus"
-            d="M0,-10 V10 M-10,0 H10"
-            stroke="black"
-            stroke-width="3px"
-          />
-          <text
-            transform="translate(0,15)"
-            dominant-baseline="hanging"
-            style="text-anchor: start;"
-            font-size="9pt"
-          >{{ linkVariables.color }}</text>
+        <!-- Link color elements -->
+        <g transform="translate(0, 80)">
+          <text dominant-baseline="hanging">Color:</text>
+          <g
+            v-if="linkVariables.color === ''"
+            id="colorElements"
+            transform="translate(50, 0)"
+            @dragenter="(e) => e.preventDefault()"
+            @dragover="(e) => e.preventDefault()"
+            @drop="rectDrop"
+          >
+            <rect
+              width="30"
+              height="30"
+              fill="#FFFFFF"
+            />
+            <path
+              d="M0,-10 V10 M-10,0 H10"
+              stroke="black"
+              stroke-width="2px"
+              transform="translate(15,15)"
+            />
+          </g>
+
+          <g v-else>
+            <text
+              transform="translate(50, 0)"
+              dominant-baseline="hanging"
+            >
+              {{ linkVariables.color }}
+            </text>
+          </g>
         </g>
       </g>
     </svg>

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -33,6 +33,14 @@ export default Vue.extend({
     return {
       svgHeight: 50,
       yAxisPadding: 25, // Gives enough width for hundreds on the y axis
+      stickyBarHeight: 100,
+      stickyBarHorizSpacing: 60,
+      stickyBarWidth: 30,
+      stickyColorMapSquareSize: 15,
+      stickyPadding: 15,
+      stickyPlusBackgroundSize: 30,
+      stickyRowHeight: 50,
+      stickyVarNameIndent: 50,
       varPadding: 10,
     };
   },
@@ -326,7 +334,7 @@ export default Vue.extend({
 
       const scale = scaleLinear()
         .domain([varMin, varMax])
-        .range([100, 0]);
+        .range([this.stickyBarHeight, 0]);
       const axis = axisRight(scale);
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -358,12 +366,12 @@ export default Vue.extend({
     <!-- Sticky SVG to drag variables onto -->
     <svg
       class="sticky"
-      :height="displayCharts ? 420 : 290"
+      :height="displayCharts ? 9 * stickyRowHeight : 6 * stickyRowHeight"
       width="100%"
     >
       <rect
         width="100%"
-        height="420"
+        height="440"
         fill="#DDDDDD"
         opacity="1"
       />
@@ -374,8 +382,8 @@ export default Vue.extend({
       >
         <text
           font-size="16pt"
-          y="15"
-          x="15"
+          :y="stickyPadding"
+          :x="stickyPadding"
           dominant-baseline="hanging"
           text-anchor="start"
         >Node Mapping</text>
@@ -385,28 +393,28 @@ export default Vue.extend({
         >
           <!-- Bar adding elements -->
           <g
-            transform="translate(15, 50)"
+            :transform="`translate(${stickyPadding}, ${stickyRowHeight})`"
           >
             <g
               v-for="(barVar, index) of nestedVariables.bar"
               :key="barVar"
             >
               <rect
-                :x="index * 60"
-                width="30"
-                height="100"
+                :x="index * stickyBarHorizSpacing"
+                :width="stickyBarWidth"
+                :height="stickyBarHeight"
                 fill="#FFFFFF"
               />
               <rect
-                :x="index * 60"
+                :x="index * stickyBarHorizSpacing"
                 y="50"
-                width="30"
+                :width="stickyBarWidth"
                 height="50"
                 :fill="nodeBarColorScale(barVar)"
               />
               <foreignObject
-                :x="index * 60"
-                y="100"
+                :x="index * stickyBarHorizSpacing"
+                :y="stickyBarHeight"
                 width="50"
                 height="20"
               >
@@ -419,33 +427,33 @@ export default Vue.extend({
               </foreignObject>
               <g
                 :id="`node_${barVar}_scale`"
-                :transform="`translate(${30 + (index * 60)}, 0)`"
+                :transform="`translate(${stickyBarWidth + (index * stickyBarHorizSpacing)}, 0)`"
               />
             </g>
             <g
               id="barElements"
-              :transform="`translate(${nestedVariables.bar.length * 60}, 0)`"
+              :transform="`translate(${nestedVariables.bar.length * stickyBarHorizSpacing}, 0)`"
               @dragenter="(e) => e.preventDefault()"
               @dragover="(e) => e.preventDefault()"
               @drop="rectDrop"
             >
               <rect
-                width="30"
-                height="100"
+                :width="stickyPlusBackgroundSize"
+                :height="stickyBarHeight"
                 fill="#FFFFFF"
               />
               <path
                 d="M0,-10 V10 M-10,0 H10"
                 stroke="black"
                 stroke-width="2px"
-                transform="translate(15,50)"
+                :transform="`translate(${stickyPlusBackgroundSize / 2}, 50)`"
               />
             </g>
           </g>
 
           <!-- Glyph adding elements -->
           <g
-            transform="translate(15, 180)"
+            :transform="`translate(${stickyPadding}, 180)`"
           >
             <text dominant-baseline="hanging">Glyph:</text>
             <g
@@ -453,8 +461,8 @@ export default Vue.extend({
               :key="glyphVar"
             >
               <text
-                x="50"
-                :y="15 + outerIndex * 60"
+                :x="stickyVarNameIndent"
+                :y="stickyPadding + outerIndex * (stickyRowHeight + 10)"
               >
                 {{ glyphVar }}
               </text>
@@ -463,16 +471,16 @@ export default Vue.extend({
                 :key="glyphDatum"
               >
                 <rect
-                  :x="50 + innerIndex * 20"
-                  :y="20 + outerIndex * 60"
-                  width="15"
-                  height="15"
+                  :x="stickyVarNameIndent + innerIndex * (stickyColorMapSquareSize + 5)"
+                  :y="(stickyColorMapSquareSize + 5) + outerIndex * (stickyRowHeight + 10)"
+                  :width="stickyColorMapSquareSize"
+                  :height="stickyColorMapSquareSize"
                   :fill="nodeGlyphColorScale(glyphDatum)"
                 />
                 <foreignObject
-                  :x="50 + innerIndex * 20"
-                  :y="30 + outerIndex * 60"
-                  width="15"
+                  :x="stickyVarNameIndent + innerIndex * (stickyColorMapSquareSize + 5)"
+                  :y="30 + outerIndex * (stickyRowHeight + 10)"
+                  :width="stickyColorMapSquareSize"
                   height="20"
                 >
                   <p
@@ -487,21 +495,21 @@ export default Vue.extend({
             <g
               v-if="nestedVariables.glyph.length !== 2"
               id="glyphElements"
-              :transform="`translate(50, ${nestedVariables.glyph.length * 60})`"
+              :transform="`translate(${stickyVarNameIndent}, ${nestedVariables.glyph.length * (stickyRowHeight + 10)})`"
               @dragenter="(e) => e.preventDefault()"
               @dragover="(e) => e.preventDefault()"
               @drop="rectDrop"
             >
               <rect
-                width="30"
-                height="30"
+                :width="stickyPlusBackgroundSize"
+                :height="stickyPlusBackgroundSize"
                 fill="#FFFFFF"
               />
               <path
                 d="M0,-10 V10 M-10,0 H10"
                 stroke="black"
                 stroke-width="2px"
-                transform="translate(15,15)"
+                :transform="`translate(${stickyPlusBackgroundSize / 2}, ${stickyPlusBackgroundSize / 2})`"
               />
             </g>
           </g>
@@ -512,33 +520,33 @@ export default Vue.extend({
         >
           <!-- Node size elements -->
           <g
-            transform="translate(15, 50)"
+            :transform="`translate(${stickyPadding}, ${stickyRowHeight})`"
           >
             <text dominant-baseline="hanging">Size:</text>
             <g
               v-if="nodeSizeVariable === ''"
               id="nodeSizeElements"
-              transform="translate(50, 0)"
+              :transform="`translate(${stickyVarNameIndent}, 0)`"
               @dragenter="(e) => e.preventDefault()"
               @dragover="(e) => e.preventDefault()"
               @drop="rectDrop"
             >
               <rect
-                width="30"
-                height="30"
+                :width="stickyPlusBackgroundSize"
+                :height="stickyPlusBackgroundSize"
                 fill="#FFFFFF"
               />
               <path
                 d="M0,-10 V10 M-10,0 H10"
                 stroke="black"
                 stroke-width="2px"
-                transform="translate(15,15)"
+                :transform="`translate(${stickyPlusBackgroundSize / 2}, ${stickyPlusBackgroundSize / 2})`"
               />
             </g>
 
             <g v-else>
               <text
-                transform="translate(50, 0)"
+                :transform="`translate(${stickyVarNameIndent}, 0)`"
                 dominant-baseline="hanging"
               >
                 {{ nodeSizeVariable }}
@@ -548,33 +556,33 @@ export default Vue.extend({
 
           <!-- Node color elements -->
           <g
-            transform="translate(15, 100)"
+            :transform="`translate(${stickyPadding}, ${2 * stickyRowHeight})`"
           >
             <text dominant-baseline="hanging">Color:</text>
             <g
               v-if="nodeColorVariable === ''"
               id="nodeColorElements"
-              transform="translate(50, 0)"
+              :transform="`translate(${stickyVarNameIndent}, 0)`"
               @dragenter="(e) => e.preventDefault()"
               @dragover="(e) => e.preventDefault()"
               @drop="rectDrop"
             >
               <rect
-                width="30"
-                height="30"
+                :width="stickyPlusBackgroundSize"
+                :height="stickyPlusBackgroundSize"
                 fill="#FFFFFF"
               />
               <path
                 d="M0,-10 V10 M-10,0 H10"
                 stroke="black"
                 stroke-width="2px"
-                transform="translate(15,15)"
+                :transform="`translate(${stickyPlusBackgroundSize / 2}, ${stickyPlusBackgroundSize / 2})`"
               />
             </g>
 
             <g v-else>
               <text
-                transform="translate(50, 0)"
+                :transform="`translate(${stickyVarNameIndent}, 0)`"
                 dominant-baseline="hanging"
               >
                 {{ nodeColorVariable }}
@@ -584,16 +592,16 @@ export default Vue.extend({
                 :key="glyphDatum"
               >
                 <rect
-                  :x="50 + innerIndex * 20"
-                  :y="20"
-                  width="15"
-                  height="15"
+                  :x="stickyVarNameIndent + innerIndex * (stickyColorMapSquareSize + 5)"
+                  :y="stickyColorMapSquareSize + 5"
+                  :width="stickyColorMapSquareSize"
+                  :height="stickyColorMapSquareSize"
                   :fill="nodeGlyphColorScale(glyphDatum)"
                 />
                 <foreignObject
-                  :x="50 + innerIndex * 20"
+                  :x="stickyVarNameIndent + innerIndex * (stickyColorMapSquareSize + 5)"
                   :y="30"
-                  width="15"
+                  :width="stickyColorMapSquareSize"
                   height="20"
                 >
                   <p
@@ -612,7 +620,9 @@ export default Vue.extend({
       <!-- Link elements -->
       <g
         id="linkMapping"
-        :transform="displayCharts ? `translate(15, 280)` : `translate(15, 150)`"
+        :transform="displayCharts ?
+          `translate(${stickyPadding}, ${6 * stickyRowHeight})` :
+          `translate(${stickyPadding}, ${3 * stickyRowHeight})`"
       >
         <text
           font-size="16pt"
@@ -621,32 +631,32 @@ export default Vue.extend({
         >Link Mapping</text>
 
         <!-- Link width elements -->
-        <g transform="translate(0, 30)">
+        <g :transform="`translate(0, ${stickyVarNameIndent - stickyPadding})`">
           <text dominant-baseline="hanging">Width:</text>
           <g
             v-if="linkVariables.width === ''"
             id="widthElements"
-            transform="translate(50, 0)"
+            :transform="`translate(${stickyVarNameIndent}, 0)`"
             @dragenter="(e) => e.preventDefault()"
             @dragover="(e) => e.preventDefault()"
             @drop="rectDrop"
           >
             <rect
-              width="30"
-              height="30"
+              :width="stickyPlusBackgroundSize"
+              :height="stickyPlusBackgroundSize"
               fill="#FFFFFF"
             />
             <path
               d="M0,-10 V10 M-10,0 H10"
               stroke="black"
               stroke-width="2px"
-              transform="translate(15,15)"
+              :transform="`translate(${stickyPlusBackgroundSize / 2}, ${stickyPlusBackgroundSize / 2})`"
             />
           </g>
 
           <g v-else>
             <text
-              transform="translate(50, 0)"
+              :transform="`translate(${stickyVarNameIndent}, 0)`"
               dominant-baseline="hanging"
             >
               {{ linkVariables.width }}
@@ -655,19 +665,19 @@ export default Vue.extend({
         </g>
 
         <!-- Link color elements -->
-        <g transform="translate(0, 80)">
+        <g :transform="`translate(0, ${2 * stickyVarNameIndent - stickyPadding})`">
           <text dominant-baseline="hanging">Color:</text>
           <g
             v-if="linkVariables.color === ''"
             id="colorElements"
-            transform="translate(50, 0)"
+            :transform="`translate(${stickyVarNameIndent}, 0)`"
             @dragenter="(e) => e.preventDefault()"
             @dragover="(e) => e.preventDefault()"
             @drop="rectDrop"
           >
             <rect
-              width="30"
-              height="30"
+              :width="stickyPlusBackgroundSize"
+              :height="stickyPlusBackgroundSize"
               fill="#FFFFFF"
             />
             <path
@@ -680,7 +690,7 @@ export default Vue.extend({
 
           <g v-else>
             <text
-              transform="translate(50, 0)"
+              :transform="`translate(${stickyVarNameIndent}, 0)`"
               dominant-baseline="hanging"
             >
               {{ linkVariables.color }}
@@ -690,16 +700,16 @@ export default Vue.extend({
               :key="glyphDatum"
             >
               <rect
-                :x="50 + innerIndex * 20"
+                :x="stickyVarNameIndent + innerIndex * (stickyColorMapSquareSize + 5)"
                 :y="20"
-                width="15"
-                height="15"
+                :width="stickyColorMapSquareSize"
+                :height="stickyColorMapSquareSize"
                 :fill="nodeGlyphColorScale(glyphDatum)"
               />
               <foreignObject
-                :x="50 + innerIndex * 20"
+                :x="stickyVarNameIndent + innerIndex * (stickyColorMapSquareSize + 5)"
                 :y="30"
-                width="15"
+                :width="stickyColorMapSquareSize"
                 height="20"
               >
                 <p

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -551,7 +551,7 @@ export default Vue.extend({
             </g>
           </g>
 
-          <!-- Node size elements -->
+          <!-- Node color elements -->
           <g
             transform="translate(15, 100)"
           >

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -335,7 +335,7 @@ export default Vue.extend({
       const scale = scaleLinear()
         .domain([varMin, varMax])
         .range([this.stickyBarHeight, 0]);
-      const axis = axisRight(scale);
+      const axis = axisRight(scale).ticks(4, 's');
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       select(`#node_${barVar}_scale`).call((axis as any));

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -476,7 +476,7 @@ export default Vue.extend({
               class="bar"
               :width="nestedBarWidth"
               :height="nestedBarHeight"
-              style="fill: white;"
+              fill="#FFFFFF"
               :x="((nestedBarWidth + nestedPadding) * i) + nestedPadding"
               y="20"
             />

--- a/src/components/MultiLink/MultiLink.vue
+++ b/src/components/MultiLink/MultiLink.vue
@@ -63,8 +63,12 @@ export default Vue.extend({
       return new Set();
     },
 
-    nodeColorScale() {
-      return store.getters.nodeColorScale;
+    nodeBarColorScale() {
+      return store.getters.nodeBarColorScale;
+    },
+
+    nodeGlyphColorScale() {
+      return store.getters.nodeGlyphColorScale;
     },
 
     tooltipStyle(): string {
@@ -367,14 +371,14 @@ export default Vue.extend({
     },
 
     linkStyle(link: Link): string {
-      const linkColor = this.linkVariables.color === '' ? '#888888' : this.nodeColorScale(link[this.linkVariables.color]);
+      const linkColor = this.linkVariables.color === '' ? '#888888' : this.nodeGlyphColorScale(link[this.linkVariables.color]);
       const linkWidth = this.linkVariables.width === '' ? 1 : this.linkWidthScale(link[this.linkVariables.width]);
 
       return `stroke: ${linkColor}; stroke-width: ${linkWidth}px;`;
     },
 
     glyphStyle(value: string) {
-      return `fill: ${this.nodeColorScale(value)};`;
+      return `fill: ${this.nodeGlyphColorScale(value)};`;
     },
 
     calculateNodeSize(node: Node) {
@@ -439,7 +443,7 @@ export default Vue.extend({
             :class="nodeClass(node)"
             :width="calculateNodeSize(node)"
             :height="calculateNodeSize(node)"
-            :fill="!displayCharts ? nodeColorScale(node[nodeColorVariable]) : '1f77b4'"
+            :fill="!displayCharts ? nodeGlyphColorScale(node[nodeColorVariable]) : '#DDDDDD'"
             :rx="!displayCharts ? (calculateNodeSize(node) / 2) : 0"
             :ry="!displayCharts ? (calculateNodeSize(node) / 2) : 0"
             @click="selectNode(node)"
@@ -484,7 +488,7 @@ export default Vue.extend({
               class="bar"
               :width="nestedBarWidth"
               :height="attributeScales[barVar](node[barVar])"
-              style="fill: blue;"
+              :fill="nodeBarColorScale(barVar)"
               :x="((nestedBarWidth + nestedPadding) * i) + nestedPadding"
               :y="20 + nestedBarHeight - attributeScales[barVar](node[barVar])"
             />

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -306,7 +306,7 @@ const {
       }
     },
 
-    addAttributeRange(state, attributeRange: { attr: string; min: number; max: number }) {
+    addAttributeRange(state, attributeRange: { attr: string; min: number; max: number; binLabels: string[]; binValues: number[] }) {
       state.attributeRanges = { ...state.attributeRanges, [attributeRange.attr]: attributeRange };
     },
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -56,7 +56,8 @@ const {
     nodeSizeVariable: '',
     nodeColorVariable: '',
     attributeRanges: {},
-    nodeColorScale: scaleOrdinal(schemeCategory10),
+    nodeBarColorScale: scaleOrdinal(schemeCategory10),
+    nodeGlyphColorScale: scaleOrdinal(schemeCategory10),
     linkWidthScale: scaleLinear().range([1, 20]),
     provenance: null,
     directionalEdges: false,
@@ -134,8 +135,12 @@ const {
       return state.attributeRanges;
     },
 
-    nodeColorScale(state: State) {
-      return state.nodeColorScale;
+    nodeBarColorScale(state: State) {
+      return state.nodeBarColorScale;
+    },
+
+    nodeGlyphColorScale(state: State) {
+      return state.nodeBarColorScale;
     },
 
     linkWidthScale(state: State) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,7 +80,8 @@ export interface State {
   nodeColorVariable: string;
   attributeRanges: AttributeRanges;
   simulation: Simulation<Node, SimulationLink> | null;
-  nodeColorScale: ScaleOrdinal<string, string>;
+  nodeBarColorScale: ScaleOrdinal<string, string>;
+  nodeGlyphColorScale: ScaleOrdinal<string, string>;
   linkWidthScale: ScaleLinear<number, number>;
   provenance: Provenance<State, ProvenanceEventTypes, unknown> | null;
   directionalEdges: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,7 @@ export interface LinkStyleVariables {
 }
 
 export interface AttributeRanges {
-  [key: string]: {attr: string; min: number; max: number};
+  [key: string]: {attr: string; min: number; max: number; binLabels: string[]; binValues: number[]};
 }
 
 export interface NetworkMetadata { [tableName: string]: TableMetadata }


### PR DESCRIPTION
Depends on #177

Closes #142

This refactors the UI for the legend drag targets and changes how the information is displayed. For visualized vars, show the categories/colors for each (including the mapping of colors to bars and glyphs).

Here's the current state:
Mapping node size and color:
![image](https://user-images.githubusercontent.com/36867477/107077554-44204980-67aa-11eb-9996-fb75bfe9841a.png)

Mapping to bars:
![image](https://user-images.githubusercontent.com/36867477/107078160-27d0dc80-67ab-11eb-87c8-63768127fe4a.png)

Mapping to bars and glyphs:
![image](https://user-images.githubusercontent.com/36867477/107078211-38815280-67ab-11eb-91d0-d9568b52d9e0.png)


Mapping to link width (looks like the width scale needs some attention):
![image](https://user-images.githubusercontent.com/36867477/107077823-a4af8680-67aa-11eb-8be5-6f158a17429d.png)

Link color also works, I just don't have a good example dataset for it.

The idea is to replicate some of the functionality from a past project. Here are some screen shots (note these are from a study to determine which visual elements were better so they vary and are inconsistent):

![image](https://user-images.githubusercontent.com/36867477/106938364-24225480-66dc-11eb-8cd1-94bd7fe2c82d.png)

![image](https://user-images.githubusercontent.com/36867477/106938416-32707080-66dc-11eb-9553-0dd73ab3f8f9.png)

![image](https://user-images.githubusercontent.com/36867477/106938492-4a47f480-66dc-11eb-90a0-b2829f6e7d97.png)


TODO:
- [x] Show color mapping for link variable
- [x] For link width show size mapping (#181)
- [x] Show color mapping for node color variable
- [x] For node size show size mapping (#180)
- [x] Refactor magic numbers
- [x] Move color swatches down and left (move onto separate row) (#183)
- [x] Add ability to remove a var from a mapping (#182)