### PR TITLE
Fix performance issues with multiple select + allow selecting multiple nodes from search

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -164,12 +164,14 @@ export default Vue.extend({
     search() {
       const searchErrors: string[] = [];
       if (this.network !== null) {
-        const nodeToSelect = this.network.nodes.find((node) => node[this.labelVariable] === this.searchTerm);
+        const nodeIDsToSelect = this.network.nodes
+          .filter((node) => node[this.labelVariable] === this.searchTerm)
+          .map((node) => node._id);
 
-        if (nodeToSelect !== undefined) {
-          store.commit.addSelectedNode(nodeToSelect._id);
+        if (nodeIDsToSelect.length > 0) {
+          store.commit.addSelectedNode(nodeIDsToSelect);
         } else {
-          searchErrors.push('Enter a node to search');
+          searchErrors.push('Enter a valid node to search');
         }
       }
 

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -245,6 +245,7 @@ export default Vue.extend({
               label="Search for Node"
               :items="autocompleteItems"
               :error-messages="searchErrors"
+              auto-select-first
             />
 
             <v-btn

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -244,7 +244,7 @@ export default Vue.extend({
       if (this.selectedNodes.has(node._id)) {
         store.commit.removeSelectedNode(node._id);
       } else {
-        store.commit.addSelectedNode(node._id);
+        store.commit.addSelectedNode([node._id]);
       }
     },
 
@@ -387,6 +387,7 @@ export default Vue.extend({
     },
 
     linkStyle(link: Link): string {
+      console.log('updating linkStyle');
       const linkColor = this.linkVariables.color === '' ? '#888888' : this.nodeGlyphColorScale(link[this.linkVariables.color]);
       const linkWidth = this.linkVariables.width === '' ? 1 : this.linkWidthScale(link[this.linkVariables.width]);
 
@@ -462,9 +463,7 @@ export default Vue.extend({
         }
 
         // Select the nodes inside the box if there are any
-        nodesInRect.forEach((node) => {
-          store.commit.addSelectedNode(node._id);
-        });
+        store.commit.addSelectedNode(nodesInRect.map((node) => node._id));
 
         // Remove the listeners so that the box stops updating location
         if (!(this.$refs.svg instanceof Element)) {

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -387,7 +387,6 @@ export default Vue.extend({
     },
 
     linkStyle(link: Link): string {
-      console.log('updating linkStyle');
       const linkColor = this.linkVariables.color === '' ? '#888888' : this.nodeGlyphColorScale(link[this.linkVariables.color]);
       const linkWidth = this.linkVariables.width === '' ? 1 : this.linkWidthScale(link[this.linkVariables.width]);
 

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -4,7 +4,7 @@ import { createAction } from '@visdesignlab/trrack';
 export function updateProvenanceState(vuexState: State, label: ProvenanceEventTypes) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const stateUpdateActions = createAction<State, any[], ProvenanceEventTypes>((provState, newProvState) => {
-    if (label === 'Select Node' || label === 'De-select Node' || label === 'Clear Selection') {
+    if (label === 'Select Node(s)' || label === 'De-select Node' || label === 'Clear Selection') {
       // TODO: #148 remove cast back to set
       // eslint-disable-next-line no-param-reassign, @typescript-eslint/no-explicit-any
       provState.selectedNodes = [...newProvState.selectedNodes] as any;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -221,11 +221,11 @@ const {
       }
     },
 
-    addSelectedNode(state, nodeID: string) {
-      state.selectedNodes = new Set(state.selectedNodes.add(nodeID));
+    addSelectedNode(state, nodesToAdd: string[]) {
+      state.selectedNodes = new Set([...state.selectedNodes, ...nodesToAdd]);
 
       if (state.provenance !== null) {
-        updateProvenanceState(state, 'Select Node');
+        updateProvenanceState(state, 'Select Node(s)');
       }
     },
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,7 +91,7 @@ export interface State {
 }
 
 export type ProvenanceEventTypes =
-  'Select Node' |
+  'Select Node(s)' |
   'De-select Node' |
   'Clear Selection' |
   'Set Display Charts' |


### PR DESCRIPTION
Closes #199

This branch does a couple of things:

1) It updates the node selection logic to allow a list to be passed to add nodes. This gives us the benefit of being able to select multiple nodes at once, and just create on provenance event. That's great for performance of the rectangular select. 

2) Uses that logic in the node searcher to allow for slelecting all nodes that match the search query.