### PR TITLE
Add slider that allows modification of link length and fix updateSimulationForces

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -4,6 +4,7 @@ import Legend from '@/components/Legend.vue';
 
 import store from '@/store';
 import { Node, Link, Network } from '@/types';
+import { forceManyBody } from 'd3-force';
 
 export default Vue.extend({
   components: {
@@ -14,6 +15,7 @@ export default Vue.extend({
     return {
       searchTerm: '' as string,
       searchErrors: [] as string[],
+      linkLength: '50',
     };
   },
 
@@ -174,11 +176,17 @@ export default Vue.extend({
       this.searchErrors = searchErrors;
     },
 
-    updateSliderProv(value: number, type: 'markerSize' | 'fontSize') {
+    updateSliderProv(value: number, type: 'markerSize' | 'fontSize' | 'linkLength') {
       if (type === 'markerSize') {
         store.commit.setMarkerSize({ markerSize: value, updateProv: true });
       } else if (type === 'fontSize') {
         store.commit.setFontSize({ fontSize: value, updateProv: true });
+      } else if (type === 'linkLength') {
+        // Scale value to between -500, 0
+        const newLinkLength = (value * -5);
+        console.log(newLinkLength);
+
+        store.dispatch.updateSimulationForce({ forceType: 'charge', forceValue: forceManyBody<Node>().strength(newLinkLength), restart: true });
       }
     },
 
@@ -332,6 +340,19 @@ export default Vue.extend({
             inverse-label
             hide-details
             @change="(value) => updateSliderProv(value, 'fontSize')"
+          />
+
+          <v-card-subtitle class="pb-0 pl-0">
+            Link Length
+          </v-card-subtitle>
+          <v-slider
+            v-model="linkLength"
+            :min="0"
+            :max="100"
+            :label="linkLength.toString()"
+            inverse-label
+            hide-details
+            @change="(value) => updateSliderProv(linkLength, 'linkLength')"
           />
 
           <v-row>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -4,7 +4,7 @@ import Legend from '@/components/Legend.vue';
 
 import store from '@/store';
 import { Node, Link, Network } from '@/types';
-import { forceManyBody } from 'd3-force';
+import { forceCollide, forceManyBody } from 'd3-force';
 
 export default Vue.extend({
   components: {
@@ -179,6 +179,7 @@ export default Vue.extend({
     updateSliderProv(value: number, type: 'markerSize' | 'fontSize' | 'linkLength') {
       if (type === 'markerSize') {
         store.commit.setMarkerSize({ markerSize: value, updateProv: true });
+        store.dispatch.updateSimulationForce({ forceType: 'collision', forceValue: forceCollide((this.markerSize / 2) * 1.5), restart: true });
       } else if (type === 'fontSize') {
         store.commit.setFontSize({ fontSize: value, updateProv: true });
       } else if (type === 'linkLength') {

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -185,7 +185,6 @@ export default Vue.extend({
       } else if (type === 'linkLength') {
         // Scale value to between -500, 0
         const newLinkLength = (value * -5);
-        console.log(newLinkLength);
 
         store.dispatch.updateSimulationForce({ forceType: 'charge', forceValue: forceManyBody<Node>().strength(newLinkLength), restart: true });
       }

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -193,7 +193,7 @@ export default Vue.extend({
       // Make the simulation
       const simulation = forceSimulation<Node, SimulationLink>()
         .force('center', forceCenter(this.svgDimensions.width / 2, this.svgDimensions.height / 2))
-        .force('charge', forceManyBody<Node>().strength(-300))
+        .force('charge', forceManyBody<Node>().strength(-250))
         .force('link', forceLink<Node, SimulationLink>().id((d) => { const datum = (d as Link); return datum._id; }))
         .force('collision', forceCollide((this.markerSize / 2) * 1.5));
 

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -154,7 +154,7 @@ export default Vue.extend({
       const { height } = this.$vuetify.breakpoint;
       const width = this.$vuetify.breakpoint.width - this.controlsWidth;
 
-      store.commit.updateSimulationForce({ forceType: 'center', forceValue: forceCenter<Node>(width / 2, height / 2) });
+      store.dispatch.updateSimulationForce({ forceType: 'center', forceValue: forceCenter<Node>(width / 2, height / 2), restart: false });
 
       return {
         height,

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -93,10 +93,6 @@ export default Vue.extend({
       return this.markerSize - 24;
     },
 
-    forceRadius(): number {
-      return (this.markerSize / 2) * 1.5;
-    },
-
     displayCharts() {
       return store.getters.displayCharts;
     },
@@ -199,7 +195,7 @@ export default Vue.extend({
         .force('center', forceCenter(this.svgDimensions.width / 2, this.svgDimensions.height / 2))
         .force('charge', forceManyBody<Node>().strength(-300))
         .force('link', forceLink<Node, SimulationLink>().id((d) => { const datum = (d as Link); return datum._id; }))
-        .force('collision', forceCollide(this.forceRadius));
+        .force('collision', forceCollide((this.markerSize / 2) * 1.5));
 
       simulation
         .nodes(this.network.nodes);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -339,16 +339,6 @@ const {
       }
     },
 
-    updateSimulationForce(state: State, payload: {
-      forceType: 'center' | 'charge' | 'link' | 'collision';
-      forceValue: ForceCenter<Node> | ForceManyBody<Node> | ForceLink<Node, SimulationLink> | ForceCollide<Node>;
-    }) {
-      if (state.simulation !== null) {
-        const { forceType, forceValue } = payload;
-        state.simulation.force(forceType, forceValue);
-      }
-    },
-
     toggleShowProvenanceVis(state: State) {
       state.showProvenanceVis = !state.showProvenanceVis;
     },
@@ -495,6 +485,22 @@ const {
 
       // Add keydown listener for undo/redo
       document.addEventListener('keydown', (event) => undoRedoKeyHandler(event, storeState));
+    },
+
+    updateSimulationForce(context, payload: {
+      forceType: 'center' | 'charge' | 'link' | 'collision';
+      forceValue: ForceCenter<Node> | ForceManyBody<Node> | ForceLink<Node, SimulationLink> | ForceCollide<Node>;
+      restart: boolean;
+    }) {
+      const { commit } = rootActionContext(context);
+      if (context.state.simulation !== null) {
+        const { forceType, forceValue, restart } = payload;
+        context.state.simulation.force(forceType, forceValue);
+
+        if (restart) {
+          commit.startSimulation();
+        }
+      }
     },
   },
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -208,7 +208,7 @@ const {
 
     startSimulation(state) {
       if (state.simulation !== null) {
-        state.simulation.alpha(0.5);
+        state.simulation.alpha(0.2);
         state.simulation.restart();
         state.simulationRunning = true;
       }


### PR DESCRIPTION
Closes #32 
Closes #92

This change set adds a new slider for link length. I also refactored the `updateSimulationForce` function to an action so that I could use the startSimulation method. I also noticed that the markerSize slider didn't restart the simulation, so I modified that to restart the simulation.

@curtislisle, I tagged you just so that you can see this change. Feel free to leave comments about the functionality

https://user-images.githubusercontent.com/36867477/107819503-84497400-6d36-11eb-9b46-cf5ab084deed.mp4

TODO:
- [x] These changes to forces are not captured in provenance (#193)