### PR TITLE
Disable no-param-reassign for updateProvenanceState function

### DIFF
--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -4,8 +4,7 @@ import { createAction } from '@visdesignlab/trrack';
 export function updateProvenanceState(vuexState: State, label: ProvenanceEventTypes) {
   /* eslint-disable no-param-reassign */
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const stateUpdateActions = createAction<State, any[], ProvenanceEventTypes>((provState, newProvState) => {
+  const stateUpdateActions = createAction<State, State[], ProvenanceEventTypes>((provState, newProvState) => {
     if (label === 'Select Node(s)' || label === 'De-select Node' || label === 'Clear Selection') {
       // TODO: #148 remove cast back to set
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -2,37 +2,33 @@ import { ProvenanceEventTypes, State } from '@/types';
 import { createAction } from '@visdesignlab/trrack';
 
 export function updateProvenanceState(vuexState: State, label: ProvenanceEventTypes) {
+  /* eslint-disable no-param-reassign */
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const stateUpdateActions = createAction<State, any[], ProvenanceEventTypes>((provState, newProvState) => {
     if (label === 'Select Node(s)' || label === 'De-select Node' || label === 'Clear Selection') {
       // TODO: #148 remove cast back to set
-      // eslint-disable-next-line no-param-reassign, @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       provState.selectedNodes = [...newProvState.selectedNodes] as any;
     } else if (label === 'Set Display Charts') {
-      // eslint-disable-next-line no-param-reassign
       provState.displayCharts = newProvState.displayCharts;
     } else if (label === 'Set Marker Size') {
-      // eslint-disable-next-line no-param-reassign
       provState.markerSize = newProvState.markerSize;
     } else if (label === 'Set Font Size') {
-      // eslint-disable-next-line no-param-reassign
       provState.fontSize = newProvState.fontSize;
     } else if (label === 'Set Label Variable') {
-      // eslint-disable-next-line no-param-reassign
       provState.labelVariable = newProvState.labelVariable;
     } else if (label === 'Set Node Color Variable') {
-      // eslint-disable-next-line no-param-reassign
       provState.nodeColorVariable = newProvState.nodeColorVariable;
     } else if (label === 'Set Node Size Variable') {
-      // eslint-disable-next-line no-param-reassign
       provState.nodeSizeVariable = newProvState.nodeSizeVariable;
     } else if (label === 'Set Select Neighbors') {
-      // eslint-disable-next-line no-param-reassign
       provState.selectNeighbors = newProvState.selectNeighbors;
     } else if (label === 'Set Directional Edges') {
-      // eslint-disable-next-line no-param-reassign
       provState.directionalEdges = newProvState.directionalEdges;
     }
+
+    /* eslint-enable no-param-reassign */
   })
     .setLabel(label);
 


### PR DESCRIPTION
This is a small update that reduces some of the needed syntax in the `updateProvenanceState` function block. I think this is more elegant and readable than doing it for every line