### PR TITLE
Make the legend charts more compact and draw proper histograms for numeric variables

### DIFF
--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -136,6 +136,36 @@ export default Vue.extend({
             }
 
             // TODO: add histogram code
+
+            xScale = scaleLinear()
+              .domain([min(currentData), max(currentData) + 1])
+              .range([this.yAxisPadding, variableSvgWidth]);
+
+            const binGenerator = histogram()
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              .domain((xScale as any).domain()) // then the domain of the graphic
+              .thresholds(xScale.ticks(15)); // then the numbers of bins
+
+            bins = binGenerator(currentData);
+
+            if (type === 'node') {
+              store.commit.addAttributeRange({ attr, min: parseFloat(min(currentData) || '0'), max: parseFloat(max(currentData) || '0') });
+            }
+
+            yScale = scaleLinear()
+              .domain([0, max(bins, (d) => d.length)])
+              .range([this.svgHeight, 0]);
+
+            variableSvg
+              .selectAll('rect')
+              .data(bins)
+              .enter()
+              .append('rect')
+              .attr('x', (d) => xScale(d.x0) || 0)
+              .attr('y', (d) => yScale(d.length) || 0)
+              .attr('height', (d) => this.svgHeight - yScale(d.length))
+              .attr('width', (d) => xScale(d.x1) - xScale(d.x0))
+              .attr('fill', (d) => (this.isQuantitative(attr, type) ? '#82B1FF' : this.nodeColorScale(d)));
           } else {
             if (type === 'node') {
               currentData = this.graphStructure.nodes.map((d: Node | Link) => d[attr]).sort();

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -157,7 +157,7 @@ export default Vue.extend({
             }
 
             yScale = scaleLinear()
-              .domain([0, max(bins, (d) => d.length)])
+              .domain([0, max(bins, (d) => d.length) || 0])
               .range([this.svgHeight, 0]);
 
             variableSvg
@@ -165,6 +165,10 @@ export default Vue.extend({
               .data(bins)
               .enter()
               .append('rect')
+              .attr('x', (d) => (xScale as ScaleLinear<number, number>)(d.x0 || 0))
+              .attr('y', (d) => (yScale as ScaleLinear<number, number>)(d.length))
+              .attr('height', (d) => this.svgHeight - (yScale as ScaleLinear<number, number>)(d.length))
+              .attr('width', (d) => (xScale as ScaleLinear<number, number>)(d.x1 || 0) - (xScale as ScaleLinear<number, number>)(d.x0 || 0))
               .attr('fill', '#82B1FF');
           } else {
             if (type === 'node') {
@@ -187,20 +191,20 @@ export default Vue.extend({
             // Generate axis scales
             yScale = scaleLinear()
               .domain([min(binValues) || 0, max(binValues) || 0])
-              .range([this.svgHeight, 0]) as ScaleLinear<number, number>;
+              .range([this.svgHeight, 0]);
 
             xScale = scaleBand()
               .domain(binLabels)
-              .range([this.yAxisPadding, variableSvgWidth]) as ScaleBand<string>;
+              .range([this.yAxisPadding, variableSvgWidth]);
 
             variableSvg
               .selectAll('rect')
               .data(currentData)
               .enter()
               .append('rect')
-              .attr('x', (d: string) => xScale(d))
-              .attr('y', (d: string) => yScale(bins.get(d) || 0))
-              .attr('height', (d: string) => this.svgHeight - yScale(bins.get(d) || 0))
+              .attr('x', (d: string) => (xScale as ScaleBand<string>)(d) || 0)
+              .attr('y', (d: string) => (yScale as ScaleLinear<number, number>)((bins as Map<string, number>).get(d) || 0))
+              .attr('height', (d: string) => this.svgHeight - (yScale as ScaleLinear<number, number>)((bins as Map<string, number>).get(d) || 0))
               .attr('width', xScale.bandwidth())
               .attr('fill', (d: string) => this.nodeColorScale(d));
           }

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -601,11 +601,7 @@ export default Vue.extend({
           width="100%"
         />
         <br>
-        <br>
       </div>
-
-      <br>
-      <br>
 
       <h2>Link Attributes</h2>
       <br>
@@ -639,9 +635,6 @@ export default Vue.extend({
 .v-card {
     height: calc(66vh - 24px);
     overflow-y: scroll
-}
-svg >>> text {
-  text-anchor: start;
 }
 svg >>> .selected{
   stroke: "#000000";

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -209,12 +209,12 @@ export default Vue.extend({
           variableSvg
             .append('g')
             .attr('transform', `translate(${this.yAxisPadding},0)`)
-            .call(axisLeft(yScale));
+            .call(axisLeft(yScale).ticks(4, 's'));
 
           variableSvg
             .append('g')
             .attr('transform', `translate(0, ${this.svgHeight})`)
-            .call(axisBottom(xScale));
+            .call(axisBottom(xScale as AxisScale<number>).ticks(4, 's'));
 
           // Add the brush
           const brush = brushX()

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -178,12 +178,8 @@ export default Vue.extend({
               (x) => [x, currentData.filter((y) => y === x).length],
             )) as Map<string, number>;
 
-            const binLabels: string[] = [];
-            const binValues: number[] = [];
-            bins.forEach((value, label) => {
-              binLabels.push(label);
-              binValues.push(value);
-            });
+            const binLabels: string[] = Array.from(bins.keys());
+            const binValues: number[] = Array.from(bins.values());
 
             // Generate axis scales
             yScale = scaleLinear()

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -28,8 +28,8 @@ export default Vue.extend({
 
   data() {
     return {
-      svgHeight: 150,
-      yAxisPadding: 10,
+      svgHeight: 50,
+      yAxisPadding: 25, // Gives enough width for hundreds on the y axis
       varPadding: 10,
     };
   },

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -165,11 +165,7 @@ export default Vue.extend({
               .data(bins)
               .enter()
               .append('rect')
-              .attr('x', (d) => xScale(d.x0) || 0)
-              .attr('y', (d) => yScale(d.length) || 0)
-              .attr('height', (d) => this.svgHeight - yScale(d.length))
-              .attr('width', (d) => xScale(d.x1) - xScale(d.x0))
-              .attr('fill', (d) => (this.isQuantitative(attr, type) ? '#82B1FF' : this.nodeColorScale(d)));
+              .attr('fill', '#82B1FF');
           } else {
             if (type === 'node') {
               currentData = this.graphStructure.nodes.map((d: Node | Link) => d[attr]).sort();
@@ -206,7 +202,7 @@ export default Vue.extend({
               .attr('y', (d: string) => yScale(bins.get(d) || 0))
               .attr('height', (d: string) => this.svgHeight - yScale(bins.get(d) || 0))
               .attr('width', xScale.bandwidth())
-              .attr('fill', (d: string) => (this.isQuantitative(attr, type) ? '#82B1FF' : this.nodeColorScale(d)));
+              .attr('fill', (d: string) => this.nodeColorScale(d));
           }
 
           // Add the axis scales onto the chart

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -138,8 +138,6 @@ export default Vue.extend({
               currentData = this.graphStructure.edges.map((d: Node | Link) => parseFloat(d[attr]));
             }
 
-            // TODO: add histogram code
-
             xScale = scaleLinear()
               .domain([min(currentData), max(currentData) + 1])
               .range([this.yAxisPadding, variableSvgWidth]);

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -8,7 +8,6 @@ import {
   scaleLinear, scaleBand, ScaleBand, ScaleLinear,
 } from 'd3-scale';
 import { axisBottom, axisLeft, AxisScale } from 'd3-axis';
-import { brushX } from 'd3-brush';
 import { TableMetadata } from 'multinet';
 
 import { Node, Link, Network } from '@/types';
@@ -219,52 +218,6 @@ export default Vue.extend({
             .append('g')
             .attr('transform', `translate(0, ${this.svgHeight})`)
             .call(axisBottom(xScale as AxisScale<number>).ticks(4, 's'));
-
-          // Add the brush
-          const brush = brushX()
-            .extent([[this.yAxisPadding, 0], [variableSvgWidth, this.svgHeight]])
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            .on('start brush', (event: any) => {
-              const extent = event.selection;
-
-              // Set the brush highlighting on the legend svg
-              // variableSvgEnter
-              //   .attr('stroke', (d: string) => ((xScale(d) || 0) >= extent[0] - xScale.bandwidth() && (xScale(d) || 0) <= extent[1] ? '#000000' : ''));
-
-              // TODO: Update the nested bars domain
-              // if (attr === this.barVariables[0]) {
-              //   const new_domain = [
-              //     this.ordinalInvert(extent[0], xScale, binLabels)[0],
-              //     this.ordinalInvert(extent[1], xScale, binLabels)[0]
-              //   ]
-              //   this.linkWidthScale.domain(new_domain).range([2,20])
-              // }
-
-              // TODO: Update the nested glyph domain
-              // if (attr === this.barVariables[0]) {
-              //   const new_domain = [
-              //     this.ordinalInvert(extent[0], xScale, binLabels)[0],
-              //     this.ordinalInvert(extent[1], xScale, binLabels)[0]
-              //   ]
-              //   this.linkWidthScale.domain(new_domain).range([2,20])
-              // }
-
-              // Update the link width domain
-            // if (attr === this.linkVariables.width) {
-            //   const newDomain = [
-            //     this.ordinalInvert(extent[0], xScale, binLabels),
-            //     this.ordinalInvert(extent[1], xScale, binLabels),
-            //   ];
-            //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            //   store.commit.updateLinkWidthDomain(newDomain as number[]);
-            // }
-            });
-
-          variableSvg
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            .call((brush as any))
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            .call((brush.move as any), xScale.range());
         });
       });
     },

--- a/src/components/MultiLink/Legend.vue
+++ b/src/components/MultiLink/Legend.vue
@@ -1,9 +1,13 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
-import { min, max } from 'd3-array';
+import {
+  min, max, histogram, Bin,
+} from 'd3-array';
 import { select } from 'd3-selection';
-import { scaleLinear, scaleBand, ScaleBand } from 'd3-scale';
-import { axisBottom, axisLeft } from 'd3-axis';
+import {
+  scaleLinear, scaleBand, ScaleBand, ScaleLinear,
+} from 'd3-scale';
+import { axisBottom, axisLeft, AxisScale } from 'd3-axis';
 import { brushX } from 'd3-brush';
 import { TableMetadata } from 'multinet';
 


### PR DESCRIPTION
Closes #172 

This PR represents a bit of progression and regression. I made the legend more compact, used a better histogram function for the numeric variables, fixed the spacing around the axes, and made the charts responsive to the multinet types. However, I've also removed brushing (since it wasn't working and it'll require some bigger refactor to get it working).

I've opened #184 to track the regression and adding it back.