### PR TITLE
Use label variable instead of _key for search

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -126,7 +126,7 @@ export default Vue.extend({
 
     autocompleteItems(): string[] {
       if (this.network !== null) {
-        return this.network.nodes.map((node) => node._key);
+        return this.network.nodes.map((node) => node[this.labelVariable]);
       }
       return [];
     },
@@ -164,7 +164,7 @@ export default Vue.extend({
     search() {
       const searchErrors: string[] = [];
       if (this.network !== null) {
-        const nodeToSelect = this.network.nodes.find((node) => node._key === this.searchTerm);
+        const nodeToSelect = this.network.nodes.find((node) => node[this.labelVariable] === this.searchTerm);
 
         if (nodeToSelect !== undefined) {
           store.commit.addSelectedNode(nodeToSelect._id);


### PR DESCRIPTION
Allows for searching of node labels instead of just node keys. The search box items are now responsive to the label variable and so is the function that selects the nodes.

Since the label variables are not currently unique for each node (e.g. group in les mis), we need to figure out what to do with those labels. (#199)