### PR TITLE
Fix directional arrow alignment and color

### DIFF
--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -535,6 +535,7 @@ export default Vue.extend({
           <text
             v-if="directionalEdges"
             dominant-baseline="middle"
+            y="1"
           >
             <textPath
               :href="`#${link._key}_path`"

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -651,6 +651,10 @@ export default Vue.extend({
   max-width: 400px
 }
 
+textPath {
+  fill: #888888;
+}
+
 .links >>> path,
 .edgeLegend {
     fill: none;


### PR DESCRIPTION
Closes #167
Closes #168

Just a couple small changes that clean up the UI. This fixes the alignment of the directional arrows by moving them down by 1px and sets their color to the default color for links. We could potentially map them to the color of the link, but Alex would probably want some input on that. I think for now, making them grey works well with color.