### PR TITLE
Add functions + UI to pin and un-pin selected nodes

### DIFF
--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -25,10 +25,24 @@ export default {
       }
     }
 
+    function unPinSelectedNodes() {
+      if (network.value !== null) {
+        network.value.nodes
+          .filter((node) => selectedNodes.value.has(node._id))
+          .forEach((node) => {
+            // eslint-disable-next-line no-param-reassign
+            delete node.fx;
+            // eslint-disable-next-line no-param-reassign
+            delete node.fy;
+          });
+      }
+    }
+
     return {
       rightClickMenu,
       clearSelection,
       pinSelectedNodes,
+      unPinSelectedNodes,
     };
   },
 };
@@ -59,6 +73,15 @@ export default {
         >
           <v-list-item-content>
             <v-list-item-title>Pin Selected Nodes</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+
+        <v-list-item
+          dense
+          @click="unPinSelectedNodes()"
+        >
+          <v-list-item-content>
+            <v-list-item-title>Un-Pin Selected Nodes</v-list-item-title>
           </v-list-item-content>
         </v-list-item>
       </v-list>

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -5,14 +5,30 @@ import { computed } from '@vue/composition-api';
 export default {
   setup() {
     const rightClickMenu = computed(() => store.getters.rightClickMenu);
+    const selectedNodes = computed(() => store.getters.selectedNodes);
+    const network = computed(() => store.getters.network);
 
     function clearSelection() {
       store.commit.setSelected(new Set());
     }
 
+    function pinSelectedNodes() {
+      if (network.value !== null) {
+        network.value.nodes
+          .filter((node) => selectedNodes.value.has(node._id))
+          .forEach((node) => {
+            // eslint-disable-next-line no-param-reassign
+            node.fx = node.x;
+            // eslint-disable-next-line no-param-reassign
+            node.fy = node.y;
+          });
+      }
+    }
+
     return {
       rightClickMenu,
       clearSelection,
+      pinSelectedNodes,
     };
   },
 };
@@ -34,6 +50,15 @@ export default {
         >
           <v-list-item-content>
             <v-list-item-title>Clear Selection</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+
+        <v-list-item
+          dense
+          @click="pinSelectedNodes()"
+        >
+          <v-list-item-content>
+            <v-list-item-title>Pin Selected Nodes</v-list-item-title>
           </v-list-item-content>
         </v-list-item>
       </v-list>


### PR DESCRIPTION
Depends on #196
Closes #166

Adds options to the context menu to pin and un-pin the selected nodes. This would allow you to keep simulating some of the nodes, while keeping other nodes in a static location.

See it in action:
https://user-images.githubusercontent.com/36867477/108933142-e001e000-7607-11eb-896d-6d67f5c76e72.mp4