### PR TITLE
Legend redesign

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -100,4 +100,8 @@ body {
 .v-btn__content {
   padding-bottom: 2px;
 }
+
+.v-input__append-outer {
+  margin-left: 0 !important;
+}
 </style>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -450,6 +450,17 @@ export default Vue.extend({
 
         <v-subheader class="grey darken-3 py-0 white--text">
           Legend
+
+          <v-spacer />
+
+          <v-switch
+            v-model="displayCharts"
+            append-icon="mdi-chart-bar"
+            class="mr-0"
+            dense
+            dark
+            color="blue darken-1"
+          />
         </v-subheader>
         <Legend v-if="networkMetadata !== null" />
       </v-list>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -5,9 +5,7 @@ import AboutDialog from '@/components/AboutDialog.vue';
 import LoginMenu from '@/components/LoginMenu.vue';
 
 import store from '@/store';
-import {
-  Node, Link, Network, internalFieldNames,
-} from '@/types';
+import { Node, Network, internalFieldNames } from '@/types';
 import { forceCollide, forceManyBody } from 'd3-force';
 
 export default Vue.extend({
@@ -40,22 +38,6 @@ export default Vue.extend({
         allVars.delete('x');
         allVars.delete('y');
         allVars.delete('index');
-        return allVars;
-      }
-      return new Set();
-    },
-
-    linkVariableList(): Set<string | null> {
-      if (this.network !== null) {
-        // Loop through all links, flatten the 2d array, and turn it into a set
-        const allVars: Set<string> = new Set();
-        this.network.edges.map((link: Link) => Object.keys(link).forEach((key) => allVars.add(key)));
-
-        internalFieldNames.forEach((field) => allVars.delete(field));
-        allVars.delete('source');
-        allVars.delete('target');
-        allVars.delete('index');
-
         return allVars;
       }
       return new Set();
@@ -125,6 +107,10 @@ export default Vue.extend({
 
     network(): Network | null {
       return store.getters.network;
+    },
+
+    networkMetadata() {
+      return store.getters.networkMetadata;
     },
 
     autocompleteItems(): string[] {
@@ -465,16 +451,7 @@ export default Vue.extend({
         <v-subheader class="grey darken-3 py-0 white--text">
           Legend
         </v-subheader>
-        <Legend
-          v-if="network !== null"
-          ref="legend"
-          class="mt-4"
-          v-bind="{
-            network,
-            multiVariableList,
-            linkVariableList,
-          }"
-        />
+        <Legend v-if="networkMetadata !== null" />
       </v-list>
     </v-navigation-drawer>
   </div>

--- a/src/components/DragTarget.vue
+++ b/src/components/DragTarget.vue
@@ -17,6 +17,7 @@ export default Vue.extend({
 
   setup(props) {
     const linkVariables = computed(() => store.state.linkVariables);
+    const nestedVariables = computed(() => store.state.nestedVariables);
 
     function elementDrop(event: DragEvent) {
       if (event.dataTransfer === null) {
@@ -25,23 +26,19 @@ export default Vue.extend({
 
       const droppedVarName = event.dataTransfer.getData('attr_id').substring(5);
 
-      // if (props.type === 'node' && props.title === 'bars') {
-      //   const updatedNestedVars = {
-      //     bar: [...this.nestedVariables.bar, droppedElText],
-      //     glyph: this.nestedVariables.glyph,
-      //   };
-      //   store.commit.setNestedVariables(updatedNestedVars);
-
-      //   // Render the scales
-      //   Vue.nextTick(() => this.renderScales(droppedElText));
-      // } else if (props.type === 'node' && targetEl === 'glyphElements') {
-      //   const updatedNestedVars = {
-      //     bar: this.nestedVariables.bar,
-      //     glyph: [...this.nestedVariables.glyph, droppedElText],
-      //   };
-      //   store.commit.setNestedVariables(updatedNestedVars);
-      // } else
-      if (props.type === 'node' && props.title === 'size') {
+      if (props.type === 'node' && props.title === 'bars') {
+        const updatedNestedVars = {
+          bar: [...nestedVariables.value.bar, droppedVarName],
+          glyph: nestedVariables.value.glyph,
+        };
+        store.commit.setNestedVariables(updatedNestedVars);
+      } else if (props.type === 'node' && props.title === 'glyphs') {
+        const updatedNestedVars = {
+          bar: nestedVariables.value.bar,
+          glyph: [...nestedVariables.value.glyph, droppedVarName],
+        };
+        store.commit.setNestedVariables(updatedNestedVars);
+      } else if (props.type === 'node' && props.title === 'size') {
         store.commit.setNodeSizeVariable(droppedVarName);
       } else if (props.type === 'node' && props.title === 'color') {
         store.commit.setNodeColorVariable(droppedVarName);

--- a/src/components/DragTarget.vue
+++ b/src/components/DragTarget.vue
@@ -65,7 +65,7 @@ export default Vue.extend({
 </script>
 
 <template>
-  <div class="pa-4 white-background">
+  <div class="pa-4">
     {{ title }}
 
     <div
@@ -88,10 +88,6 @@ export default Vue.extend({
 </template>
 
 <style scoped>
-.white-background {
-  background-color: white;
-}
-
 .drag-target {
   display: flex;
   flex-direction: column;

--- a/src/components/DragTarget.vue
+++ b/src/components/DragTarget.vue
@@ -13,6 +13,10 @@ export default Vue.extend({
       type: String as PropType<'node' | 'link'>,
       required: true,
     },
+    showTitle: {
+      type: Boolean,
+      default: true,
+    },
   },
 
   setup(props) {
@@ -66,7 +70,9 @@ export default Vue.extend({
 
 <template>
   <div class="pa-4">
-    {{ title }}
+    <div v-if="showTitle">
+      {{ title }}
+    </div>
 
     <div
       class="drag-target"

--- a/src/components/DragTarget.vue
+++ b/src/components/DragTarget.vue
@@ -1,0 +1,115 @@
+<script lang="ts">
+import store from '@/store';
+import { computed } from '@vue/composition-api';
+import Vue, { PropType } from 'vue';
+
+export default Vue.extend({
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    type: {
+      type: String as PropType<'node' | 'link'>,
+      required: true,
+    },
+  },
+
+  setup(props) {
+    const linkVariables = computed(() => store.getters.linkVariables);
+
+    function elementDrop(event: DragEvent) {
+      if (event.dataTransfer === null) {
+        return;
+      }
+
+      const droppedVarName = event.dataTransfer.getData('attr_id').substring(5);
+
+      // if (props.type === 'node' && props.title === 'bars') {
+      //   const updatedNestedVars = {
+      //     bar: [...this.nestedVariables.bar, droppedElText],
+      //     glyph: this.nestedVariables.glyph,
+      //   };
+      //   store.commit.setNestedVariables(updatedNestedVars);
+
+      //   // Render the scales
+      //   Vue.nextTick(() => this.renderScales(droppedElText));
+      // } else if (props.type === 'node' && targetEl === 'glyphElements') {
+      //   const updatedNestedVars = {
+      //     bar: this.nestedVariables.bar,
+      //     glyph: [...this.nestedVariables.glyph, droppedElText],
+      //   };
+      //   store.commit.setNestedVariables(updatedNestedVars);
+      // } else
+      if (props.type === 'node' && props.title === 'size') {
+        store.commit.setNodeSizeVariable(droppedVarName);
+      } else if (props.type === 'node' && props.title === 'color') {
+        store.commit.setNodeColorVariable(droppedVarName);
+      } else if (props.type === 'link' && props.title === 'width') {
+        const updatedLinkVars = {
+          width: droppedVarName,
+          color: linkVariables.value.color,
+        };
+        store.commit.setLinkVariables(updatedLinkVars);
+      } else if (props.type === 'link' && props.title === 'color') {
+        const updatedLinkVars = {
+          width: linkVariables.value.width,
+          color: droppedVarName,
+        };
+        store.commit.setLinkVariables(updatedLinkVars);
+      }
+    }
+
+    return {
+      elementDrop,
+    };
+  },
+});
+</script>
+
+<template>
+  <div class="pa-4 white-background">
+    {{ title }}
+
+    <div
+      class="drag-target"
+      @drop="elementDrop"
+      @dragenter.prevent
+      @dragover.prevent
+    >
+      <p>
+        <v-icon
+          small
+          dark
+          color="grey"
+        >
+          mdi-chart-bar
+        </v-icon> drag attribute
+      </p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.white-background {
+  background-color: white;
+}
+
+.drag-target {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: auto;
+  height: 50px;
+  border: dashed;
+  border-width: 2px;
+  border-radius: 5px;
+  border-color: grey;
+  padding: auto;
+}
+
+p {
+  margin: auto;
+  color: grey;
+}
+</style>

--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -309,6 +309,7 @@ export default Vue.extend({
   position: sticky;
   top: 0;
   z-index: 2;
+  background-color: white;
 }
 
 .draggable {

--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -1,36 +1,18 @@
 <script lang="ts">
-import Vue, { PropType } from 'vue';
-import {
-  min, max, histogram,
-} from 'd3-array';
-import { select } from 'd3-selection';
-import {
-  scaleLinear, scaleBand, ScaleBand,
-} from 'd3-scale';
-import { axisBottom, axisLeft, axisRight } from 'd3-axis';
-
-import { Node, Link, Network } from '@/types';
+import Vue from 'vue';
 import store from '@/store';
+import { internalFieldNames, Link, Node } from '@/types';
+import DragTarget from '@/components/DragTarget.vue';
+import LegendChart from '@/components/LegendChart.vue';
 
 export default Vue.extend({
-  props: {
-    network: {
-      type: Object as PropType<Network | null>,
-      default: null,
-    },
-    multiVariableList: {
-      type: Set,
-      default: () => new Set(),
-    },
-    linkVariableList: {
-      type: Set,
-      default: () => new Set(),
-    },
+  components: {
+    DragTarget,
+    LegendChart,
   },
 
   data() {
     return {
-      svgHeight: 50,
       yAxisPadding: 25, // Gives enough width for hundreds on the y axis
       sticky: {
         barHeight: 100,
@@ -43,21 +25,13 @@ export default Vue.extend({
         varNameIndent: 50,
       },
       varPadding: 10,
+      tab: undefined,
     };
   },
 
   computed: {
-    properties() {
-      const {
-        network,
-        multiVariableList,
-        linkVariableList,
-      } = this;
-      return {
-        network,
-        multiVariableList,
-        linkVariableList,
-      };
+    network() {
+      return store.getters.network;
     },
 
     nestedVariables() {
@@ -76,24 +50,41 @@ export default Vue.extend({
       return store.getters.nodeColorVariable;
     },
 
-    nodeBarColorScale() {
-      return store.getters.nodeBarColorScale;
-    },
-
-    nodeGlyphColorScale() {
-      return store.getters.nodeGlyphColorScale;
-    },
-
     columnTypes() {
       return store.getters.columnTypes;
     },
 
     cleanedNodeVariables(): Set<string> {
-      return this.cleanVariableList(this.multiVariableList as Set<string>);
+      if (this.network !== null) {
+        // Loop through all nodes, flatten the 2d array, and turn it into a set
+        const allVars: Set<string> = new Set();
+        this.network.nodes.forEach((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
+
+        internalFieldNames.forEach((field) => allVars.delete(field));
+        allVars.delete('vx');
+        allVars.delete('vy');
+        allVars.delete('x');
+        allVars.delete('y');
+        allVars.delete('index');
+        return this.cleanVariableList(allVars);
+      }
+      return new Set();
     },
 
     cleanedLinkVariables(): Set<string> {
-      return this.cleanVariableList(this.linkVariableList as Set<string>);
+      if (this.network !== null) {
+        // Loop through all links, flatten the 2d array, and turn it into a set
+        const allVars: Set<string> = new Set();
+        this.network.edges.map((link: Link) => Object.keys(link).forEach((key) => allVars.add(key)));
+
+        internalFieldNames.forEach((field) => allVars.delete(field));
+        allVars.delete('source');
+        allVars.delete('target');
+        allVars.delete('index');
+
+        return this.cleanVariableList(allVars);
+      }
+      return new Set();
     },
 
     displayCharts() {
@@ -105,237 +96,7 @@ export default Vue.extend({
     },
   },
 
-  mounted() {
-    this.setUpPanel();
-  },
-
   methods: {
-    setUpPanel() {
-      // For node and link variables
-      [this.cleanedNodeVariables as Set<string>, this.cleanedLinkVariables as Set<string>].forEach((list) => {
-        // For each attribute
-        list.forEach((attr) => {
-          // Get the SVG element and its width
-          const type = list === this.cleanedNodeVariables ? 'node' : 'link';
-          const variableSvg = select(`#${type}${attr}`);
-
-          const variableSvgWidth = (variableSvg
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            .node() as any)
-            .getBoundingClientRect()
-            .width - this.yAxisPadding - this.varPadding;
-
-          // Get the data and generate the bins
-          if (this.network === null) {
-            return;
-          }
-
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          let currentData: any[];
-
-          // Process data for bars/histogram
-          if (this.isQuantitative(attr, type)) {
-            if (type === 'node') {
-              currentData = this.network.nodes.map((d: Node | Link) => parseFloat(d[attr]));
-            } else {
-              currentData = this.network.edges.map((d: Node | Link) => parseFloat(d[attr]));
-            }
-
-            const xScale = scaleLinear()
-              .domain([min(currentData), max(currentData) + 1])
-              .range([this.yAxisPadding, variableSvgWidth]);
-
-            const binGenerator = histogram()
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              .domain((xScale as any).domain()) // then the domain of the graphic
-              .thresholds(xScale.ticks(15)); // then the numbers of bins
-
-            const bins = binGenerator(currentData);
-
-            store.commit.addAttributeRange({
-              attr,
-              min: xScale.domain()[0] || 0,
-              max: xScale.domain()[1] || 0,
-              binLabels: xScale.domain().map((label) => label.toString()),
-              binValues: xScale.range(),
-            });
-
-            const yScale = scaleLinear()
-              .domain([0, max(bins, (d) => d.length) || 0])
-              .range([this.svgHeight, 0]);
-
-            variableSvg
-              .selectAll('rect')
-              .data(bins)
-              .enter()
-              .append('rect')
-              .attr('x', (d) => xScale(d.x0 || 0))
-              .attr('y', (d) => yScale(d.length))
-              .attr('height', (d) => this.svgHeight - yScale(d.length))
-              .attr('width', (d) => xScale(d.x1 || 0) - xScale(d.x0 || 0))
-              .attr('fill', '#82B1FF');
-
-            // Add the axis scales onto the chart
-            variableSvg
-              .append('g')
-              .attr('transform', `translate(${this.yAxisPadding},0)`)
-              .call(axisLeft(yScale).ticks(4, 's'));
-
-            variableSvg
-              .append('g')
-              .attr('transform', `translate(0, ${this.svgHeight})`)
-              .call(axisBottom(xScale).ticks(4, 's'));
-          } else {
-            if (type === 'node') {
-              currentData = this.network.nodes.map((d: Node | Link) => d[attr]).sort();
-            } else {
-              currentData = this.network.edges.map((d: Node | Link) => d[attr]).sort();
-            }
-
-            const bins = new Map([...new Set(currentData)].map(
-              (x) => [x, currentData.filter((y) => y === x).length],
-            ));
-
-            const binLabels: string[] = Array.from(bins.keys());
-            const binValues: number[] = Array.from(bins.values());
-
-            store.commit.addAttributeRange({
-              attr,
-              min: parseFloat(min(binLabels) || '0'),
-              max: parseFloat(max(binLabels) || '0'),
-              binLabels,
-              binValues,
-            });
-
-            // Generate axis scales
-            const yScale = scaleLinear()
-              .domain([min(binValues) || 0, max(binValues) || 0])
-              .range([this.svgHeight, 0]);
-
-            const xScale = scaleBand()
-              .domain(binLabels)
-              .range([this.yAxisPadding, variableSvgWidth]);
-
-            variableSvg
-              .selectAll('rect')
-              .data(currentData)
-              .enter()
-              .append('rect')
-              .attr('x', (d: string) => xScale(d) || 0)
-              .attr('y', (d: string) => yScale(bins.get(d) || 0))
-              .attr('height', (d: string) => this.svgHeight - yScale(bins.get(d) || 0))
-              .attr('width', xScale.bandwidth())
-              .attr('fill', (d: string) => this.nodeGlyphColorScale(d));
-
-            // Add the axis scales onto the chart
-            variableSvg
-              .append('g')
-              .attr('transform', `translate(${this.yAxisPadding},0)`)
-              .call(axisLeft(yScale).ticks(4, 's'));
-
-            variableSvg
-              .append('g')
-              .attr('transform', `translate(0, ${this.svgHeight})`)
-              .call(axisBottom(xScale).ticks(4, 's'));
-          }
-        });
-      });
-    },
-
-    // TODO: https://github.com/multinet-app/multilink/issues/176
-    // use table name for var selection
-    isQuantitative(varName: string, type: 'node' | 'link') {
-      if (Object.keys(this.columnTypes).length > 0) {
-        return this.columnTypes[varName] === 'number';
-      }
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let nodesOrLinks: any[];
-
-      if (this.network !== null) {
-        nodesOrLinks = type === 'node' ? this.network.nodes : this.network.edges;
-        const uniqueValues = [...new Set(nodesOrLinks.map((element) => parseFloat(element[varName])))];
-        return uniqueValues.length > 5;
-      }
-      return false;
-    },
-
-    ordinalInvert(pos: number, scale: ScaleBand<string>, binLabels: string[]) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let previous: any = null;
-      const domain = scale.domain();
-
-      domain.forEach((value, idx: number) => {
-        if (idx !== null) {
-          if ((scale(binLabels[idx]) || 0) > pos) {
-            return previous;
-          }
-          previous = binLabels[idx];
-        }
-
-        return null;
-      });
-      return previous;
-    },
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    rectDrop(newEvent: any) {
-      const droppedEl = newEvent.dataTransfer.getData('attr_id');
-      const type = droppedEl.substring(0, 4) === 'node' ? 'node' : 'link';
-      const targetEl = newEvent.target.parentNode.id;
-      const droppedElText: string = droppedEl.replace(type, '').replace('div', '');
-
-      if (type === 'node' && targetEl === 'barElements') {
-        const updatedNestedVars = {
-          bar: [...this.nestedVariables.bar, droppedElText],
-          glyph: this.nestedVariables.glyph,
-        };
-        store.commit.setNestedVariables(updatedNestedVars);
-
-        // Render the scales
-        Vue.nextTick(() => this.renderScales(droppedElText));
-      } else if (type === 'node' && targetEl === 'glyphElements') {
-        const updatedNestedVars = {
-          bar: this.nestedVariables.bar,
-          glyph: [...this.nestedVariables.glyph, droppedElText],
-        };
-        store.commit.setNestedVariables(updatedNestedVars);
-      } else if (type === 'node' && targetEl === 'nodeSizeElements') {
-        store.commit.setNodeSizeVariable(droppedElText);
-      } else if (type === 'node' && targetEl === 'nodeColorElements') {
-        store.commit.setNodeColorVariable(droppedElText);
-      } else if (type === 'link' && targetEl === 'widthElements') {
-        const updatedLinkVars = {
-          width: droppedElText,
-          color: this.linkVariables.color,
-        };
-        store.commit.setLinkVariables(updatedLinkVars);
-      } else if (type === 'link' && targetEl === 'colorElements') {
-        const updatedLinkVars = {
-          width: this.linkVariables.width,
-          color: droppedElText,
-        };
-        store.commit.setLinkVariables(updatedLinkVars);
-      }
-    },
-
-    renderScales(barVar: string) {
-      const varMin = this.attributeRanges[barVar].min;
-      const varMax = this.attributeRanges[barVar].max;
-
-      const scale = scaleLinear()
-        .domain([varMin, varMax])
-        .range([this.sticky.barHeight, 0]);
-      const axis = axisRight(scale).ticks(4, 's');
-
-      select(`#node_${barVar}_scale`).append('g').call(axis);
-    },
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    dragStart(newEvent: any) {
-      newEvent.dataTransfer.setData('attr_id', newEvent.target.id);
-    },
-
     cleanVariableList(list: Set<string>): Set<string> {
       const cleanedVariables = new Set<string>();
 
@@ -370,20 +131,6 @@ export default Vue.extend({
           bar: this.nestedVariables.bar,
           glyph: newGlyphVars,
         });
-      } else if (type === 'nodeSize') {
-        store.commit.setNodeSizeVariable('');
-      } else if (type === 'nodeColor') {
-        store.commit.setNodeColorVariable('');
-      } else if (type === 'linkWidth') {
-        store.commit.setLinkVariables({
-          width: '',
-          color: this.linkVariables.color,
-        });
-      } else if (type === 'linkColor') {
-        store.commit.setLinkVariables({
-          width: this.linkVariables.width,
-          color: '',
-        });
       }
     },
   },
@@ -392,420 +139,132 @@ export default Vue.extend({
 
 <template>
   <div id="legend">
-    <!-- Sticky SVG to drag variables onto -->
-    <svg
-      class="sticky"
-      :height="displayCharts ? 9 * sticky.rowHeight : 6 * sticky.rowHeight"
-      width="100%"
+    <v-tabs
+      v-model="tab"
+      background-color="grey darken-2"
+      dark
+      grow
+      slider-color="blue darken-1"
     >
+      <v-tab class="text-subtitle-2">
+        Node Attrs.
+      </v-tab>
+      <v-tab class="text-subtitle-2">
+        Link Attrs.
+      </v-tab>
+    </v-tabs>
 
-      <!-- Define some recurring elements -->
-      <defs>
-        <g id="plus">
-          <rect
-            :width="sticky.plusBackgroundSize"
-            :height="sticky.plusBackgroundSize"
-            fill="#FFFFFF"
-          />
-          <path
-            d="M0,-10 V10 M-10,0 H10"
-            stroke="black"
-            stroke-width="2px"
-            :transform="`translate(${sticky.plusBackgroundSize / 2}, ${sticky.plusBackgroundSize / 2})`"
-          />
-        </g>
-
-        <g id="removeX">
-          <rect
-            width="16"
-            height="16"
-            fill="white"
-          />
-          <path
-            d="M0,-10 V10 M-10,0 H10"
-            stroke="black"
-            stroke-width="2px"
-            transform="translate(8,8)rotate(45)scale(.5)"
-          />
-        </g>
-      </defs>
-
-      <rect
-        width="100%"
-        height="440"
-        fill="#DDDDDD"
-        opacity="1"
-      />
-
-      <!-- Node elements when displayCharts === true -->
-      <g
-        id="nodeMapping"
+    <v-tabs-items
+      v-model="tab"
+    >
+      <v-tab-item
+        class="pb-4"
       >
-        <text
-          font-size="16pt"
-          :y="sticky.padding"
-          :x="sticky.padding"
-          dominant-baseline="hanging"
-          text-anchor="start"
-        >Node Mapping</text>
+        <div class="sticky">
+          <drag-target
+            v-if="nodeSizeVariable === ''"
+            :title="'size'"
+            :type="'node'"
+          />
 
-        <g
-          v-if="displayCharts"
-        >
-          <!-- Bar adding elements -->
-          <g
-            :transform="`translate(${sticky.padding}, ${sticky.rowHeight})`"
-          >
-            <g
-              v-for="(barVar, index) of nestedVariables.bar"
-              :key="barVar"
-            >
-              <rect
-                :x="index * sticky.barHorizSpacing"
-                :width="sticky.barWidth"
-                :height="sticky.barHeight"
-                fill="#FFFFFF"
-              />
-              <rect
-                :x="index * sticky.barHorizSpacing"
-                y="50"
-                :width="sticky.barWidth"
-                height="50"
-                :fill="nodeBarColorScale(barVar)"
-              />
-              <foreignObject
-                :x="index * sticky.barHorizSpacing"
-                :y="sticky.barHeight"
-                width="50"
-                height="20"
-              >
-                <p
-                  class="barLabel"
-                  :title="barVar"
-                >
-                  {{ barVar }}
-                </p>
-              </foreignObject>
-              <g
-                :id="`node_${barVar}_scale`"
-                :transform="`translate(${sticky.barWidth + (index * sticky.barHorizSpacing)}, 0)`"
-              />
-              <use
-                xlink:href="#removeX"
-                :transform="`translate(${index * sticky.barHorizSpacing}, 0)`"
-                @click="removeMapping('nodeBar', barVar)"
-              />
-            </g>
-            <g
-              id="barElements"
-              :transform="`translate(${nestedVariables.bar.length * sticky.barHorizSpacing}, 0)`"
-              @dragenter="(e) => e.preventDefault()"
-              @dragover="(e) => e.preventDefault()"
-              @drop="rectDrop"
-            >
-              <use xlink:href="#plus" />
-            </g>
-          </g>
+          <legend-chart
+            v-else
+            :var-name="nodeSizeVariable"
+            :type="'node'"
+            :selected="true"
+            :mapped-to="'size'"
+          />
 
-          <!-- Glyph adding elements -->
-          <g
-            :transform="`translate(${sticky.padding}, 180)`"
-          >
-            <text dominant-baseline="hanging">Glyph:</text>
-            <g
-              v-for="(glyphVar, outerIndex) of nestedVariables.glyph"
-              :key="glyphVar"
-              :transform="`translate(${sticky.varNameIndent}, ${sticky.padding + outerIndex * (sticky.rowHeight + 10)})`"
-            >
-              <text>
-                {{ glyphVar }}
-              </text>
-              <use
-                xlink:href="#removeX"
-                transform="translate(-20, 0)"
-                @click="removeMapping('nodeGlyph', glyphVar)"
-              />
-              <g
-                v-for="(glyphDatum, innerIndex) of attributeRanges[glyphVar].binLabels"
-                :key="glyphDatum"
-              >
-                <rect
-                  :x="innerIndex * (sticky.colorMapSquareSize + 5)"
-                  :y="5"
-                  :width="sticky.colorMapSquareSize"
-                  :height="sticky.colorMapSquareSize"
-                  :fill="nodeGlyphColorScale(glyphDatum)"
-                />
-                <foreignObject
-                  :x="innerIndex * (sticky.colorMapSquareSize + 5)"
-                  :y="20"
-                  :width="sticky.colorMapSquareSize"
-                  height="20"
-                >
-                  <p
-                    class="glyphLabel"
-                    :title="glyphDatum"
-                  >
-                    {{ glyphDatum }}
-                  </p>
-                </foreignObject>
-              </g>
-            </g>
-            <g
-              v-if="nestedVariables.glyph.length !== 2"
-              id="glyphElements"
-              :transform="`translate(${sticky.varNameIndent}, ${nestedVariables.glyph.length * (sticky.rowHeight + 10)})`"
-              @dragenter="(e) => e.preventDefault()"
-              @dragover="(e) => e.preventDefault()"
-              @drop="rectDrop"
-            >
-              <use xlink:href="#plus" />
-            </g>
-          </g>
-        </g>
+          <v-divider />
 
-        <g
+          <drag-target
+            v-if="nodeColorVariable === ''"
+            :title="'color'"
+            :type="'node'"
+          />
+
+          <legend-chart
+            v-else
+            :var-name="nodeColorVariable"
+            :type="'node'"
+            :selected="true"
+            :mapped-to="'color'"
+          />
+
+          <v-divider />
+        </div>
+
+        <div v-if="cleanedNodeVariables.size === 0">
+          No node attributes to visualize
+        </div>
+
+        <div
+          v-for="nodeAttr of cleanedNodeVariables"
           v-else
+          :key="`node${nodeAttr}`"
         >
-          <!-- Node size elements -->
-          <g
-            :transform="`translate(${sticky.padding}, ${sticky.rowHeight})`"
-          >
-            <text dominant-baseline="hanging">Size:</text>
-            <g
-              v-if="nodeSizeVariable === ''"
-              id="nodeSizeElements"
-              :transform="`translate(${sticky.varNameIndent}, 0)`"
-              @dragenter="(e) => e.preventDefault()"
-              @dragover="(e) => e.preventDefault()"
-              @drop="rectDrop"
-            >
-              <use xlink:href="#plus" />
-            </g>
+          <legend-chart
+            :var-name="nodeAttr"
+            :type="'node'"
+            :selected="false"
+          />
+        </div>
+      </v-tab-item>
 
-            <g v-else>
-              <text
-                :transform="`translate(${sticky.varNameIndent}, 0)`"
-                dominant-baseline="hanging"
-              >
-                {{ nodeSizeVariable }}
-              </text>
-              <use
-                xlink:href="#removeX"
-                transform="translate(0, 15)"
-                @click="removeMapping('nodeSize')"
-              />
-            </g>
-          </g>
-
-          <!-- Node color elements -->
-          <g
-            :transform="`translate(${sticky.padding}, ${2 * sticky.rowHeight})`"
-          >
-            <text dominant-baseline="hanging">Color:</text>
-            <g
-              v-if="nodeColorVariable === ''"
-              id="nodeColorElements"
-              :transform="`translate(${sticky.varNameIndent}, 0)`"
-              @dragenter="(e) => e.preventDefault()"
-              @dragover="(e) => e.preventDefault()"
-              @drop="rectDrop"
-            >
-              <use xlink:href="#plus" />
-            </g>
-
-            <g v-else>
-              <text
-                :transform="`translate(${sticky.varNameIndent}, 0)`"
-                dominant-baseline="hanging"
-              >
-                {{ nodeColorVariable }}
-              </text>
-              <g
-                v-for="(glyphDatum, innerIndex) of attributeRanges[nodeColorVariable].binLabels"
-                :key="glyphDatum"
-              >
-                <rect
-                  :x="sticky.varNameIndent + innerIndex * (sticky.colorMapSquareSize + 5)"
-                  :y="sticky.colorMapSquareSize + 5"
-                  :width="sticky.colorMapSquareSize"
-                  :height="sticky.colorMapSquareSize"
-                  :fill="nodeGlyphColorScale(glyphDatum)"
-                />
-                <foreignObject
-                  :x="sticky.varNameIndent + innerIndex * (sticky.colorMapSquareSize + 5)"
-                  :y="30"
-                  :width="sticky.colorMapSquareSize"
-                  height="20"
-                >
-                  <p
-                    class="glyphLabel"
-                    :title="glyphDatum"
-                  >
-                    {{ glyphDatum }}
-                  </p>
-                </foreignObject>
-                <use
-                  xlink:href="#removeX"
-                  transform="translate(0, 15)"
-                  @click="removeMapping('nodeColor')"
-                />
-              </g>
-            </g>
-          </g>
-        </g>
-      </g>
-
-      <!-- Link elements -->
-      <g
-        id="linkMapping"
-        :transform="displayCharts ?
-          `translate(${sticky.padding}, ${6 * sticky.rowHeight})` :
-          `translate(${sticky.padding}, ${3 * sticky.rowHeight})`"
+      <v-tab-item
+        class="pb-4"
       >
-        <text
-          font-size="16pt"
-          dominant-baseline="hanging"
-          text-anchor="start"
-        >Link Mapping</text>
-
-        <!-- Link width elements -->
-        <g :transform="`translate(0, ${sticky.varNameIndent - sticky.padding})`">
-          <text dominant-baseline="hanging">Width:</text>
-          <g
+        <div class="sticky">
+          <drag-target
             v-if="linkVariables.width === ''"
-            id="widthElements"
-            :transform="`translate(${sticky.varNameIndent}, 0)`"
-            @dragenter="(e) => e.preventDefault()"
-            @dragover="(e) => e.preventDefault()"
-            @drop="rectDrop"
-          >
-            <use xlink:href="#plus" />
-          </g>
+            :title="'width'"
+            :type="'link'"
+          />
 
-          <g v-else>
-            <text
-              :transform="`translate(${sticky.varNameIndent}, 0)`"
-              dominant-baseline="hanging"
-            >
-              {{ linkVariables.width }}
-            </text>
-            <use
-              xlink:href="#removeX"
-              transform="translate(0, 15)"
-              @click="removeMapping('linkWidth')"
-            />
-          </g>
-        </g>
+          <legend-chart
+            v-else
+            :var-name="linkVariables.width"
+            :type="'link'"
+            :selected="true"
+            :mapped-to="'width'"
+          />
 
-        <!-- Link color elements -->
-        <g :transform="`translate(0, ${2 * sticky.varNameIndent - sticky.padding})`">
-          <text dominant-baseline="hanging">Color:</text>
-          <g
+          <v-divider />
+
+          <drag-target
             v-if="linkVariables.color === ''"
-            id="colorElements"
-            :transform="`translate(${sticky.varNameIndent}, 0)`"
-            @dragenter="(e) => e.preventDefault()"
-            @dragover="(e) => e.preventDefault()"
-            @drop="rectDrop"
-          >
-            <use xlink:href="#plus" />
-          </g>
+            :title="'color'"
+            :type="'link'"
+          />
 
-          <g v-else>
-            <text
-              :transform="`translate(${sticky.varNameIndent}, 0)`"
-              dominant-baseline="hanging"
-            >
-              {{ linkVariables.color }}
-            </text>
-            <use
-              xlink:href="#removeX"
-              transform="translate(0, 15)"
-              @click="removeMapping('linkColor')"
-            />
-            <g
-              v-for="(glyphDatum, innerIndex) of attributeRanges[linkVariables.color].binLabels"
-              :key="glyphDatum"
-            >
-              <rect
-                :x="sticky.varNameIndent + innerIndex * (sticky.colorMapSquareSize + 5)"
-                :y="20"
-                :width="sticky.colorMapSquareSize"
-                :height="sticky.colorMapSquareSize"
-                :fill="nodeGlyphColorScale(glyphDatum)"
-              />
-              <foreignObject
-                :x="sticky.varNameIndent + innerIndex * (sticky.colorMapSquareSize + 5)"
-                :y="30"
-                :width="sticky.colorMapSquareSize"
-                height="20"
-              >
-                <p
-                  class="glyphLabel"
-                  :title="glyphDatum"
-                >
-                  {{ glyphDatum }}
-                </p>
-              </foreignObject>
-            </g>
-          </g>
-        </g>
-      </g>
-    </svg>
+          <legend-chart
+            v-else
+            :var-name="linkVariables.color"
+            :type="'link'"
+            :selected="true"
+            :mapped-to="'color'"
+          />
 
-    <!-- Variables to brush and to drag onto the sticky SVG -->
-    <div :style="{'padding': `${varPadding}px`}">
-      <h2>Node Attributes</h2>
-      <br>
+          <v-divider />
+        </div>
 
-      <div v-if="cleanedNodeVariables.size === 0">
-        No node attributes to visualize
-      </div>
+        <div v-if="cleanedLinkVariables.size === 0">
+          No link attributes to visualize
+        </div>
 
-      <div
-        v-for="nodeAttr of cleanedNodeVariables"
-        v-else
-        :id="`node${nodeAttr}div`"
-        :key="`node${nodeAttr}`"
-        class="draggable"
-        draggable="true"
-        @dragstart="dragStart"
-      >
-        <h3>{{ nodeAttr }}</h3>
-        <svg
-          :id="`node${nodeAttr}`"
-          :height="svgHeight + 20"
-          width="100%"
-        />
-        <br>
-      </div>
-
-      <h2>Link Attributes</h2>
-      <br>
-
-      <div v-if="cleanedLinkVariables.size === 0">
-        No link attributes to visualize
-      </div>
-
-      <div
-        v-for="linkAttr of cleanedLinkVariables"
-        v-else
-        :id="`link${linkAttr}div`"
-        :key="`link${linkAttr}`"
-        class="draggable"
-        draggable="true"
-        @dragstart="dragStart"
-      >
-        <h3>{{ linkAttr }}</h3>
-        <svg
-          :id="`link${linkAttr}`"
-          :height="svgHeight + 20"
-          width="100%"
-        />
-        <br>
-      </div>
-    </div>
+        <div
+          v-for="linkAttr of cleanedLinkVariables"
+          v-else
+          :key="`link${linkAttr}`"
+        >
+          <legend-chart
+            :var-name="linkAttr"
+            :type="'link'"
+            :selected="false"
+          />
+        </div>
+      </v-tab-item>
+    </v-tabs-items>
   </div>
 </template>
 
@@ -818,12 +277,5 @@ export default Vue.extend({
 
 .draggable {
   cursor: pointer;
-}
-
-.barLabel, .glyphLabel{
-  display: block;
-  max-width: 50px;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 </style>

--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -175,6 +175,13 @@ export default Vue.extend({
               :selected="true"
               :mapped-to="'bars'"
             />
+
+            <drag-target
+              v-if="nestedVariables.bar.length < 4 && nestedVariables.bar[0] !== undefined"
+              :title="'bars'"
+              :type="'node'"
+              :show-title="false"
+            />
           </div>
 
           <div v-else>
@@ -205,6 +212,21 @@ export default Vue.extend({
             <legend-chart
               v-else
               :var-name="nestedVariables.glyph[0]"
+              :type="'node'"
+              :selected="true"
+              :mapped-to="'glyphs'"
+            />
+
+            <drag-target
+              v-if="nestedVariables.glyph[0] !== undefined && nestedVariables.glyph[1] === undefined"
+              :title="'glyphs'"
+              :type="'node'"
+              :show-title="false"
+            />
+
+            <legend-chart
+              v-else-if="nestedVariables.glyph[0] !== undefined"
+              :var-name="nestedVariables.glyph[1]"
               :type="'node'"
               :selected="true"
               :mapped-to="'glyphs'"

--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -161,35 +161,71 @@ export default Vue.extend({
         class="pb-4"
       >
         <div class="sticky">
-          <drag-target
-            v-if="nodeSizeVariable === ''"
-            :title="'size'"
-            :type="'node'"
-          />
+          <div v-if="displayCharts">
+            <drag-target
+              v-if="nestedVariables.bar[0] === undefined"
+              :title="'bars'"
+              :type="'node'"
+            />
 
-          <legend-chart
-            v-else
-            :var-name="nodeSizeVariable"
-            :type="'node'"
-            :selected="true"
-            :mapped-to="'size'"
-          />
+            <legend-chart
+              v-else
+              :var-name="nestedVariables.bar[0]"
+              :type="'node'"
+              :selected="true"
+              :mapped-to="'bars'"
+            />
+          </div>
+
+          <div v-else>
+            <drag-target
+              v-if="nodeSizeVariable === ''"
+              :title="'size'"
+              :type="'node'"
+            />
+
+            <legend-chart
+              v-else
+              :var-name="nodeSizeVariable"
+              :type="'node'"
+              :selected="true"
+              :mapped-to="'size'"
+            />
+          </div>
 
           <v-divider />
 
-          <drag-target
-            v-if="nodeColorVariable === ''"
-            :title="'color'"
-            :type="'node'"
-          />
+          <div v-if="displayCharts">
+            <drag-target
+              v-if="nestedVariables.glyph[0] === undefined"
+              :title="'glyphs'"
+              :type="'node'"
+            />
 
-          <legend-chart
-            v-else
-            :var-name="nodeColorVariable"
-            :type="'node'"
-            :selected="true"
-            :mapped-to="'color'"
-          />
+            <legend-chart
+              v-else
+              :var-name="nestedVariables.glyph[0]"
+              :type="'node'"
+              :selected="true"
+              :mapped-to="'glyphs'"
+            />
+          </div>
+
+          <div v-else>
+            <drag-target
+              v-if="nodeColorVariable === ''"
+              :title="'color'"
+              :type="'node'"
+            />
+
+            <legend-chart
+              v-else
+              :var-name="nodeColorVariable"
+              :type="'node'"
+              :selected="true"
+              :mapped-to="'color'"
+            />
+          </div>
 
           <v-divider />
         </div>

--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -108,31 +108,6 @@ export default Vue.extend({
 
       return cleanedVariables;
     },
-
-    removeMapping(
-      type: 'nodeBar' | 'nodeGlyph' | 'nodeSize' | 'nodeColor' | 'linkWidth' | 'linkColor',
-      varName?: string,
-    ) {
-      if (type === 'nodeBar' && varName !== undefined) {
-        const newBarVars = this.nestedVariables.bar.filter(
-          (barVar) => barVar !== varName,
-        );
-
-        store.commit.setNestedVariables({
-          bar: newBarVars,
-          glyph: this.nestedVariables.glyph,
-        });
-      } else if (type === 'nodeGlyph' && varName !== undefined) {
-        const newGlyphVars = this.nestedVariables.glyph.filter(
-          (glyphVar) => glyphVar !== varName,
-        );
-
-        store.commit.setNestedVariables({
-          bar: this.nestedVariables.bar,
-          glyph: newGlyphVars,
-        });
-      }
-    },
   },
 });
 </script>

--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -121,10 +121,10 @@ export default Vue.extend({
       grow
       slider-color="blue darken-1"
     >
-      <v-tab class="text-subtitle-2">
+      <v-tab>
         Node Attrs.
       </v-tab>
-      <v-tab class="text-subtitle-2">
+      <v-tab>
         Link Attrs.
       </v-tab>
     </v-tabs>

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -168,10 +168,10 @@ export default defineComponent({
 
         variableSvg
           .append('rect')
-          .attr('height', minValue)
+          .attr('height', minValue + 2)
           .attr('width', variableSvgWidth)
           .attr('x', yAxisPadding)
-          .attr('y', svgHeight)
+          .attr('y', svgHeight - 1)
           .attr('fill', '#888888');
       } else if (props.mappedTo === 'color') { // node color and link color
         if (isQuantitative(props.varName, props.type)) {

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -51,6 +51,7 @@ export default defineComponent({
     const nodeGlyphColorScale = computed(() => store.state.nodeGlyphColorScale);
     const linkWidthScale = computed(() => store.state.linkWidthScale);
     const linkColorScale = computed(() => store.getters.linkColorScale);
+    const attributeRanges = computed(() => store.state.attributeRanges);
 
     // TODO: https://github.com/multinet-app/multilink/issues/176
     // use table name for var selection
@@ -305,6 +306,17 @@ export default defineComponent({
               .append('xhtml:p')
               .attr('title', barVar)
               .text(barVar);
+
+            // Axis
+            const barScale = scaleLinear()
+              .domain([attributeRanges.value[barVar].min, attributeRanges.value[barVar].max])
+              .range([59, 10]);
+
+            variableSvg
+              .append('g')
+              .classed('legend-bars', true)
+              .attr('transform', `translate(${50 * (index) + 23},0)`)
+              .call(axisLeft(barScale).ticks(4, 's'));
           });
         });
       } else if (isQuantitative(props.varName, props.type)) { // main numeric legend charts

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -6,7 +6,7 @@ import {
 } from '@vue/composition-api';
 import { histogram, max, min } from 'd3-array';
 import { axisBottom, axisLeft } from 'd3-axis';
-import { brushX, D3BrushEvent } from 'd3-brush';
+import { brushX } from 'd3-brush';
 import {
   ScaleBand, scaleBand, ScaleLinear, scaleLinear,
 } from 'd3-scale';
@@ -407,7 +407,6 @@ export default defineComponent({
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       if (yScale! !== undefined) {
-        console.log(props.mappedTo, yScale);
         variableSvg
           .append('g')
           .attr('transform', `translate(${yAxisPadding},0)`)
@@ -417,13 +416,13 @@ export default defineComponent({
       // For the brushable charts for filtering add brushing
       if (props.brushable) {
         const brush = brushX()
-          .extent([[yAxisPadding, 0], [variableSvgWidth, svgHeight]])
-          .on('brush', (event: unknown) => {
-            const brushEvent = event as D3BrushEvent<unknown>;
-            const extent = brushEvent.selection;
-            console.log(extent);
-            // TODO: Fix the brushing logic to update the scales
-          });
+          .extent([[yAxisPadding, 0], [variableSvgWidth, svgHeight]]);
+          // .on('brush', (event: unknown) => {
+          //   const brushEvent = event as D3BrushEvent<unknown>;
+          //   const extent = brushEvent.selection;
+          //   console.log(extent);
+          //   // TODO: Fix the brushing logic to update the scales
+          // });
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (variableSvg as any)

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -316,7 +316,8 @@ export default defineComponent({
               .append('g')
               .classed('legend-bars', true)
               .attr('transform', `translate(${50 * (index) + 23},0)`)
-              .call(axisLeft(barScale).ticks(4, 's'));
+              .call(axisLeft(barScale).ticks(4, 's'))
+              .call((g) => g.select('path').remove());
           });
         });
       } else if (isQuantitative(props.varName, props.type)) { // main numeric legend charts
@@ -414,7 +415,8 @@ export default defineComponent({
           .append('g')
           .attr('transform', `translate(0, ${svgHeight})`)
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .call((axisBottom as any)(xScale).ticks(4, 's'));
+          .call((axisBottom as any)(xScale).ticks(4, 's'))
+          .call((g) => g.select('path').remove());
       }
 
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -422,7 +424,8 @@ export default defineComponent({
         variableSvg
           .append('g')
           .attr('transform', `translate(${yAxisPadding},0)`)
-          .call(axisLeft(yScale).ticks(3, 's'));
+          .call(axisLeft(yScale).ticks(3, 's'))
+          .call((g) => g.select('path').remove());
       }
 
       // For the brushable charts for filtering add brushing

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -220,8 +220,8 @@ export default defineComponent({
           variableSvg
             .append('rect')
             .attr('height', 20)
-            .attr('width', variableSvgWidth - yAxisPadding)
-            .attr('x', yAxisPadding)
+            .attr('width', (xScale(scale.domain()[1]) || 0) - (xScale(scale.domain()[0]) || 0))
+            .attr('x', yAxisPadding + (xScale(scale.domain()[0]) || 0) + 8)
             .attr('y', 20)
             .attr('fill', 'url(#grad)');
         } else {

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -249,13 +249,16 @@ export default defineComponent({
     >
       <div
         :id="`drag-${varName}`"
-        class="px-2 grey lighten-3"
+        class="pl-2 grey lighten-3"
         draggable
         @dragstart="dragStart"
       >
         {{ varName }}
-        <v-icon class="icon">
-          mdi-drag
+        <v-icon
+          small
+          class="icon"
+        >
+          mdi-drag-vertical
         </v-icon>
       </div>
 
@@ -275,6 +278,8 @@ export default defineComponent({
 }
 
 .icon {
+  padding-top: 6px;
+  padding-right: 4px;
   margin-right: 0;
   float: right;
 }

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -201,14 +201,14 @@ export default defineComponent({
           let scale: any;
 
           if (props.type === 'node') {
-            xScale = scaleBand()
-              .domain(nodeColorScale.value.domain() as string[])
+            xScale = scaleLinear()
+              .domain(nodeColorScale.value.domain() as number[])
               .range([yAxisPadding, variableSvgWidth]);
 
             scale = nodeColorScale.value;
           } else {
-            xScale = scaleBand()
-              .domain((linkColorScale.value).domain() as string[])
+            xScale = scaleLinear()
+              .domain(linkColorScale.value.domain() as number[])
               .range([yAxisPadding, variableSvgWidth]);
 
             scale = linkColorScale.value;
@@ -241,8 +241,8 @@ export default defineComponent({
           variableSvg
             .append('rect')
             .attr('height', 20)
-            .attr('width', (xScale(scale.domain()[1]) || 0) - (xScale(scale.domain()[0]) || 0))
-            .attr('x', yAxisPadding + (xScale(scale.domain()[0]) || 0) + 8)
+            .attr('width', (xScale.range()[1] || 0) - (xScale.range()[0] || 0))
+            .attr('x', xScale.range()[0] || 0)
             .attr('y', 20)
             .attr('fill', 'url(#grad)');
         } else {

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -1,0 +1,281 @@
+<script lang="ts">
+import store from '@/store';
+import { Node, Link } from '@/types';
+import {
+  computed, defineComponent, onMounted, PropType,
+} from '@vue/composition-api';
+import { histogram, max, min } from 'd3-array';
+import { axisBottom, axisLeft } from 'd3-axis';
+import { scaleBand, scaleLinear } from 'd3-scale';
+import { select } from 'd3-selection';
+
+export default defineComponent({
+  props: {
+    varName: {
+      type: String,
+      required: true,
+    },
+    type: {
+      type: String as PropType<'node' | 'link'>,
+      required: true,
+    },
+    selected: {
+      type: Boolean,
+      required: true,
+    },
+    mappedTo: {
+      type: String,
+      default: '',
+    },
+  },
+
+  setup(props) {
+    const yAxisPadding = 30;
+    const svgHeight = 50;
+
+    const network = computed(() => store.getters.network);
+    const columnTypes = computed(() => store.getters.columnTypes);
+    const nodeGlyphColorScale = computed(() => store.getters.nodeGlyphColorScale);
+
+    // TODO: https://github.com/multinet-app/multilink/issues/176
+    // use table name for var selection
+    function isQuantitative(varName: string, type: 'node' | 'link') {
+      if (Object.keys(columnTypes.value).length > 0) {
+        return columnTypes.value[varName] === 'number';
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let nodesOrLinks: any[];
+
+      if (network.value !== null) {
+        nodesOrLinks = type === 'node' ? network.value.nodes : network.value.edges;
+        const uniqueValues = [...new Set(nodesOrLinks.map((element) => parseFloat(element[varName])))];
+        return uniqueValues.length > 5;
+      }
+      return false;
+    }
+
+    function dragStart(event: DragEvent) {
+      if (event.dataTransfer !== null && event.target !== null) {
+        event.dataTransfer.setData('attr_id', (event.target as Element).id);
+      }
+    }
+
+    function unAssignVar() {
+      if (props.type === 'node') {
+        if (props.mappedTo === 'size') {
+          store.commit.setNodeSizeVariable('');
+        } else if (props.mappedTo === 'color') {
+          store.commit.setNodeColorVariable('');
+        }
+      } else if (props.type === 'link') {
+        if (props.mappedTo === 'width') {
+          store.commit.setLinkVariables({
+            width: '',
+            color: store.getters.linkVariables.color,
+          });
+        } else if (props.mappedTo === 'color') {
+          store.commit.setLinkVariables({
+            width: store.getters.linkVariables.width,
+            color: '',
+          });
+        }
+      }
+    }
+
+    onMounted(() => {
+      const variableSvg = select(`#${props.type}${props.varName}${props.mappedTo}`);
+
+      const variableSvgWidth = (variableSvg
+        .node() as Element)
+        .getBoundingClientRect()
+        .width - yAxisPadding;
+
+      if (network.value === null) {
+        return;
+      }
+
+      // Process data for bars/histogram
+      if (isQuantitative(props.varName, props.type)) {
+        let currentData: number[] = [];
+        if (props.type === 'node') {
+          currentData = network.value.nodes.map((d: Node | Link) => parseFloat(d[props.varName]));
+        } else {
+          currentData = network.value.edges.map((d: Node | Link) => parseFloat(d[props.varName]));
+        }
+
+        const xScale = scaleLinear()
+          .domain([Math.min(...currentData), Math.max(...currentData) + 1])
+          .range([yAxisPadding, variableSvgWidth]);
+
+        const binGenerator = histogram()
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .domain((xScale as any).domain()) // then the domain of the graphic
+          .thresholds(xScale.ticks(15)); // then the numbers of bins
+
+        const bins = binGenerator(currentData);
+
+        store.commit.addAttributeRange({
+          attr: props.varName,
+          min: xScale.domain()[0] || 0,
+          max: xScale.domain()[1] || 0,
+          binLabels: xScale.domain().map((label) => label.toString()),
+          binValues: xScale.range(),
+        });
+
+        const yScale = scaleLinear()
+          .domain([0, max(bins, (d) => d.length) || 0])
+          .range([svgHeight, 10]);
+
+        variableSvg
+          .selectAll('rect')
+          .data(bins)
+          .enter()
+          .append('rect')
+          .attr('x', (d) => xScale(d.x0 || 0))
+          .attr('y', (d) => yScale(d.length))
+          .attr('height', (d) => svgHeight - yScale(d.length))
+          .attr('width', (d) => xScale(d.x1 || 0) - xScale(d.x0 || 0))
+          .attr('fill', '#82B1FF');
+
+        // Add the axis scales onto the chart
+        variableSvg
+          .append('g')
+          .attr('transform', `translate(${yAxisPadding},0)`)
+          .call(axisLeft(yScale).ticks(4, 's'));
+
+        variableSvg
+          .append('g')
+          .attr('transform', `translate(0, ${svgHeight})`)
+          .call(axisBottom(xScale).ticks(4, 's'));
+      } else {
+        let currentData: string[] = [];
+        if (props.type === 'node') {
+          currentData = network.value.nodes.map((d: Node | Link) => d[props.varName]).sort();
+        } else {
+          currentData = network.value.edges.map((d: Node | Link) => d[props.varName]).sort();
+        }
+
+        const bins = new Map([...new Set(currentData)].map(
+          (x) => [x, currentData.filter((y) => y === x).length],
+        ));
+
+        const binLabels: string[] = Array.from(bins.keys());
+        const binValues: number[] = Array.from(bins.values());
+
+        store.commit.addAttributeRange({
+          attr: props.varName,
+          min: parseFloat(min(binLabels) || '0'),
+          max: parseFloat(max(binLabels) || '0'),
+          binLabels,
+          binValues,
+        });
+
+        // Generate axis scales
+        const yScale = scaleLinear()
+          .domain([min(binValues) || 0, max(binValues) || 0])
+          .range([svgHeight, 0]);
+
+        const xScale = scaleBand()
+          .domain(binLabels)
+          .range([yAxisPadding, variableSvgWidth]);
+
+        variableSvg
+          .selectAll('rect')
+          .data(currentData)
+          .enter()
+          .append('rect')
+          .attr('x', (d: string) => xScale(d) || 0)
+          .attr('y', (d: string) => yScale(bins.get(d) || 0))
+          .attr('height', (d: string) => svgHeight - yScale(bins.get(d) || 0))
+          .attr('width', xScale.bandwidth())
+          .attr('fill', (d: string) => nodeGlyphColorScale.value(d));
+
+        // Add the axis scales onto the chart
+        variableSvg
+          .append('g')
+          .attr('transform', `translate(${yAxisPadding},0)`)
+          .call(axisLeft(yScale).ticks(4, 's'));
+
+        variableSvg
+          .append('g')
+          .attr('transform', `translate(0, ${svgHeight})`)
+          .call(axisBottom(xScale).ticks(4, 's'));
+      }
+    });
+
+    return {
+      svgHeight,
+      dragStart,
+      unAssignVar,
+    };
+  },
+});
+</script>
+
+<template>
+  <div
+    class="pa-4 pb-0"
+  >
+    <div
+      v-if="selected"
+      class="sticky-legend-chart"
+    >
+      <div>
+        <v-row style="margin-right: 0; margin-left: 0;">
+          {{ mappedTo }}:
+          <v-spacer />
+          <strong class="pr-2">{{ varName }}</strong>
+          <v-icon
+            small
+            class="icon"
+            @click="unAssignVar"
+          >
+            mdi-close
+          </v-icon>
+        </v-row>
+      </div>
+
+      <svg
+        :id="`${type}${varName}${mappedTo}`"
+        :height="svgHeight + 20"
+        width="100%"
+      />
+    </div>
+
+    <div
+      v-else
+      class="legend-chart"
+    >
+      <div
+        :id="`drag-${varName}`"
+        class="px-2 grey lighten-3"
+        draggable
+        @dragstart="dragStart"
+      >
+        {{ varName }}
+        <v-icon class="icon">
+          mdi-drag
+        </v-icon>
+      </div>
+
+      <svg
+        :id="`${type}${varName}${mappedTo}`"
+        :height="svgHeight + 20"
+        width="100%"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.legend-chart {
+  border: 1px solid #BDBDBD;
+  box-shadow: 0px 1px 6px rgba(0, 0, 0, 0.1);
+}
+
+.icon {
+  margin-right: 0;
+  float: right;
+}
+</style>

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -44,6 +44,7 @@ export default defineComponent({
 
     const network = computed(() => store.state.network);
     const columnTypes = computed(() => store.state.columnTypes);
+    const nestedVariables = computed(() => store.state.nestedVariables);
     const nodeSizeScale = computed(() => store.getters.nodeSizeScale);
     const nodeColorScale = computed(() => store.getters.nodeColorScale);
     const nodeGlyphColorScale = computed(() => store.state.nodeGlyphColorScale);
@@ -74,12 +75,30 @@ export default defineComponent({
       }
     }
 
-    function unAssignVar() {
+    function unAssignVar(variable?: string) {
       if (props.type === 'node') {
         if (props.mappedTo === 'size') {
           store.commit.setNodeSizeVariable('');
         } else if (props.mappedTo === 'color') {
           store.commit.setNodeColorVariable('');
+        } else if (props.mappedTo === 'bars') {
+          const newBarVars = nestedVariables.value.bar.filter(
+            (barVar) => barVar !== variable,
+          );
+
+          store.commit.setNestedVariables({
+            bar: newBarVars,
+            glyph: nestedVariables.value.glyph,
+          });
+        } else if (props.mappedTo === 'glyphs') {
+          const newGlyphVars = nestedVariables.value.glyph.filter(
+            (glyphVar) => glyphVar !== props.varName,
+          );
+
+          store.commit.setNestedVariables({
+            bar: nestedVariables.value.bar,
+            glyph: newGlyphVars,
+          });
         }
       } else if (props.type === 'link') {
         if (props.mappedTo === 'width') {

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -6,7 +6,7 @@ import {
 } from '@vue/composition-api';
 import { histogram, max, min } from 'd3-array';
 import { axisBottom, axisLeft } from 'd3-axis';
-import { brushX } from 'd3-brush';
+import { brushX, D3BrushEvent } from 'd3-brush';
 import { scaleBand, scaleLinear } from 'd3-scale';
 import { select } from 'd3-selection';
 
@@ -214,12 +214,18 @@ export default defineComponent({
 
       if (props.brushable) {
         const brush = brushX()
-          .extent([[yAxisPadding, 0], [variableSvgWidth, svgHeight]]);
+          .extent([[yAxisPadding, 0], [variableSvgWidth, svgHeight]])
+          .on('brush', (event: unknown) => {
+            const brushEvent = event as D3BrushEvent<unknown>;
+            const extent = brushEvent.selection;
+            console.log(extent);
+          });
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (variableSvg as any)
           .call(brush)
-          .call(brush.move, [yAxisPadding, variableSvgWidth]);
+          // start with the whole graph brushed
+          .call(brush.move, [yAxisPadding, variableSvgWidth - yAxisPadding]);
       }
     });
 

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -213,13 +213,13 @@ export default defineComponent({
       }
 
       if (props.brushable) {
-        console.log('brushable');
+        const brush = brushX()
+          .extent([[yAxisPadding, 0], [variableSvgWidth, svgHeight]]);
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (variableSvg as any).call(
-          brushX()
-            .extent([[yAxisPadding, 0], [variableSvgWidth, svgHeight]]),
-        );
+        (variableSvg as any)
+          .call(brush)
+          .call(brush.move, [yAxisPadding, variableSvgWidth]);
       }
     });
 

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -45,6 +45,7 @@ export default defineComponent({
     const network = computed(() => store.state.network);
     const columnTypes = computed(() => store.state.columnTypes);
     const nodeSizeScale = computed(() => store.getters.nodeSizeScale);
+    const nodeColorScale = computed(() => store.getters.nodeColorScale);
     const nodeGlyphColorScale = computed(() => store.state.nodeGlyphColorScale);
     const linkWidthScale = computed(() => store.state.linkWidthScale);
     const linkColorScale = computed(() => store.getters.linkColorScale);
@@ -180,10 +181,10 @@ export default defineComponent({
 
           if (props.type === 'node') {
             xScale = scaleBand()
-              .domain(nodeGlyphColorScale.value.domain())
+              .domain(nodeColorScale.value.domain() as string[])
               .range([yAxisPadding, variableSvgWidth]);
 
-            scale = nodeGlyphColorScale.value;
+            scale = nodeColorScale.value;
           } else {
             xScale = scaleBand()
               .domain((linkColorScale.value).domain() as string[])

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -268,6 +268,28 @@ export default defineComponent({
             .attr('fill', (d) => nodeGlyphColorScale.value(d))
             .classed('swatch', true);
         }
+      } else if (props.mappedTo === 'glyphs') { // node color and link color
+        // Swatches
+        const binLabels = [...new Set(network.value.nodes.map((d: Node | Link) => d[props.varName]))];
+
+        xScale = scaleBand()
+          .domain(binLabels)
+          .range([yAxisPadding, variableSvgWidth]);
+
+        // Draw swatches
+        const swatchWidth = (variableSvgWidth - yAxisPadding) / binLabels.length;
+
+        variableSvg
+          .selectAll('rect')
+          .data(binLabels)
+          .enter()
+          .append('rect')
+          .attr('height', 15)
+          .attr('width', swatchWidth)
+          .attr('x', (d, i) => (swatchWidth * i) + yAxisPadding)
+          .attr('y', 25)
+          .attr('fill', (d) => nodeGlyphColorScale.value(d))
+          .classed('swatch', true);
       } else if (props.mappedTo === 'bars') { // nested bars
         watchEffect(() => {
           selectAll('.legend-bars').remove();

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -186,7 +186,7 @@ export default defineComponent({
             scale = nodeGlyphColorScale.value;
           } else {
             xScale = scaleBand()
-              .domain((linkColorScale.value).domain().map((val: number | string) => val.toString()))
+              .domain((linkColorScale.value).domain() as string[])
               .range([yAxisPadding, variableSvgWidth]);
 
             scale = linkColorScale.value;

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -196,13 +196,8 @@ export default Vue.extend({
       return store.state.controlsWidth;
     },
 
-    nodeSizeScale(): ScaleLinear<number, number> | null {
-      if (this.network === null) { return null; }
-      const values = this.network.nodes.map((node) => node[this.nodeSizeVariable]);
-
-      return scaleLinear()
-        .domain([Math.min(...values), Math.max(...values)])
-        .range([10, 100]);
+    nodeSizeScale() {
+      return store.getters.nodeSizeScale;
     },
 
     linkColorScale() {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -352,6 +352,12 @@ const {
 
     setLinkVariables(state, linkVariables: LinkStyleVariables) {
       state.linkVariables = linkVariables;
+
+      if (state.network !== null) {
+        const values = state.network.edges.map((d) => parseFloat(d[state.linkVariables.width])) || [];
+        const domain = [Math.min(...values), Math.max(...values)];
+        state.linkWidthScale.domain(domain);
+      }
     },
 
     setNodeSizeVariable(state, nodeSizeVariable: string) {
@@ -364,12 +370,6 @@ const {
 
     addAttributeRange(state, attributeRange: { attr: string; min: number; max: number; binLabels: string[]; binValues: number[] }) {
       state.attributeRanges = { ...state.attributeRanges, [attributeRange.attr]: attributeRange };
-    },
-
-    updateLinkWidthDomain(state, domain: number[]) {
-      if (domain.length === 2) {
-        state.linkWidthScale.domain(domain).range([1, 20]);
-      }
     },
 
     setProvenance(state, provenance: Provenance<State, ProvenanceEventTypes, unknown>) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -98,6 +98,17 @@ const {
 
       return scaleOrdinal(schemeCategory10);
     },
+
+    nodeSizeScale(state) {
+      if (state.network === null) {
+        return scaleLinear();
+      }
+      const values = state.network.nodes.map((node) => node[state.nodeSizeVariable]);
+
+      return scaleLinear()
+        .domain([Math.min(...values), Math.max(...values)])
+        .range([10, 40]);
+    },
   },
   mutations: {
     setWorkspaceName(state, workspaceName: string) {


### PR DESCRIPTION
Closes #74 
Closes #76
Closes #175
Closes #180
Closes #181
Closes #183
Relates to #184 (will close once brushing logic is added back, next PR)
Relates to #186 (will close once brushing logic is added back, next PR))
Closes #209

This adds the drag targets and legend chart styling from Jared's design.

We're still missing a couple of things:
- [x] ability to map to bars and glyphs
- [x] a visual representation of the mapping
- [x] a quick switch for enabling the nested chart rendering from the legend (Alex's suggestion)
- [x] The text for the tabs is probably too large and could be made smaller
- [x] We're missing the help icon, but I'm not sure what functionality that's supposed to enable (replace with chart toggle)
- [x] Add filter icon and chart popover for brushing
- [x] Add back brushing logic (still tracked in #184)
- [x] Fix the margin on the left of the toggle charts icon
- [x] Add axis to bars

In my meeting with Jared we identified a couple more TODOS:
- [x] Color scales should utilize more of the width
- [x] The glyph mapping should use swatches
- [x] The buttons to open the brushing popover could be improved with a redesign (#241)