### PR TITLE
Remove clear selection, fix start/stop button width, and fix label variable bottom margin issue

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -190,10 +190,6 @@ export default Vue.extend({
       }
     },
 
-    clearSelection() {
-      store.commit.setSelected(new Set());
-    },
-
     toggleProvVis() {
       store.commit.toggleShowProvenanceVis();
     },

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -261,6 +261,7 @@ export default Vue.extend({
               v-model="labelVariable"
               label="Label Variable"
               :items="Array.from(multiVariableList)"
+              :hide-details="true"
               clearable
               outlined
               dense

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -272,18 +272,6 @@ export default Vue.extend({
           </v-list-item>
 
           <v-list-item class="px-0">
-            <v-btn
-              color="primary"
-              depressed
-              small
-              block
-              @click="clearSelection"
-            >
-              Clear Selection
-            </v-btn>
-          </v-list-item>
-
-          <v-list-item class="px-0">
             <v-list-item-action class="mr-3">
               <v-switch
                 v-model="displayCharts"

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -367,7 +367,7 @@ export default Vue.extend({
                 color="primary"
                 depressed
                 small
-                width="85"
+                width="75"
                 @click="simulationRunning ? stopSimulation() : startSimulation()"
               >
                 <v-icon


### PR DESCRIPTION
I cleaned up a couple UI issues I've noticed over the past little while:
- The start/stop button for the simulation would sometime migrate down to a new line
- The label variable v-select had a huge margin on the bottom (caused by the details prop not being set to false)

I also removed the `clearSelection` button since that functionality will be captured by the context menu changes