### PR TITLE
Rename graph to network accross the codebase

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -22,15 +22,11 @@ export default Vue.extend({
   },
 
   computed: {
-    graphStructure() {
-      return store.getters.network;
-    },
-
     multiVariableList(): Set<string | null> {
-      if (this.graphStructure !== null) {
+      if (this.network !== null) {
         // Loop through all nodes, flatten the 2d array, and turn it into a set
         const allVars: Set<string> = new Set();
-        this.graphStructure.nodes.map((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
+        this.network.nodes.map((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
 
         internalFieldNames.forEach((field) => allVars.delete(field));
         allVars.delete('vx');
@@ -44,10 +40,10 @@ export default Vue.extend({
     },
 
     linkVariableList(): Set<string | null> {
-      if (this.graphStructure !== null) {
+      if (this.network !== null) {
         // Loop through all links, flatten the 2d array, and turn it into a set
         const allVars: Set<string> = new Set();
-        this.graphStructure.edges.map((link: Link) => Object.keys(link).forEach((key) => allVars.add(key)));
+        this.network.edges.map((link: Link) => Object.keys(link).forEach((key) => allVars.add(key)));
 
         internalFieldNames.forEach((field) => allVars.delete(field));
         allVars.delete('source');
@@ -146,15 +142,15 @@ export default Vue.extend({
       store.dispatch.releaseNodes();
     },
 
-    exportGraph() {
+    exportNetwork() {
       const a = document.createElement('a');
       a.href = URL.createObjectURL(
         new Blob(
-          [JSON.stringify(this.graphStructure)],
+          [JSON.stringify(this.network)],
           { type: 'text/json' },
         ),
       );
-      a.download = `${store.getters.networkName || 'unknown_graph'}.json`;
+      a.download = `${store.getters.networkName || 'unknown_network'}.json`;
       a.click();
     },
 
@@ -385,9 +381,9 @@ export default Vue.extend({
               class="ml-0"
               color="grey darken-3 white--text"
               depressed
-              @click="exportGraph"
+              @click="exportNetwork"
             >
-              Export Graph
+              Export Network
             </v-btn>
           </v-list-item>
 
@@ -407,11 +403,11 @@ export default Vue.extend({
           Legend
         </v-subheader>
         <Legend
-          v-if="graphStructure !== null"
+          v-if="network !== null"
           ref="legend"
           class="mt-4"
           v-bind="{
-            graphStructure,
+            network,
             multiVariableList,
             linkVariableList,
           }"

--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -14,7 +14,7 @@ import store from '@/store';
 
 export default Vue.extend({
   props: {
-    graphStructure: {
+    network: {
       type: Object as PropType<Network | null>,
       default: null,
     },
@@ -49,12 +49,12 @@ export default Vue.extend({
   computed: {
     properties() {
       const {
-        graphStructure,
+        network,
         multiVariableList,
         linkVariableList,
       } = this;
       return {
-        graphStructure,
+        network,
         multiVariableList,
         linkVariableList,
       };
@@ -126,7 +126,7 @@ export default Vue.extend({
             .width - this.yAxisPadding - this.varPadding;
 
           // Get the data and generate the bins
-          if (this.graphStructure === null) {
+          if (this.network === null) {
             return;
           }
 
@@ -136,9 +136,9 @@ export default Vue.extend({
           // Process data for bars/histogram
           if (this.isQuantitative(attr, type)) {
             if (type === 'node') {
-              currentData = this.graphStructure.nodes.map((d: Node | Link) => parseFloat(d[attr]));
+              currentData = this.network.nodes.map((d: Node | Link) => parseFloat(d[attr]));
             } else {
-              currentData = this.graphStructure.edges.map((d: Node | Link) => parseFloat(d[attr]));
+              currentData = this.network.edges.map((d: Node | Link) => parseFloat(d[attr]));
             }
 
             const xScale = scaleLinear()
@@ -187,9 +187,9 @@ export default Vue.extend({
               .call(axisBottom(xScale).ticks(4, 's'));
           } else {
             if (type === 'node') {
-              currentData = this.graphStructure.nodes.map((d: Node | Link) => d[attr]).sort();
+              currentData = this.network.nodes.map((d: Node | Link) => d[attr]).sort();
             } else {
-              currentData = this.graphStructure.edges.map((d: Node | Link) => d[attr]).sort();
+              currentData = this.network.edges.map((d: Node | Link) => d[attr]).sort();
             }
 
             const bins = new Map([...new Set(currentData)].map(
@@ -252,8 +252,8 @@ export default Vue.extend({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let nodesOrLinks: any[];
 
-      if (this.graphStructure !== null) {
-        nodesOrLinks = type === 'node' ? this.graphStructure.nodes : this.graphStructure.edges;
+      if (this.network !== null) {
+        nodesOrLinks = type === 'node' ? this.network.nodes : this.network.edges;
         const uniqueValues = [...new Set(nodesOrLinks.map((element) => parseFloat(element[varName])))];
         return uniqueValues.length > 5;
       }

--- a/src/lib/typeUtils.ts
+++ b/src/lib/typeUtils.ts
@@ -1,0 +1,7 @@
+import { InternalField, internalFieldNames } from '@/types';
+
+// Disable no explicit any, since there are type errors for string and unknown
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isInternalField(candidate: any): candidate is InternalField {
+  return internalFieldNames.includes(candidate);
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -18,6 +18,7 @@ import {
 import { interpolateReds, schemeCategory10 } from 'd3-scale-chromatic';
 import { initProvenance, Provenance } from '@visdesignlab/trrack';
 import { undoRedoKeyHandler, updateProvenanceState } from '@/lib/provenanceUtils';
+import { isInternalField } from '@/lib/typeUtils';
 
 Vue.use(Vuex);
 
@@ -307,7 +308,7 @@ const {
       }
     },
 
-    setLabelVariable(state, labelVariable: string) {
+    setLabelVariable(state, labelVariable: string | undefined) {
       state.labelVariable = labelVariable;
 
       if (state.provenance !== null) {
@@ -484,6 +485,14 @@ const {
 
       commit.setNetworkMetadata(networkMetadata);
       commit.setColumnTypes(networkMetadata);
+
+      // Guess the best label variable and set it
+      const allVars: Set<string> = new Set();
+      network.nodes.map((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
+
+      const bestLabelVar = [...allVars]
+        .find((colName) => !isInternalField(colName) && context.getters.columnTypes[colName] === 'label');
+      commit.setLabelVariable(bestLabelVar);
     },
 
     releaseNodes(context) {

--- a/tests/unit/nodelink.spec.js
+++ b/tests/unit/nodelink.spec.js
@@ -12,7 +12,7 @@ describe('Node-Link Utils', () => {
     beforeEach(() => {
       wrapper = mount(MultiLink, {
         propsData: {
-          graphStructure: { nodes: [], links: [{ source: { x: 100, y: 150 }, target: { x: 400, y: 450 } }] },
+          network: { nodes: [], links: [{ source: { x: 100, y: 150 }, target: { x: 400, y: 450 } }] },
           app: App,
         },
       });
@@ -29,7 +29,7 @@ describe('Node-Link Utils', () => {
     it('A straight arc returns the expected path', () => {
       // Arrange
       wrapper.vm.straightEdges = true;
-      const link = wrapper.vm.graphStructure.links[0];
+      const link = wrapper.vm.network.links[0];
 
       // Act
       const arc = wrapper.vm.arcPath(true, link, false);
@@ -41,7 +41,7 @@ describe('Node-Link Utils', () => {
     it('A curved arc returns the expected path', () => {
       // Arrange
       wrapper.vm.straightEdges = false;
-      const link = wrapper.vm.graphStructure.links[0];
+      const link = wrapper.vm.network.links[0];
       const dx = link.source.x - link.target.x;
       const dy = link.source.y - link.target.y;
       const dr = Math.sqrt(dx * dx + dy * dy);


### PR DESCRIPTION
Depends on #214 

This renames all instances of graph to network, aside from in a few key places:

- querystring (#226)
- `multinetjs` calls and types (https://github.com/multinet-app/multinetjs/issues/34)

I'll make issues to track these remaining places or link the existing ones.