### PR TITLE
Add a context menu with a quick option to remove node selections

### DIFF
--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -1,0 +1,48 @@
+<script lang="ts">
+import store from '@/store';
+import { computed } from '@vue/composition-api';
+
+export default {
+  setup() {
+    const rightClickMenu = computed(() => store.getters.rightClickMenu);
+
+    function clearSelection() {
+      store.commit.setSelected(new Set());
+    }
+
+    return {
+      rightClickMenu,
+      clearSelection,
+    };
+  },
+};
+</script>
+
+<template>
+  <div
+    id="right-click-menu"
+  >
+    <v-menu
+      v-model="rightClickMenu.show"
+      :position-x="rightClickMenu.left"
+      :position-y="rightClickMenu.top"
+    >
+      <v-list>
+        <v-list-item
+          dense
+          @click="clearSelection"
+        >
+          <v-list-item-content>
+            <v-list-item-title>Clear Selection</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </v-list>
+    </v-menu>
+  </div>
+</template>
+
+<style>
+#right-click-menu {
+  position: absolute;
+}
+</style>

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -414,6 +414,11 @@ export default Vue.extend({
     },
 
     rectSelectDrag(event: MouseEvent) {
+      // Only drag on left clicks
+      if (event.button !== 0) {
+        return;
+      }
+
       // Set initial location for box (pins one corner)
       this.rectSelect = {
         x: event.x - this.controlsWidth,

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -10,7 +10,13 @@ import {
   Node, Link, SimulationLink, Dimensions,
 } from '@/types';
 
+import ContextMenu from '@/components/ContextMenu.vue';
+
 export default Vue.extend({
+  components: {
+    ContextMenu,
+  },
+
   data() {
     return {
       straightEdges: false,
@@ -490,6 +496,16 @@ export default Vue.extend({
       this.$refs.svg.addEventListener('mousemove', moveFn);
       this.$refs.svg.addEventListener('mouseup', stopFn);
     },
+
+    showContextMenu(event: MouseEvent) {
+      store.commit.updateRightClickMenu({
+        show: true,
+        top: event.y,
+        left: event.x,
+      });
+
+      event.preventDefault();
+    },
   },
 });
 </script>
@@ -501,6 +517,7 @@ export default Vue.extend({
       :width="svgDimensions.width"
       :height="svgDimensions.height"
       @mousedown="rectSelectDrag"
+      @contextmenu="showContextMenu"
     >
       <rect
         id="rect-select"
@@ -639,6 +656,8 @@ export default Vue.extend({
     >
       ID: {{ tooltipMessage }}
     </div>
+
+    <context-menu />
   </div>
 </template>
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -64,6 +64,11 @@ const {
     controlsWidth: 256,
     simulationRunning: false,
     showProvenanceVis: false,
+    rightClickMenu: {
+      show: false,
+      top: 0,
+      left: 0,
+    },
   } as State,
 
   getters: {
@@ -165,6 +170,10 @@ const {
 
     showProvenanceVis(state: State) {
       return state.showProvenanceVis;
+    },
+
+    rightClickMenu(state: State) {
+      return state.rightClickMenu;
     },
   },
   mutations: {
@@ -341,6 +350,10 @@ const {
 
     toggleShowProvenanceVis(state: State) {
       state.showProvenanceVis = !state.showProvenanceVis;
+    },
+
+    updateRightClickMenu(state: State, payload: { show: boolean; top: number; left: number }) {
+      state.rightClickMenu = payload;
     },
   },
   actions: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,11 @@ export interface State {
   controlsWidth: number;
   simulationRunning: boolean;
   showProvenanceVis: boolean;
+  rightClickMenu: {
+    show: boolean;
+    top: number;
+    left: number;
+  };
 }
 
 export type ProvenanceEventTypes =


### PR DESCRIPTION
This doesn't close an issue, but it's an improvement that we've wanted for a while. I added a context menu with a button to quickly clear the selection. I also used the composition API style and I feel like I'm becoming more familiar with it.

After reviewing the documentation, I saw there was an `@contextmenu` event hook so I'm using that. The only lingering issue was if the user held right click it would draw the rect select, so I made sure that only triggers on a left click by checking which button is pressed in the event handler.

This improvement will allow for a couple of improvements requested by Alex,  namely #166 and moving some of the menu buttons from the controls to this context menu (like I've done with "Clear Selection")

See #201 for a demo of the functionality