### PR TITLE
Add logic to layout nodes by numeric attributes

### DIFF
--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -7,25 +7,10 @@ export default {
     const rightClickMenu = computed(() => store.getters.rightClickMenu);
     const selectedNodes = computed(() => store.getters.selectedNodes);
     const network = computed(() => store.getters.network);
-    const numericVariables = computed(() => {
-      const numericColumns = Object.entries(store.getters.columnTypes)
-        .map(([key, value]) => (value === 'number' ? key : ''));
-
-      const numericColumnsSet = new Set(numericColumns);
-      numericColumnsSet.delete('');
-
-      numericColumnsSet.forEach((column) => {
-        if (
-          store.getters.network !== null
-          && store.getters.network.nodes[0] !== null
-          && store.getters.network.nodes[0][column] === undefined
-        ) {
-          numericColumnsSet.delete(column);
-        }
-      });
-
-      return [...numericColumnsSet].sort();
-    });
+    const numericVariables = computed(() => Object.entries(store.getters.columnTypes)
+      .filter(([, value]) => value === 'number')
+      .map(([key]) => key)
+      .sort());
 
     function clearSelection() {
       store.commit.setSelected(new Set());
@@ -140,7 +125,7 @@ export default {
                 v-bind="attrs"
                 v-on="on"
               >
-                Layout By
+                Lay Out By
                 <v-icon
                   dense
                   right

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -13,6 +13,17 @@ export default {
 
       const numericColumnsSet = new Set(numericColumns);
       numericColumnsSet.delete('');
+
+      numericColumnsSet.forEach((column) => {
+        if (
+          store.getters.network !== null
+          && store.getters.network.nodes[0] !== null
+          && store.getters.network.nodes[0][column] === undefined
+        ) {
+          numericColumnsSet.delete(column);
+        }
+      });
+
       return [...numericColumnsSet].sort();
     });
 

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -10,6 +10,12 @@ export default {
     const numericVariables = computed(() => Object.entries(store.getters.columnTypes)
       .filter(([, value]) => value === 'number')
       .map(([key]) => key)
+      .filter((key) => {
+        if (network.value !== null) {
+          return network.value.nodes[0][key] !== undefined;
+        }
+        return true;
+      })
       .sort());
 
     function clearSelection() {

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -157,16 +157,19 @@ export default {
                 <v-list-item-content>
                   <v-menu
                     offset-x
+                    :disabled="numericVariables.length === 0"
                   >
                     <template #activator="{ on, attrs }">
                       <v-list-item-title
                         v-bind="attrs"
+                        :class="numericVariables.length === 0 ? 'grey--text text--lighten-1' : ''"
                         v-on="on"
                       >
                         Numerical Variable
                         <v-icon
                           dense
                           right
+                          :color="numericVariables.length === 0 ? 'grey lighten-1' : ''"
                         >
                           mdi-chevron-right
                         </v-icon>

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import store from '@/store';
-import { computed } from '@vue/composition-api';
+import { computed, ref, watchEffect } from '@vue/composition-api';
 
 export default {
   setup() {
@@ -46,12 +46,35 @@ export default {
       }
     }
 
+    // Track whether the layout has been applied before, reset when simulation starts again
+    // If so, we won't want to reset the "other axis" to a constant value
+    const firstLayout = ref(true);
+    watchEffect(() => {
+      if (store.getters.simulationRunning && !firstLayout.value) {
+        firstLayout.value = true;
+      }
+    });
+
+    function changeLayout(numVar: string, axis: 'x' | 'y') {
+      // Close the menu
+      store.commit.updateRightClickMenu({
+        show: false,
+        top: rightClickMenu.value.top,
+        left: rightClickMenu.value.left,
+      });
+
+      store.commit.applyNumericLayout({ varName: numVar, axis, firstLayout: firstLayout.value });
+
+      firstLayout.value = false;
+    }
+
     return {
       rightClickMenu,
       numericVariables,
       clearSelection,
       pinSelectedNodes,
       unPinSelectedNodes,
+      changeLayout,
     };
   },
 };

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -7,6 +7,14 @@ export default {
     const rightClickMenu = computed(() => store.getters.rightClickMenu);
     const selectedNodes = computed(() => store.getters.selectedNodes);
     const network = computed(() => store.getters.network);
+    const numericVariables = computed(() => {
+      const numericColumns = Object.entries(store.getters.columnTypes)
+        .map(([key, value]) => (value === 'number' ? key : ''));
+
+      const numericColumnsSet = new Set(numericColumns);
+      numericColumnsSet.delete('');
+      return [...numericColumnsSet].sort();
+    });
 
     function clearSelection() {
       store.commit.setSelected(new Set());
@@ -40,6 +48,7 @@ export default {
 
     return {
       rightClickMenu,
+      numericVariables,
       clearSelection,
       pinSelectedNodes,
       unPinSelectedNodes,
@@ -83,6 +92,140 @@ export default {
           <v-list-item-content>
             <v-list-item-title>Un-Pin Selected Nodes</v-list-item-title>
           </v-list-item-content>
+        </v-list-item>
+
+        <v-list-item
+          dense
+        >
+          <v-menu
+            allow-overflow
+            offset-x
+          >
+            <template #activator="{ on, attrs }">
+              <v-list-item-title
+                v-bind="attrs"
+                v-on="on"
+              >
+                Layout By
+                <v-icon
+                  dense
+                  right
+                >
+                  mdi-chevron-right
+                </v-icon>
+              </v-list-item-title>
+            </template>
+
+            <v-list>
+              <v-list-item
+                dense
+              >
+                <v-list-item-content>
+                  <v-menu
+                    offset-x
+                  >
+                    <template #activator="{ on, attrs }">
+                      <v-list-item-title
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        Numerical Variable
+                        <v-icon
+                          dense
+                          right
+                        >
+                          mdi-chevron-right
+                        </v-icon>
+                      </v-list-item-title>
+                    </template>
+
+                    <v-list>
+                      <v-list-item
+                        v-for="numVar in numericVariables"
+                        :key="numVar"
+                        dense
+                      >
+                        <v-list-item-content>
+                          <v-menu
+                            offset-x
+                          >
+                            <template #activator="{ on, attrs }">
+                              <v-list-item-title
+                                v-bind="attrs"
+                                v-on="on"
+                              >
+                                {{ numVar }}
+                                <v-icon
+                                  dense
+                                  right
+                                >
+                                  mdi-chevron-right
+                                </v-icon>
+                              </v-list-item-title>
+                            </template>
+
+                            <v-list>
+                              <v-list-item
+                                dense
+                                @click="changeLayout(numVar, 'x')"
+                              >
+                                <v-list-item-content>
+                                  <v-list-item-title>
+                                    X-axis
+                                  </v-list-item-title>
+                                </v-list-item-content>
+                              </v-list-item>
+
+                              <v-list-item
+                                dense
+                                @click="changeLayout(numVar, 'y')"
+                              >
+                                <v-list-item-content>
+                                  <v-list-item-title>
+                                    Y-axis
+                                  </v-list-item-title>
+                                </v-list-item-content>
+                              </v-list-item>
+                            </v-list>
+                          </v-menu>
+                        </v-list-item-content>
+                      </v-list-item>
+                    </v-list>
+                  </v-menu>
+                </v-list-item-content>
+              </v-list-item>
+
+              <v-list-item
+                dense
+              >
+                <v-list-item-content>
+                  <v-menu
+                    disabled
+                    offset-x
+                  >
+                    <template #activator="{ on, attrs }">
+                      <v-list-item-title
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        Categorical Variable
+                        <v-icon
+                          dense
+                          right
+                        >
+                          mdi-chevron-right
+                        </v-icon>
+                      </v-list-item-title>
+                    </template>
+
+                    <v-list>
+                      This is where the categorical vars go
+                    </v-list>
+                  </v-menu>
+                </v-list-item-content>
+              </v-list-item>
+            </v-list>
+          </v-menu>
         </v-list-item>
       </v-list>
     </v-menu>

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -178,10 +178,14 @@ export default Vue.extend({
       );
       store.commit.startSimulation();
 
-      return {
+      const dimensions = {
         height,
         width,
       };
+
+      store.commit.setSvgDimensions(dimensions);
+
+      return dimensions;
     },
 
     directionalEdges() {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -460,12 +460,16 @@ const {
         state.network.nodes.forEach((node) => {
           // eslint-disable-next-line no-param-reassign
           node[axis] = positionScale(node[varName]);
+          // eslint-disable-next-line no-param-reassign
+          node[`f${axis}`] = positionScale(node[varName]);
 
           if (firstLayout) {
             const otherAxis = axis === 'x' ? 'y' : 'x';
             const otherSvgDimension = axis === 'x' ? state.svgDimensions.height : state.svgDimensions.width;
             // eslint-disable-next-line no-param-reassign
             node[otherAxis] = otherSvgDimension / 2;
+            // eslint-disable-next-line no-param-reassign
+            node[`f${otherAxis}`] = otherSvgDimension / 2;
           }
         });
       }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -441,6 +441,36 @@ const {
       state.userInfo = userInfo;
     },
 
+    applyNumericLayout(state: State, payload: { varName: string; axis: 'x' | 'y'; firstLayout: boolean }) {
+      store.commit.stopSimulation();
+
+      if (state.network !== null) {
+        const { varName, axis, firstLayout } = payload;
+        const range = state.attributeRanges[varName];
+        const positionScale = scaleLinear()
+          .domain([range.min, range.max])
+          .range([0, axis === 'x' ? state.svgDimensions.width : state.svgDimensions.height]);
+
+        state.network.nodes.forEach((node) => {
+          // eslint-disable-next-line no-param-reassign
+          node[axis] = positionScale(node[varName]);
+
+          if (firstLayout) {
+            const otherAxis = axis === 'x' ? 'y' : 'x';
+            const otherSvgDimension = axis === 'x' ? state.svgDimensions.height : state.svgDimensions.width;
+            // eslint-disable-next-line no-param-reassign
+            node[otherAxis] = otherSvgDimension / 2;
+          }
+        });
+
+        // Set node size smaller
+        store.commit.setMarkerSize({ markerSize: 10, updateProv: true });
+
+        // Clear the label variable
+        store.commit.setLabelVariable('');
+      }
+    },
+
     setSvgDimensions(state: State, payload: Dimensions) {
       state.svgDimensions = payload;
     },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -6,7 +6,7 @@ import {
 } from 'd3-force';
 
 import {
-  Link, Node, Network, NetworkMetadata, SimulationLink, State, LinkStyleVariables, LoadError, NestedVariables, ProvenanceEventTypes,
+  Link, Node, Network, NetworkMetadata, SimulationLink, State, LinkStyleVariables, LoadError, NestedVariables, ProvenanceEventTypes, Dimensions,
 } from '@/types';
 import api from '@/api';
 import {
@@ -74,6 +74,10 @@ const {
     },
     userInfo: null,
     linkLength: 50,
+    svgDimensions: {
+      height: 0,
+      width: 0,
+    },
   } as State,
 
   getters: {
@@ -435,6 +439,10 @@ const {
 
     setUserInfo(state, userInfo: UserSpec | null) {
       state.userInfo = userInfo;
+    },
+
+    setSvgDimensions(state: State, payload: Dimensions) {
+      state.svgDimensions = payload;
     },
   },
   actions: {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -442,6 +442,12 @@ const {
     },
 
     applyNumericLayout(state: State, payload: { varName: string; axis: 'x' | 'y'; firstLayout: boolean }) {
+      // Set node size smaller
+      store.commit.setMarkerSize({ markerSize: 10, updateProv: true });
+
+      // Clear the label variable
+      store.commit.setLabelVariable(undefined);
+
       store.commit.stopSimulation();
 
       if (state.network !== null) {
@@ -462,12 +468,6 @@ const {
             node[otherAxis] = otherSvgDimension / 2;
           }
         });
-
-        // Set node size smaller
-        store.commit.setMarkerSize({ markerSize: 10, updateProv: true });
-
-        // Clear the label variable
-        store.commit.setLabelVariable('');
       }
     },
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -457,7 +457,8 @@ const {
           .domain([range.min, range.max])
           .range([0, axis === 'x' ? state.svgDimensions.width : state.svgDimensions.height]);
 
-        state.network.nodes.forEach((node) => {
+        const newNodes = state.network.nodes.map((oldNode) => {
+          const node = { ...oldNode };
           // eslint-disable-next-line no-param-reassign
           node[axis] = positionScale(node[varName]);
           // eslint-disable-next-line no-param-reassign
@@ -471,6 +472,13 @@ const {
             // eslint-disable-next-line no-param-reassign
             node[`f${otherAxis}`] = otherSvgDimension / 2;
           }
+
+          return node;
+        });
+
+        store.commit.setNetwork({
+          nodes: newNodes,
+          edges: state.network.edges,
         });
       }
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,7 @@ export interface State {
   };
   userInfo: UserSpec | null;
   linkLength: number;
+  svgDimensions: Dimensions;
 }
 
 export type ProvenanceEventTypes =


### PR DESCRIPTION
Closes #219

This adds the logic to layout the nodes by a node's numeric attributes. You can assign one variable to the x and one to the y. There is currently no feedback as to which is mapped where. Maybe this could be added to the legend in a later iteration.

I modified the logic here slightly to only accept variables that are node variables so there shouldn't be any issues.

@jtomeck, could you give me some pointers on UX here, please? It seems like there might be too many clicks

@waxlamp Is there a way for me to trigger a render update instead of requiring a node hover? Maybe using `Vue.forceUpdate`?

TODO:
- [x] Only accept node variables in the list of vars to layout by
- [x] Add issue to add axes to the vis (#222)
- [x] Consider whether we should track this in the legend, too. (#234)
- [x] Have to hover over node to cause update to trigger on second layout (#234)

Layout by 2 variables:
https://user-images.githubusercontent.com/36867477/114741076-aac06700-9d07-11eb-9830-ffe775f84ca4.mp4

Disabled numeric variables:
![image](https://user-images.githubusercontent.com/36867477/114741173-bd3aa080-9d07-11eb-8d8c-08d05b9712ee.png)