### PR TITLE
Track all variables that set forces in the store/provenance, update forces on provenance change

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -8,7 +8,7 @@ import store from '@/store';
 import {
   Node, Link, Network, internalFieldNames,
 } from '@/types';
-import { forceCollide, forceManyBody } from 'd3-force';
+import { forceCollide } from 'd3-force';
 
 export default Vue.extend({
   components: {
@@ -21,7 +21,6 @@ export default Vue.extend({
     return {
       searchTerm: '' as string,
       searchErrors: [] as string[],
-      linkLength: '50',
       showTabs: false,
       tab: undefined,
     };
@@ -115,6 +114,15 @@ export default Vue.extend({
       },
     },
 
+    linkLength: {
+      get() {
+        return store.getters.linkLength;
+      },
+      set(value: number) {
+        store.commit.setLinkLength({ linkLength: value, updateProv: false });
+      },
+    },
+
     controlsWidth(): number {
       return store.getters.controlsWidth;
     },
@@ -184,10 +192,7 @@ export default Vue.extend({
       } else if (type === 'fontSize') {
         store.commit.setFontSize({ fontSize: value, updateProv: true });
       } else if (type === 'linkLength') {
-        // Scale value to between -500, 0
-        const newLinkLength = (value * -5);
-
-        store.dispatch.updateSimulationForce({ forceType: 'charge', forceValue: forceManyBody<Node>().strength(newLinkLength), restart: true });
+        store.commit.setLinkLength({ linkLength: value, updateProv: true });
       }
     },
 

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -8,7 +8,6 @@ import store from '@/store';
 import {
   Node, Link, Network, internalFieldNames,
 } from '@/types';
-import { forceCollide } from 'd3-force';
 
 export default Vue.extend({
   components: {
@@ -188,7 +187,6 @@ export default Vue.extend({
     updateSliderProv(value: number, type: 'markerSize' | 'fontSize' | 'linkLength') {
       if (type === 'markerSize') {
         store.commit.setMarkerSize({ markerSize: value, updateProv: true });
-        store.dispatch.updateSimulationForce({ forceType: 'collision', forceValue: forceCollide((this.markerSize / 2) * 1.5), restart: true });
       } else if (type === 'fontSize') {
         store.commit.setFontSize({ fontSize: value, updateProv: true });
       } else if (type === 'linkLength') {

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -13,6 +13,7 @@ import {
 } from '@/types';
 
 import ContextMenu from '@/components/ContextMenu.vue';
+import { applyForceToSimulation } from '@/lib/d3ForceUtils';
 
 export default Vue.extend({
   components: {
@@ -170,7 +171,12 @@ export default Vue.extend({
       const { height } = this.$vuetify.breakpoint;
       const width = this.$vuetify.breakpoint.width - this.controlsWidth;
 
-      store.dispatch.updateSimulationForce({ forceType: 'center', forceValue: forceCenter<Node>(width / 2, height / 2), restart: false });
+      applyForceToSimulation(
+        store.getters.simulation,
+        'center',
+        forceCenter<Node>(width / 2, height / 2),
+      );
+      store.commit.startSimulation();
 
       return {
         height,

--- a/src/lib/d3ForceUtils.ts
+++ b/src/lib/d3ForceUtils.ts
@@ -1,0 +1,16 @@
+import { Node, SimulationLink } from '@/types';
+import {
+  ForceCenter, ForceManyBody, ForceLink, ForceCollide, Simulation,
+} from 'd3-force';
+
+export function applyForceToSimulation(
+  simulation: Simulation<Node, SimulationLink> | null,
+  forceType: 'center' | 'charge' | 'link' | 'collision',
+  forceValue: ForceCenter<Node> | ForceManyBody<Node> | ForceLink<Node, SimulationLink> | ForceCollide<Node>,
+) {
+  if (simulation === null) {
+    return;
+  }
+
+  simulation.force(forceType, forceValue);
+}

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -25,6 +25,9 @@ export function updateProvenanceState(vuexState: State, label: ProvenanceEventTy
       provState.selectNeighbors = newProvState.selectNeighbors;
     } else if (label === 'Set Directional Edges') {
       provState.directionalEdges = newProvState.directionalEdges;
+    } else if (label === 'Set Link Length') {
+      // eslint-disable-next-line no-param-reassign
+      provState.linkLength = newProvState.linkLength;
     }
 
     /* eslint-enable no-param-reassign */

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -26,7 +26,6 @@ export function updateProvenanceState(vuexState: State, label: ProvenanceEventTy
     } else if (label === 'Set Directional Edges') {
       provState.directionalEdges = newProvState.directionalEdges;
     } else if (label === 'Set Link Length') {
-      // eslint-disable-next-line no-param-reassign
       provState.linkLength = newProvState.linkLength;
     }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -72,6 +72,7 @@ const {
       left: 0,
     },
     userInfo: null,
+    linkLength: 50,
   } as State,
 
   getters: {
@@ -179,6 +180,10 @@ const {
 
     directionalEdges(state: State) {
       return state.directionalEdges;
+    },
+
+    linkLength(state: State) {
+      return state.linkLength;
     },
 
     controlsWidth(state: State) {
@@ -381,6 +386,15 @@ const {
 
       if (state.provenance !== null) {
         updateProvenanceState(state, 'Set Directional Edges');
+      }
+    },
+
+    setLinkLength(state, payload: { linkLength: number; updateProv: boolean }) {
+      const { linkLength, updateProv } = payload;
+      state.linkLength = linkLength;
+
+      if (state.provenance !== null && updateProv) {
+        updateProvenanceState(state, 'Set Link Length');
       }
     },
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,8 +1,8 @@
 import Vue from 'vue';
-import Vuex, { Store } from 'vuex';
+import Vuex from 'vuex';
 import { createDirectStore } from 'direct-vuex';
 import {
-  ForceCenter, ForceCollide, ForceLink, ForceManyBody, Simulation,
+  forceCollide, forceManyBody, Simulation,
 } from 'd3-force';
 
 import {
@@ -19,6 +19,7 @@ import { interpolateReds, schemeCategory10 } from 'd3-scale-chromatic';
 import { initProvenance, Provenance } from '@visdesignlab/trrack';
 import { undoRedoKeyHandler, updateProvenanceState } from '@/lib/provenanceUtils';
 import { isInternalField } from '@/lib/typeUtils';
+import { applyForceToSimulation } from '@/lib/d3ForceUtils';
 
 Vue.use(Vuex);
 
@@ -303,9 +304,18 @@ const {
     },
 
     setMarkerSize(state, payload: { markerSize: number; updateProv: boolean }) {
-      state.markerSize = payload.markerSize;
+      const { markerSize, updateProv } = payload;
+      state.markerSize = markerSize;
 
-      if (state.provenance !== null && payload.updateProv) {
+      // Apply force to simulation and restart it
+      applyForceToSimulation(
+        state.simulation,
+        'collision',
+        forceCollide((markerSize / 2) * 1.5),
+      );
+      store.commit.startSimulation();
+
+      if (state.provenance !== null && updateProv) {
         updateProvenanceState(state, 'Set Marker Size');
       }
     },
@@ -392,6 +402,17 @@ const {
     setLinkLength(state, payload: { linkLength: number; updateProv: boolean }) {
       const { linkLength, updateProv } = payload;
       state.linkLength = linkLength;
+
+      // Scale value to between -500, 0 for d3
+      const linkLengthForce = (linkLength * -5);
+
+      // Apply force to simulation and restart it
+      applyForceToSimulation(
+        state.simulation,
+        'charge',
+        forceManyBody<Node>().strength(linkLengthForce),
+      );
+      store.commit.startSimulation();
 
       if (state.provenance !== null && updateProv) {
         updateProvenanceState(state, 'Set Link Length');
@@ -590,7 +611,9 @@ const {
             'directionalEdges',
             'linkLength',
           ].forEach((primitiveVariable) => {
-            if (primitiveVariable === 'linkLength') {
+            if (primitiveVariable === 'markerSize') {
+              commit.setMarkerSize({ markerSize: provenanceState[primitiveVariable], updateProv: false });
+            } else if (primitiveVariable === 'linkLength') {
               commit.setLinkLength({ linkLength: provenanceState[primitiveVariable], updateProv: false });
             } else if (storeState[primitiveVariable] !== provenanceState[primitiveVariable]) {
               storeState[primitiveVariable] = provenanceState[primitiveVariable];
@@ -603,22 +626,6 @@ const {
 
       // Add keydown listener for undo/redo
       document.addEventListener('keydown', (event) => undoRedoKeyHandler(event, storeState));
-    },
-
-    updateSimulationForce(context, payload: {
-      forceType: 'center' | 'charge' | 'link' | 'collision';
-      forceValue: ForceCenter<Node> | ForceManyBody<Node> | ForceLink<Node, SimulationLink> | ForceCollide<Node>;
-      restart: boolean;
-    }) {
-      const { commit } = rootActionContext(context);
-      if (context.state.simulation !== null) {
-        const { forceType, forceValue, restart } = payload;
-        context.state.simulation.force(forceType, forceValue);
-
-        if (restart) {
-          commit.startSimulation();
-        }
-      }
     },
 
     guessLabel(context) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -588,8 +588,11 @@ const {
             'nodeColorVariable',
             'selectNeighbors',
             'directionalEdges',
+            'linkLength',
           ].forEach((primitiveVariable) => {
-            if (storeState[primitiveVariable] !== provenanceState[primitiveVariable]) {
+            if (primitiveVariable === 'linkLength') {
+              commit.setLinkLength({ linkLength: provenanceState[primitiveVariable], updateProv: false });
+            } else if (storeState[primitiveVariable] !== provenanceState[primitiveVariable]) {
               storeState[primitiveVariable] = provenanceState[primitiveVariable];
             }
           });

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,7 +109,8 @@ export type ProvenanceEventTypes =
   'Set Node Color Variable' |
   'Set Node Size Variable' |
   'Set Select Neighbors'|
-  'Set Directional Edges';
+  'Set Directional Edges' |
+  'Set Link Length';
 
 export const internalFieldNames = ['_from', '_to', '_id', '_rev'] as const;
 export type InternalField = (typeof internalFieldNames)[number];

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,7 @@ export interface State {
     left: number;
   };
   userInfo: UserSpec | null;
+  linkLength: number;
 }
 
 export type ProvenanceEventTypes =


### PR DESCRIPTION
Closes #193

This PR adds support for tracking all variables that modify forces in the store and in the provenance. This gives users the ability to undo and redo the changes to the forces.

This PR does not track the forces that trigger on a window resize, since those shouldn't be undone and could cause problems with the simulation if they are reverted.

I noticed as I was making this PR that I'd need some common logic for applying the functions so I added that to a utils file and I just reference it where I need it. The function replaces another action function from the store, which would apply the forces. I'm not certain this was necessary, but it seemed a bit cleaner to me. You'll have to let me know your thoughts. 

*NOTE*: We had discussed an approach I was taking in the stand up on 3/30 where I outlined that all these parameters would be tracked in another object and then updated/restored by the provenance library. I have that code on a local branch and can share it, but it adds significant complexity and it would require some debugging with the trrack team. This branch seems like a much cleaner way to add this feature. Ping me if you'd like to see the alternative approach.

Video below:
https://user-images.githubusercontent.com/36867477/113050338-f3055400-9161-11eb-96ee-6ac3e7d4c962.mp4