### PR TITLE
Add rectangular selection tool to select multiple nodes at once

### DIFF
--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -431,7 +431,6 @@ export default Vue.extend({
       };
 
       const stopFn = () => {
-        console.log(this.rectSelect.x, this.rectSelect.transformX);
         const boxX1 = Math.min(this.rectSelect.x + this.rectSelect.transformX, this.rectSelect.x);
         const boxX2 = boxX1 + this.rectSelect.width;
         const boxY1 = Math.min(this.rectSelect.y + this.rectSelect.transformY, this.rectSelect.y);

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -20,6 +20,14 @@ export default Vue.extend({
       el: null as Element | null,
       simulation: null as Simulation<Node, SimulationLink> | null,
       nestedPadding: 5,
+      rectSelect: {
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        transformX: 0,
+        transformY: 0,
+      },
     };
   },
 
@@ -401,6 +409,19 @@ export default Vue.extend({
       :width="svgDimensions.width"
       :height="svgDimensions.height"
     >
+      <rect
+        id="rect-select"
+        :x="rectSelect.x"
+        :y="rectSelect.y"
+        :width="rectSelect.width"
+        :height="rectSelect.height"
+        :transform="`translate(${rectSelect.transformX}, ${rectSelect.transformY})`"
+        fill="none"
+        stroke="black"
+        stroke-width="2px"
+        stroke-dasharray="5,5"
+      />
+
       <g
         class="links"
       >

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -249,13 +249,17 @@ export default Vue.extend({
     },
 
     dragNode(node: Node, event: MouseEvent) {
-      if (!(this.$refs.svg instanceof Element)) { throw new Error('SVG is not of type Element'); }
+      if (!(this.$refs.svg instanceof Element)) {
+        throw new Error('SVG is not of type Element');
+      }
 
       event.stopPropagation();
 
       const moveFn = (evt: Event) => {
         // Check we have a mouse event
-        if (!(evt instanceof MouseEvent)) { throw new Error('event is not MouseEvent'); }
+        if (!(evt instanceof MouseEvent)) {
+          throw new Error('event is not MouseEvent');
+        }
 
         // eslint-disable-next-line no-param-reassign
         node.x = evt.x - this.controlsWidth - (this.calculateNodeSize(node) / 2);
@@ -265,7 +269,9 @@ export default Vue.extend({
       };
 
       const stopFn = () => {
-        if (!(this.$refs.svg instanceof Element)) { throw new Error('SVG is not of type Element'); }
+        if (!(this.$refs.svg instanceof Element)) {
+          throw new Error('SVG is not of type Element');
+        }
         this.$refs.svg.removeEventListener('mousemove', moveFn);
         this.$refs.svg.removeEventListener('mouseup', stopFn);
       };
@@ -414,7 +420,9 @@ export default Vue.extend({
 
       const moveFn = (evt: Event) => {
         // Check we have a mouse event
-        if (!(evt instanceof MouseEvent)) { throw new Error('event is not MouseEvent'); }
+        if (!(evt instanceof MouseEvent)) {
+          throw new Error('event is not MouseEvent');
+        }
 
         // Get event location
         const mouseX = evt.x - this.controlsWidth;
@@ -459,7 +467,9 @@ export default Vue.extend({
         });
 
         // Remove the listeners so that the box stops updating location
-        if (!(this.$refs.svg instanceof Element)) { throw new Error('SVG is not of type Element'); }
+        if (!(this.$refs.svg instanceof Element)) {
+          throw new Error('SVG is not of type Element');
+        }
         this.$refs.svg.removeEventListener('mousemove', moveFn);
         this.$refs.svg.removeEventListener('mouseup', stopFn);
 
@@ -474,7 +484,9 @@ export default Vue.extend({
         };
       };
 
-      if (!(this.$refs.svg instanceof Element)) { throw new Error('SVG is not of type Element'); }
+      if (!(this.$refs.svg instanceof Element)) {
+        throw new Error('SVG is not of type Element');
+      }
       this.$refs.svg.addEventListener('mousemove', moveFn);
       this.$refs.svg.addEventListener('mouseup', stopFn);
     },

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -255,9 +255,7 @@ export default Vue.extend({
 
       const moveFn = (evt: Event) => {
         // Check we have a mouse event
-        if (!this.isMouseEvent(evt)) {
-          return;
-        }
+        if (!(evt instanceof MouseEvent)) { throw new Error('event is not MouseEvent'); }
 
         // eslint-disable-next-line no-param-reassign
         node.x = evt.x - this.controlsWidth - (this.calculateNodeSize(node) / 2);
@@ -403,10 +401,6 @@ export default Vue.extend({
       return this.nodeSizeScale(node[this.nodeSizeVariable]);
     },
 
-    isMouseEvent(event: Event): event is MouseEvent {
-      return (event as MouseEvent).x !== undefined && (event as MouseEvent).y !== undefined;
-    },
-
     rectSelectDrag(event: MouseEvent) {
       // Set initial location for box (pins one corner)
       this.rectSelect = {
@@ -420,9 +414,7 @@ export default Vue.extend({
 
       const moveFn = (evt: Event) => {
         // Check we have a mouse event
-        if (!this.isMouseEvent(evt)) {
-          return;
-        }
+        if (!(evt instanceof MouseEvent)) { throw new Error('event is not MouseEvent'); }
 
         // Get event location
         const mouseX = evt.x - this.controlsWidth;

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -249,6 +249,8 @@ export default Vue.extend({
     },
 
     dragNode(node: Node, event: MouseEvent) {
+      if (!(this.$refs.svg instanceof Element)) { throw new Error('SVG is not of type Element'); }
+
       event.stopPropagation();
 
       const moveFn = (evt: Event) => {
@@ -265,12 +267,13 @@ export default Vue.extend({
       };
 
       const stopFn = () => {
-        (this.$refs.svg as Element).removeEventListener('mousemove', moveFn);
-        (this.$refs.svg as Element).removeEventListener('mouseup', stopFn);
+        if (!(this.$refs.svg instanceof Element)) { throw new Error('SVG is not of type Element'); }
+        this.$refs.svg.removeEventListener('mousemove', moveFn);
+        this.$refs.svg.removeEventListener('mouseup', stopFn);
       };
 
-      (this.$refs.svg as Element).addEventListener('mousemove', moveFn);
-      (this.$refs.svg as Element).addEventListener('mouseup', stopFn);
+      this.$refs.svg.addEventListener('mousemove', moveFn);
+      this.$refs.svg.addEventListener('mouseup', stopFn);
     },
 
     showTooltip(element: Node | Link, event: MouseEvent) {
@@ -464,8 +467,9 @@ export default Vue.extend({
         });
 
         // Remove the listeners so that the box stops updating location
-        (this.$refs.svg as Element).removeEventListener('mousemove', moveFn);
-        (this.$refs.svg as Element).removeEventListener('mouseup', stopFn);
+        if (!(this.$refs.svg instanceof Element)) { throw new Error('SVG is not of type Element'); }
+        this.$refs.svg.removeEventListener('mousemove', moveFn);
+        this.$refs.svg.removeEventListener('mouseup', stopFn);
 
         // Remove the selection box
         this.rectSelect = {
@@ -478,8 +482,9 @@ export default Vue.extend({
         };
       };
 
-      (this.$refs.svg as Element).addEventListener('mousemove', moveFn);
-      (this.$refs.svg as Element).addEventListener('mouseup', stopFn);
+      if (!(this.$refs.svg instanceof Element)) { throw new Error('SVG is not of type Element'); }
+      this.$refs.svg.addEventListener('mousemove', moveFn);
+      this.$refs.svg.addEventListener('mouseup', stopFn);
     },
   },
 });

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -256,10 +256,15 @@ export default Vue.extend({
       event.stopPropagation();
 
       const moveFn = (evt: Event) => {
+        // Check we have a mouse event
+        if (!this.isMouseEvent(evt)) {
+          return;
+        }
+
         // eslint-disable-next-line no-param-reassign
-        node.x = (evt as MouseEvent).clientX - this.controlsWidth - (this.calculateNodeSize(node) / 2);
+        node.x = evt.x - this.controlsWidth - (this.calculateNodeSize(node) / 2);
         // eslint-disable-next-line no-param-reassign
-        node.y = (evt as MouseEvent).clientY - (this.calculateNodeSize(node) / 2);
+        node.y = evt.y - (this.calculateNodeSize(node) / 2);
         this.$forceUpdate();
       };
 
@@ -399,6 +404,10 @@ export default Vue.extend({
       return this.nodeSizeScale(node[this.nodeSizeVariable]);
     },
 
+    isMouseEvent(event: Event): event is MouseEvent {
+      return (event as MouseEvent).x !== undefined && (event as MouseEvent).y !== undefined;
+    },
+
     rectSelectDrag(event: MouseEvent) {
       // Set initial location for box (pins one corner)
       this.rectSelect = {
@@ -411,9 +420,14 @@ export default Vue.extend({
       };
 
       const moveFn = (evt: Event) => {
+        // Check we have a mouse event
+        if (!this.isMouseEvent(evt)) {
+          return;
+        }
+
         // Get event location
-        const mouseX = (evt as MouseEvent).x - this.controlsWidth;
-        const mouseY = (evt as MouseEvent).y;
+        const mouseX = evt.x - this.controlsWidth;
+        const mouseY = evt.y;
 
         // Check if we need to translate (case when mouse is left/above initial click)
         const translateX = mouseX < this.rectSelect.x;

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -253,7 +253,7 @@ export default Vue.extend({
     },
 
     dragNode(node: Node, event: MouseEvent) {
-      event.preventDefault();
+      event.stopPropagation();
 
       const moveFn = (evt: Event) => {
         // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
Closes #164

This adds a rectangle to the svg that allows for selecting multiple nodes at once. Again, I had issues using dragstarted, etc., but got around them using the mousedown handler (similar to the dragNode logic). The user can now drag a rectangular region and every node that has its center in the boundaries will be selected at once. There is no logic here to remove selections from already selected nodes (but it wouldn't be too hard to add that if it's requested)

Here it is in action:
https://user-images.githubusercontent.com/36867477/107707784-a7651c80-6c7f-11eb-9050-054a00d0c6c4.mp4



