### PR TITLE
Add linkColorScale with support for numeric typed data

### DIFF
--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -8,7 +8,6 @@ import {
   scaleLinear, scaleBand, ScaleBand,
 } from 'd3-scale';
 import { axisBottom, axisLeft, axisRight } from 'd3-axis';
-import { TableMetadata } from 'multinet';
 
 import { Node, Link, Network } from '@/types';
 import store from '@/store';
@@ -86,17 +85,7 @@ export default Vue.extend({
     },
 
     columnTypes() {
-      const typeMapping: { [key: string]: string } = {};
-
-      if (store.getters.networkMetadata !== null) {
-        Object.values(store.getters.networkMetadata).forEach((metadata) => {
-          (metadata as TableMetadata).table.columns.forEach((columnType) => {
-            typeMapping[columnType.key] = columnType.type;
-          });
-        });
-      }
-
-      return typeMapping;
+      return store.getters.columnTypes;
     },
 
     cleanedNodeVariables(): Set<string> {

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import {
-  scaleLinear, ScaleLinear, scaleSequential, ScaleSequential,
+  scaleLinear, ScaleLinear,
 } from 'd3-scale';
 import {
   forceCenter, forceCollide, forceLink, forceManyBody, forceSimulation, Simulation,
@@ -13,7 +13,6 @@ import {
 } from '@/types';
 
 import ContextMenu from '@/components/ContextMenu.vue';
-import { interpolateReds } from 'd3-scale-chromatic';
 
 export default Vue.extend({
   components: {
@@ -196,18 +195,8 @@ export default Vue.extend({
         .range([10, 100]);
     },
 
-    linkColorScale(): ScaleSequential<string> {
-      let minLinkValue = 0;
-      let maxLinkValue = 1;
-
-      if (this.network !== null) {
-        const values = this.network.edges.map((link) => link[this.linkVariables.color]);
-        minLinkValue = Math.min(...values);
-        maxLinkValue = Math.max(...values);
-      }
-
-      return scaleSequential(interpolateReds)
-        .domain([minLinkValue, maxLinkValue]);
+    linkColorScale() {
+      return store.getters.linkColorScale;
     },
   },
 

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
 import Vue from 'vue';
-import { scaleLinear, ScaleLinear } from 'd3-scale';
+import {
+  scaleLinear, ScaleLinear, scaleSequential, ScaleSequential,
+} from 'd3-scale';
 import {
   forceCenter, forceCollide, forceLink, forceManyBody, forceSimulation, Simulation,
 } from 'd3-force';
@@ -11,6 +13,7 @@ import {
 } from '@/types';
 
 import ContextMenu from '@/components/ContextMenu.vue';
+import { interpolateReds } from 'd3-scale-chromatic';
 
 export default Vue.extend({
   components: {
@@ -191,6 +194,20 @@ export default Vue.extend({
       return scaleLinear()
         .domain([Math.min(...values), Math.max(...values)])
         .range([10, 100]);
+    },
+
+    linkColorScale(): ScaleSequential<string> {
+      let minLinkValue = 0;
+      let maxLinkValue = 1;
+
+      if (this.network !== null) {
+        const values = this.network.edges.map((link) => link[this.linkVariables.color]);
+        minLinkValue = Math.min(...values);
+        maxLinkValue = Math.max(...values);
+      }
+
+      return scaleSequential(interpolateReds)
+        .domain([minLinkValue, maxLinkValue]);
     },
   },
 
@@ -393,7 +410,7 @@ export default Vue.extend({
     },
 
     linkStyle(link: Link): string {
-      const linkColor = this.linkVariables.color === '' ? '#888888' : this.nodeGlyphColorScale(link[this.linkVariables.color]);
+      const linkColor = this.linkVariables.color === '' ? '#888888' : this.linkColorScale(link[this.linkVariables.color]);
       const linkWidth = this.linkVariables.width === '' ? 1 : this.linkWidthScale(link[this.linkVariables.width]);
 
       return `stroke: ${linkColor}; stroke-width: ${linkWidth}px;`;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -13,9 +13,9 @@ import {
   GraphSpec, RowsSpec, TableMetadata, TableRow,
 } from 'multinet';
 import {
-  scaleLinear, scaleOrdinal,
+  scaleLinear, scaleOrdinal, scaleSequential,
 } from 'd3-scale';
-import { schemeCategory10 } from 'd3-scale-chromatic';
+import { interpolateReds, schemeCategory10 } from 'd3-scale-chromatic';
 import { initProvenance, Provenance } from '@visdesignlab/trrack';
 import { undoRedoKeyHandler, updateProvenanceState } from '@/lib/provenanceUtils';
 
@@ -60,6 +60,7 @@ const {
     nodeBarColorScale: scaleOrdinal(schemeCategory10),
     nodeGlyphColorScale: scaleOrdinal(schemeCategory10),
     linkWidthScale: scaleLinear().range([1, 20]),
+    linkColorScale: scaleOrdinal(schemeCategory10),
     provenance: null,
     directionalEdges: false,
     controlsWidth: 256,
@@ -155,6 +156,24 @@ const {
 
     linkWidthScale(state: State) {
       return state.linkWidthScale;
+    },
+
+    linkColorScale(state: State) {
+      if (Object.keys(state.columnTypes).length > 0 && state.columnTypes[state.linkVariables.color] === 'number') {
+        let minLinkValue = 0;
+        let maxLinkValue = 1;
+
+        if (state.network !== null) {
+          const values = state.network.edges.map((link) => link[state.linkVariables.color]);
+          minLinkValue = Math.min(...values);
+          maxLinkValue = Math.max(...values);
+        }
+
+        return scaleSequential(interpolateReds)
+          .domain([minLinkValue, maxLinkValue]);
+      }
+
+      return scaleOrdinal(schemeCategory10);
     },
 
     directionalEdges(state: State) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -33,6 +33,7 @@ const {
     networkName: null,
     network: null,
     networkMetadata: null,
+    columnTypes: {},
     selectedNodes: new Set(),
     loadError: {
       message: '',
@@ -86,6 +87,10 @@ const {
 
     networkMetadata(state: State) {
       return state.networkMetadata;
+    },
+
+    columnTypes(state: State) {
+      return state.columnTypes;
     },
 
     selectedNodes(state: State) {
@@ -191,6 +196,20 @@ const {
 
     setNetworkMetadata(state, networkMetadata: NetworkMetadata) {
       state.networkMetadata = networkMetadata;
+    },
+
+    setColumnTypes(state, networkMetadata: NetworkMetadata) {
+      const typeMapping: { [key: string]: string } = {};
+
+      if (networkMetadata !== null) {
+        Object.values(networkMetadata).forEach((metadata) => {
+          (metadata as TableMetadata).table.columns.forEach((columnType) => {
+            typeMapping[columnType.key] = columnType.type;
+          });
+        });
+      }
+
+      state.columnTypes = typeMapping;
     },
 
     setSelected(state, selectedNodes: Set<string>) {
@@ -438,6 +457,7 @@ const {
       });
 
       commit.setNetworkMetadata(networkMetadata);
+      commit.setColumnTypes(networkMetadata);
     },
 
     releaseNodes(context) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,7 @@ export interface State {
   networkName: string | null;
   network: Network | null;
   networkMetadata: NetworkMetadata | null;
+  columnTypes: { [key: string]: string };
   selectedNodes: Set<string>;
   loadError: LoadError;
   displayCharts: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { Provenance } from '@visdesignlab/trrack';
 import { Simulation } from 'd3-force';
-import { ScaleLinear, ScaleOrdinal } from 'd3-scale';
+import { ScaleLinear, ScaleOrdinal, ScaleSequential } from 'd3-scale';
 import { TableRow, TableMetadata } from 'multinet';
 
 export interface Dimensions {
@@ -84,6 +84,7 @@ export interface State {
   nodeBarColorScale: ScaleOrdinal<string, string>;
   nodeGlyphColorScale: ScaleOrdinal<string, string>;
   linkWidthScale: ScaleLinear<number, number>;
+  linkColorScale: ScaleSequential<string> | ScaleOrdinal<string, string>;
   provenance: Provenance<State, ProvenanceEventTypes, unknown> | null;
   directionalEdges: boolean;
   controlsWidth: number;


### PR DESCRIPTION
Closes #57

Adds a linkColorScale that uses type information to create a color scale for the links. If the variable is numeric, we use a sequential scale. If not, we use a ordinal scale. I refactored some type getting logic from the legend to the the store, since it will be reused across components.

The lingering todo is to show a representation of the color scale in the legend, but I'm defering that until after we're done with the re-design. I'll open an issue (see #209).