### PR TITLE
Add dropdowns to alert to select workspace and graphs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@ import {
   ref, computed, Ref,
 } from '@vue/composition-api';
 
+import Alert from '@/components/Alert.vue';
 import Controls from './components/Controls.vue';
 import MultiLink from './components/MultiLink.vue';
 import ProvVis from './components/ProvVis.vue';
@@ -13,6 +14,7 @@ export default {
   name: 'App',
 
   components: {
+    Alert,
     Controls,
     MultiLink,
     ProvVis,
@@ -65,22 +67,7 @@ export default {
         v-if="network !== null && selectedNodes !== null"
       />
 
-      <v-alert
-        type="error"
-        :value="loadError.message !== ''"
-        prominent
-      >
-        <v-row align="center">
-          <v-col class="grow">
-            {{ loadError.message }}
-          </v-col>
-          <v-col class="shrink">
-            <v-btn :href="loadError.href">
-              {{ loadError.buttonText }}
-            </v-btn>
-          </v-col>
-        </v-row>
-      </v-alert>
+      <alert v-if="loadError.message !== ''" />
     </v-main>
 
     <prov-vis v-if="showProvenanceVis" />

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,9 +6,9 @@ import {
 } from '@vue/composition-api';
 
 import Alert from '@/components/Alert.vue';
-import Controls from './components/Controls.vue';
-import MultiLink from './components/MultiLink.vue';
-import ProvVis from './components/ProvVis.vue';
+import Controls from '@/components/Controls.vue';
+import MultiLink from '@/components/MultiLink.vue';
+import ProvVis from '@/components/ProvVis.vue';
 
 export default {
   name: 'App',

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -63,6 +63,16 @@ export default {
       <v-row align="center">
         <v-col class="grow">
           {{ loadError.message }}
+
+          <br>
+
+          <small v-if="loadError.message === 'You are not authorized to view this workspace'">
+            If you are already logged in, please check with the workspace owner to verify your permissions.
+          </small>
+
+          <small v-else>
+            Select a workspace or network you'd like to return to.
+          </small>
         </v-col>
 
         <v-col

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -58,6 +58,7 @@ export default {
     <v-alert
       type="error"
       prominent
+      tile
     >
       <v-row align="center">
         <v-col class="grow">

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -59,7 +59,8 @@ export default {
 <template>
   <div>
     <v-alert
-      type="error"
+      type="warning"
+      border="left"
       prominent
       tile
     >
@@ -102,7 +103,12 @@ export default {
         </v-col>
 
         <v-col class="shrink">
-          <v-btn :href="buttonHref">
+          <v-btn
+            :href="buttonHref"
+            depressed
+            dark
+            color="grey darken-3"
+          >
             {{ buttonText }}
           </v-btn>
         </v-col>

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -33,7 +33,7 @@ export default {
     watchEffect(async () => {
       if (workspace.value !== null && network.value !== null) {
         buttonHref.value = `./?workspace=${workspace.value}&graph=${network.value}`;
-        buttonText.value = 'Go To Graph';
+        buttonText.value = 'Go To Network';
       } else {
         buttonHref.value = loadError.value.href;
         buttonText.value = loadError.value.buttonText;
@@ -81,7 +81,7 @@ export default {
             <v-col class="py-0">
               <v-select
                 v-model="network"
-                label="Graph"
+                label="Network"
                 :items="networkOptions"
               />
             </v-col>

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -71,7 +71,7 @@ export default {
           </small>
 
           <small v-else>
-            Select a workspace or network you'd like to return to.
+            Select a workspace and network you'd like to view.
           </small>
         </v-col>
 

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -31,7 +31,6 @@ export default {
     const buttonHref: Ref<string> = ref(loadError.value.href);
     const buttonText: Ref<string> = ref(loadError.value.href);
     watchEffect(async () => {
-      console.log(workspace.value, network.value);
       if (workspace.value !== null && network.value !== null) {
         buttonHref.value = `./?workspace=${workspace.value}&graph=${network.value}`;
         buttonText.value = 'Go To Graph';

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -66,10 +66,10 @@ export default {
 
         <v-col
           v-if="loadError.buttonText === 'Back to MultiNet'"
-          class="grow"
+          class="grow, py-0"
         >
           <v-row>
-            <v-col>
+            <v-col class="py-0">
               <v-select
                 v-model="workspace"
                 label="Workspace"
@@ -77,7 +77,7 @@ export default {
               />
             </v-col>
 
-            <v-col>
+            <v-col class="py-0">
               <v-select
                 v-model="network"
                 label="Graph"

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -29,14 +29,17 @@ export default {
     });
 
     const buttonHref: Ref<string> = ref(loadError.value.href);
-    const buttonText: Ref<string> = ref(loadError.value.href);
+    const buttonText: Ref<string> = ref('');
     watchEffect(async () => {
       if (workspace.value !== null && network.value !== null) {
         buttonHref.value = `./?workspace=${workspace.value}&graph=${network.value}`;
         buttonText.value = 'Go To Network';
+      } else if (loadError.value.message === 'There was a network issue when getting data') {
+        buttonHref.value = loadError.value.href;
+        buttonText.value = 'Refresh the page';
       } else {
         buttonHref.value = loadError.value.href;
-        buttonText.value = loadError.value.buttonText;
+        buttonText.value = 'Back to MultiNet';
       }
     });
 
@@ -76,7 +79,7 @@ export default {
         </v-col>
 
         <v-col
-          v-if="loadError.buttonText === 'Back to MultiNet'"
+          v-if="buttonText !== 'Refresh the page'"
           class="grow, py-0"
         >
           <v-row>

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -1,0 +1,124 @@
+<script lang="ts">
+import store from '@/store';
+import {
+  computed, Ref, ref, watchEffect,
+} from '@vue/composition-api';
+import api from '@/api';
+
+export default {
+  name: 'Alert',
+
+  setup() {
+    const loadError = computed(() => store.getters.loadError);
+
+    // Vars to store the selected choices in
+    const workspace: Ref<string | null> = ref(null);
+    const network: Ref<string | null> = ref(null);
+
+    // Compute the workspace/network options
+    const workspaceOptions: Ref<string[]> = ref([]);
+    watchEffect(async () => {
+      workspaceOptions.value = await api.workspaces();
+    });
+
+    const networkOptions: Ref<string[]> = ref([]);
+    watchEffect(async () => {
+      if (workspace.value !== null) {
+        networkOptions.value = await api.graphs(workspace.value);
+      }
+    });
+
+    const buttonHref: Ref<string> = ref(loadError.value.href);
+    const buttonText: Ref<string> = ref(loadError.value.href);
+    watchEffect(async () => {
+      console.log(workspace.value, network.value);
+      if (workspace.value !== null && network.value !== null) {
+        buttonHref.value = `./?workspace=${workspace.value}&graph=${network.value}`;
+        buttonText.value = 'Go To Graph';
+      } else {
+        buttonHref.value = loadError.value.href;
+        buttonText.value = loadError.value.buttonText;
+      }
+    });
+
+    return {
+      buttonHref,
+      buttonText,
+      loadError,
+      network,
+      networkOptions,
+      workspace,
+      workspaceOptions,
+    };
+  },
+};
+</script>
+
+<template>
+  <div>
+    <v-alert
+      type="error"
+      prominent
+    >
+      <v-row align="center">
+        <v-col class="grow">
+          {{ loadError.message }}
+        </v-col>
+
+        <v-col
+          v-if="loadError.buttonText === 'Back to MultiNet'"
+          class="grow"
+        >
+          <v-row>
+            <v-col>
+              <v-select
+                v-model="workspace"
+                label="Workspace"
+                :items="workspaceOptions"
+              />
+            </v-col>
+
+            <v-col>
+              <v-select
+                v-model="network"
+                label="Graph"
+                :items="networkOptions"
+              />
+            </v-col>
+          </v-row>
+        </v-col>
+
+        <v-col class="shrink">
+          <v-btn :href="buttonHref">
+            {{ buttonText }}
+          </v-btn>
+        </v-col>
+      </v-row>
+    </v-alert>
+  </div>
+</template>
+
+<style>
+html {
+  scrollbar-width: none;
+}
+
+html::-webkit-scrollbar {
+  display: none;
+}
+
+body {
+  overflow: hidden;
+}
+
+#app {
+  font-family: "Blinker", Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  overflow: none;
+}
+
+.v-btn__content {
+  padding-bottom: 2px;
+}
+</style>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -36,7 +36,6 @@ const {
     selectedNodes: new Set(),
     loadError: {
       message: '',
-      buttonText: '',
       href: '',
     },
     simulation: null,
@@ -206,7 +205,6 @@ const {
     setLoadError(state, loadError: LoadError) {
       state.loadError = {
         message: loadError.message,
-        buttonText: loadError.buttonText,
         href: loadError.href,
       };
     },
@@ -372,26 +370,22 @@ const {
           if (workspaceName === undefined || networkName === undefined) {
             commit.setLoadError({
               message: 'Workspace and/or network were not defined in the url',
-              buttonText: 'Back to MultiNet',
               href: 'https://multinet.app',
             });
           } else {
             commit.setLoadError({
               message: error.statusText,
-              buttonText: 'Back to MultiNet',
               href: 'https://multinet.app',
             });
           }
         } else if (error.status === 401) {
           commit.setLoadError({
             message: 'You are not authorized to view this workspace',
-            buttonText: 'Back to MultiNet',
             href: 'https://multinet.app',
           });
         } else {
           commit.setLoadError({
             message: 'An unexpected error ocurred',
-            buttonText: 'Back to MultiNet',
             href: 'https://multinet.app',
           });
         }
@@ -400,7 +394,6 @@ const {
           // Catches CORS errors, issues when DB/API are down, etc.
           commit.setLoadError({
             message: 'There was a network issue when getting data',
-            buttonText: 'Refresh the page',
             href: `./?workspace=${workspaceName}&graph=${networkName}`,
           });
         }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -369,11 +369,19 @@ const {
         networkTables = await api.graph(workspaceName, networkName);
       } catch (error) {
         if (error.status === 404) {
-          commit.setLoadError({
-            message: error.statusText,
-            buttonText: 'Back to MultiNet',
-            href: 'https://multinet.app',
-          });
+          if (workspaceName === undefined || networkName === undefined) {
+            commit.setLoadError({
+              message: 'Workspace and/or network were not defined in the url',
+              buttonText: 'Back to MultiNet',
+              href: 'https://multinet.app',
+            });
+          } else {
+            commit.setLoadError({
+              message: error.statusText,
+              buttonText: 'Back to MultiNet',
+              href: 'https://multinet.app',
+            });
+          }
         } else if (error.status === 401) {
           commit.setLoadError({
             message: 'You are not authorized to view this workspace',

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -374,6 +374,12 @@ const {
             buttonText: 'Back to MultiNet',
             href: 'https://multinet.app',
           });
+        } else if (error.status === 401) {
+          commit.setLoadError({
+            message: 'You are not authorized to view this workspace',
+            buttonText: 'Back to MultiNet',
+            href: 'https://multinet.app',
+          });
         } else {
           commit.setLoadError({
             message: 'An unexpected error ocurred',

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,6 @@ export interface Cell {
 
 export interface LoadError {
   message: string;
-  buttonText: string;
   href: string;
 }
 


### PR DESCRIPTION
A partial solution to #107 (missing the AQL suggestion and the large network warnings)

Adds dropdowns to select a workspace and graph when the load fails because of a 404. We could possibly do something smarter with suggesting similar network names, but this does the simpler option -- letting the user choose.

The one question I have, is should we still offer a refresh on network error or should we show these dropdowns instead?

404 causes dropdowns:
![image](https://user-images.githubusercontent.com/36867477/109372111-096b7780-7865-11eb-814c-bfa0062d5226.png)

404 dropdowns filled gives "GO TO GRAPH":
![image](https://user-images.githubusercontent.com/36867477/109372142-40418d80-7865-11eb-9ef5-cfa03b2372fb.png)

CORS error:
![image](https://user-images.githubusercontent.com/36867477/109372123-20aa6500-7865-11eb-9219-1d2a31ea59b5.png)


TODO:
- [x] Fix vertical padding
- [x] Add text hint under the main error message with resolution advice
- [x] Check what happens on permissions issue (give message to resolve it with the workspace owner)
- [x] Add `tile` prop to un-round the corners
- [x] Change graph to network (maybe this needs to be across this app)
- [x] If workspace/graph is missing, give a gentler message