### PR TITLE
Automatically guess a label variable

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -41,7 +41,10 @@ export default {
     store.dispatch.fetchNetwork({
       workspaceName: workspace,
       networkName: graph,
-    }).then(() => store.dispatch.createProvenance());
+    }).then(() => {
+      store.dispatch.createProvenance();
+      store.dispatch.guessLabel();
+    });
 
     // Provenance vis boolean
     const showProvenanceVis = computed(() => store.getters.showProvenanceVis);

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -30,7 +30,7 @@ export default Vue.extend({
       if (this.graphStructure !== null) {
         // Loop through all nodes, flatten the 2d array, and turn it into a set
         const allVars: Set<string> = new Set();
-        this.graphStructure.nodes.map((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
+        this.graphStructure.nodes.forEach((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
 
         internalFieldNames.forEach((field) => allVars.delete(field));
         allVars.delete('vx');

--- a/src/lib/typeUtils.ts
+++ b/src/lib/typeUtils.ts
@@ -1,0 +1,7 @@
+import { InternalField, internalFieldNames } from '@/types';
+
+// Disable no explicit any, since there are type errors for string and unknown
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isInternalField(candidate: any): candidate is InternalField {
+  return internalFieldNames.includes(candidate);
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -485,14 +485,6 @@ const {
 
       commit.setNetworkMetadata(networkMetadata);
       commit.setColumnTypes(networkMetadata);
-
-      // Guess the best label variable and set it
-      const allVars: Set<string> = new Set();
-      network.nodes.forEach((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
-
-      const bestLabelVar = [...allVars]
-        .find((colName) => !isInternalField(colName) && context.getters.columnTypes[colName] === 'label');
-      commit.setLabelVariable(bestLabelVar);
     },
 
     releaseNodes(context) {
@@ -578,6 +570,18 @@ const {
           commit.startSimulation();
         }
       }
+    },
+
+    guessLabel(context) {
+      const { commit } = rootActionContext(context);
+
+      // Guess the best label variable and set it
+      const allVars: Set<string> = new Set();
+      context.getters.network.nodes.forEach((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
+
+      const bestLabelVar = [...allVars]
+        .find((colName) => !isInternalField(colName) && context.getters.columnTypes[colName] === 'label');
+      commit.setLabelVariable(bestLabelVar);
     },
   },
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -579,9 +579,13 @@ const {
       const allVars: Set<string> = new Set();
       context.getters.network.nodes.forEach((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
 
+      // Remove _key from the search
+      allVars.delete('_key');
       const bestLabelVar = [...allVars]
         .find((colName) => !isInternalField(colName) && context.getters.columnTypes[colName] === 'label');
-      commit.setLabelVariable(bestLabelVar);
+
+      // Use the label variable we found or _key if we didn't find one
+      commit.setLabelVariable(bestLabelVar || '_key');
     },
   },
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -488,7 +488,7 @@ const {
 
       // Guess the best label variable and set it
       const allVars: Set<string> = new Set();
-      network.nodes.map((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
+      network.nodes.forEach((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
 
       const bestLabelVar = [...allVars]
         .find((colName) => !isInternalField(colName) && context.getters.columnTypes[colName] === 'label');

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -18,6 +18,7 @@ import {
 import { interpolateReds, schemeCategory10 } from 'd3-scale-chromatic';
 import { initProvenance, Provenance } from '@visdesignlab/trrack';
 import { undoRedoKeyHandler, updateProvenanceState } from '@/lib/provenanceUtils';
+import { isInternalField } from '@/lib/typeUtils';
 
 Vue.use(Vuex);
 
@@ -307,7 +308,7 @@ const {
       }
     },
 
-    setLabelVariable(state, labelVariable: string) {
+    setLabelVariable(state, labelVariable: string | undefined) {
       state.labelVariable = labelVariable;
 
       if (state.provenance !== null) {
@@ -484,6 +485,14 @@ const {
 
       commit.setNetworkMetadata(networkMetadata);
       commit.setColumnTypes(networkMetadata);
+
+      // Guess the best label variable and set it
+      const allVars: Set<string> = new Set();
+      network.nodes.map((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
+
+      const bestLabelVar = [...allVars]
+        .find((colName) => !isInternalField(colName) && context.getters.columnTypes[colName] === 'label');
+      commit.setLabelVariable(bestLabelVar);
     },
 
     releaseNodes(context) {


### PR DESCRIPTION
Depends on #213 

After removing `_key` from the options for label variable, it makes sense to try and guess a label variable for the dataset using the type information that we have available. To do so, I added another call to the end of the `fetchNetwork` function that sets a label variable based on the first variable of type label that it finds.

I'm not sure if this is the right place for the function, though, since it's not related to fetching the network. It's a bit of post processing once we have the data. Maybe it should live in App.vue after the fetchNetwork call happens. I'm open to suggestions