### PR TITLE
Hide internal fields from label variable and from variables in the legend

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -3,7 +3,9 @@ import Vue from 'vue';
 import Legend from '@/components/Legend.vue';
 
 import store from '@/store';
-import { Node, Link, Network } from '@/types';
+import {
+  Node, Link, Network, internalFieldNames,
+} from '@/types';
 import { forceCollide, forceManyBody } from 'd3-force';
 
 export default Vue.extend({
@@ -29,9 +31,8 @@ export default Vue.extend({
         // Loop through all nodes, flatten the 2d array, and turn it into a set
         const allVars: Set<string> = new Set();
         this.graphStructure.nodes.map((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
-        allVars.delete('_id');
-        allVars.delete('_key');
-        allVars.delete('_rev');
+
+        internalFieldNames.forEach((field) => allVars.delete(field));
         allVars.delete('vx');
         allVars.delete('vy');
         allVars.delete('x');
@@ -48,11 +49,7 @@ export default Vue.extend({
         const allVars: Set<string> = new Set();
         this.graphStructure.edges.map((link: Link) => Object.keys(link).forEach((key) => allVars.add(key)));
 
-        allVars.delete('_id');
-        allVars.delete('_key');
-        allVars.delete('_from');
-        allVars.delete('_to');
-        allVars.delete('_rev');
+        internalFieldNames.forEach((field) => allVars.delete(field));
         allVars.delete('source');
         allVars.delete('target');
         allVars.delete('index');

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -125,8 +125,8 @@ export default Vue.extend({
     },
 
     autocompleteItems(): string[] {
-      if (this.network !== null) {
-        return this.network.nodes.map((node) => node[this.labelVariable]);
+      if (this.network !== null && this.labelVariable !== undefined) {
+        return this.network.nodes.map((node) => node[this.labelVariable as string]);
       }
       return [];
     },
@@ -163,9 +163,9 @@ export default Vue.extend({
 
     search() {
       const searchErrors: string[] = [];
-      if (this.network !== null) {
+      if (this.network !== null && this.labelVariable !== undefined) {
         const nodeIDsToSelect = this.network.nodes
-          .filter((node) => node[this.labelVariable] === this.searchTerm)
+          .filter((node) => node[this.labelVariable as string] === this.searchTerm)
           .map((node) => node._id);
 
         if (nodeIDsToSelect.length > 0) {
@@ -245,6 +245,7 @@ export default Vue.extend({
               label="Search for Node"
               :items="autocompleteItems"
               :error-messages="searchErrors"
+              no-data-text="Select a label variable"
               auto-select-first
             />
 

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -126,8 +126,8 @@ export default Vue.extend({
     },
 
     autocompleteItems(): string[] {
-      if (this.network !== null) {
-        return this.network.nodes.map((node) => (this.labelVariable !== undefined ? node[this.labelVariable] : ''));
+      if (this.network !== null && this.labelVariable !== undefined) {
+        return this.network.nodes.map((node) => (node[this.labelVariable || '']));
       }
       return [];
     },

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -30,6 +30,7 @@ export default Vue.extend({
         const allVars: Set<string> = new Set();
         this.graphStructure.nodes.map((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
         allVars.delete('_id');
+        allVars.delete('_key');
         allVars.delete('_rev');
         allVars.delete('vx');
         allVars.delete('vy');
@@ -48,6 +49,9 @@ export default Vue.extend({
         this.graphStructure.edges.map((link: Link) => Object.keys(link).forEach((key) => allVars.add(key)));
 
         allVars.delete('_id');
+        allVars.delete('_key');
+        allVars.delete('_from');
+        allVars.delete('_to');
         allVars.delete('_rev');
         allVars.delete('source');
         allVars.delete('target');
@@ -410,7 +414,7 @@ export default Vue.extend({
           Legend
         </v-subheader>
         <Legend
-          v-if="multiVariableList.has('_key') && networkMetadata"
+          v-if="graphStructure !== null"
           ref="legend"
           class="mt-4"
           v-bind="{

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -87,7 +87,7 @@ export default Vue.extend({
     },
 
     labelVariable: {
-      get() {
+      get(): string | undefined {
         return store.getters.labelVariable;
       },
       set(value: string) {
@@ -126,8 +126,8 @@ export default Vue.extend({
     },
 
     autocompleteItems(): string[] {
-      if (this.network !== null && this.labelVariable !== undefined) {
-        return this.network.nodes.map((node) => node[this.labelVariable as string]);
+      if (this.network !== null) {
+        return this.network.nodes.map((node) => (this.labelVariable !== undefined ? node[this.labelVariable] : ''));
       }
       return [];
     },
@@ -160,9 +160,9 @@ export default Vue.extend({
 
     search() {
       const searchErrors: string[] = [];
-      if (this.network !== null && this.labelVariable !== undefined) {
+      if (this.network !== null) {
         const nodeIDsToSelect = this.network.nodes
-          .filter((node) => node[this.labelVariable as string] === this.searchTerm)
+          .filter((node) => (this.labelVariable !== undefined ? node[this.labelVariable] === this.searchTerm : false))
           .map((node) => node._id);
 
         if (nodeIDsToSelect.length > 0) {

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -131,10 +131,6 @@ export default Vue.extend({
       }
       return [];
     },
-
-    networkMetadata() {
-      return store.getters.networkMetadata;
-    },
   },
 
   methods: {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -43,7 +43,7 @@ const {
     displayCharts: false,
     markerSize: 50,
     fontSize: 12,
-    labelVariable: '_key',
+    labelVariable: undefined,
     selectNeighbors: true,
     nestedVariables: {
       bar: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,3 +108,6 @@ export type ProvenanceEventTypes =
   'Set Node Size Variable' |
   'Set Select Neighbors'|
   'Set Directional Edges';
+
+export const internalFieldNames = ['_key', '_from', '_to', '_id', '_rev'] as const;
+export type InternalField = (typeof internalFieldNames)[number];

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,7 +72,7 @@ export interface State {
   displayCharts: boolean;
   markerSize: number;
   fontSize: number;
-  labelVariable: string;
+  labelVariable: string | undefined;
   selectNeighbors: boolean;
   nestedVariables: NestedVariables;
   linkVariables: LinkStyleVariables;

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,5 +109,5 @@ export type ProvenanceEventTypes =
   'Set Select Neighbors'|
   'Set Directional Edges';
 
-export const internalFieldNames = ['_key', '_from', '_to', '_id', '_rev'] as const;
+export const internalFieldNames = ['_from', '_to', '_id', '_rev'] as const;
 export type InternalField = (typeof internalFieldNames)[number];


### PR DESCRIPTION
Closes #207

Hides internal fields from the UI of the application by using a typescript type and checking if the string is a member. This was the most elegant way I could think to do it without duplicating lots of the strings all over the application.

This is potentially breaking in the case where the `_key` variable is being used for storing useful info (like our les_mis d3 json example). The fix would be to warn users that this using the _key for anything other than IDs is unsupported, and change the d3 json parser to set an arbitrary key variable for json networks

This uses the `as string` type assertion, which I know is not the best. I couldn't figure out a way to tell typescript that this was a string. You can see that there are checks for undefined, but that doesn't seem to be letting typescript know that it must be string. Any help here would be great.