### PR TITLE
Fix error message on 404 and CORS failure

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -372,15 +372,15 @@ const {
           commit.setLoadError({
             message: error.statusText,
             buttonText: 'Back to MultiNet',
-            href: '/',
+            href: 'https://multinet.app',
+          });
+        } else {
+          commit.setLoadError({
+            message: 'An unexpected error ocurred',
+            buttonText: 'Back to MultiNet',
+            href: 'https://multinet.app',
           });
         }
-
-        commit.setLoadError({
-          message: 'An unexpected error ocurred',
-          buttonText: 'Back to MultiNet',
-          href: '/',
-        });
       }
 
       if (networkTables === undefined) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -381,6 +381,15 @@ const {
             href: 'https://multinet.app',
           });
         }
+      } finally {
+        if (store.getters.loadError.message === '' && typeof networkTables === 'undefined') {
+          // Catches CORS errors, issues when DB/API are down, etc.
+          commit.setLoadError({
+            message: 'There was a network issue when getting data',
+            buttonText: 'Refresh the page',
+            href: `./?workspace=${workspaceName}&graph=${networkName}`,
+          });
+        }
       }
 
       if (networkTables === undefined) {


### PR DESCRIPTION
Closes #128

Fixes the logic for setting the 404 errors and adds a new check in the `finally` to see if the api call failed. Checking CORS is pretty tricky, since the browser doesn't report if the error was because of CORS (for security), so I had to check it in a bit of a roundabout way. 