### PR TITLE
Add support for continuous color mapping to node color

### DIFF
--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -80,6 +80,10 @@ export default Vue.extend({
       return new Set();
     },
 
+    nodeColorScale() {
+      return store.getters.nodeColorScale;
+    },
+
     nodeBarColorScale() {
       return store.state.nodeBarColorScale;
     },
@@ -436,10 +440,6 @@ export default Vue.extend({
       return `stroke: ${linkColor}; stroke-width: ${linkWidth}px;`;
     },
 
-    glyphStyle(value: string) {
-      return `fill: ${this.nodeGlyphColorScale(value)};`;
-    },
-
     calculateNodeSize(node: Node) {
       // Don't render dynamic node size if the size variable is empty or
       // we want to display charts
@@ -618,7 +618,7 @@ export default Vue.extend({
             :class="nodeClass(node)"
             :width="calculateNodeSize(node)"
             :height="calculateNodeSize(node)"
-            :fill="!displayCharts ? nodeGlyphColorScale(node[nodeColorVariable]) : '#DDDDDD'"
+            :fill="!displayCharts ? nodeColorScale(node[nodeColorVariable]) : '#DDDDDD'"
             :rx="!displayCharts ? (calculateNodeSize(node) / 2) : 0"
             :ry="!displayCharts ? (calculateNodeSize(node) / 2) : 0"
             @click="selectNode(node)"
@@ -681,7 +681,7 @@ export default Vue.extend({
               :x="((nestedBarWidth + nestedPadding) * nestedVariables.bar.length) + nestedPadding"
               rx="100"
               ry="100"
-              :style="glyphStyle(node[glyphVar])"
+              :fill="nodeGlyphColorScale(node[glyphVar])"
             />
             <g />
           </g>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -15,7 +15,7 @@ import {
 import {
   scaleLinear, scaleOrdinal, scaleSequential,
 } from 'd3-scale';
-import { interpolateReds, schemeCategory10 } from 'd3-scale-chromatic';
+import { interpolateBlues, interpolateReds, schemeCategory10 } from 'd3-scale-chromatic';
 import { initProvenance, Provenance } from '@visdesignlab/trrack';
 import { undoRedoKeyHandler, updateProvenanceState } from '@/lib/provenanceUtils';
 import { isInternalField } from '@/lib/typeUtils';
@@ -58,6 +58,7 @@ const {
     nodeSizeVariable: '',
     nodeColorVariable: '',
     attributeRanges: {},
+    nodeColorScale: scaleOrdinal(schemeCategory10),
     nodeBarColorScale: scaleOrdinal(schemeCategory10),
     nodeGlyphColorScale: scaleOrdinal(schemeCategory10),
     linkWidthScale: scaleLinear().range([1, 20]),
@@ -81,6 +82,24 @@ const {
   } as State,
 
   getters: {
+    nodeColorScale(state) {
+      if (Object.keys(state.columnTypes).length > 0 && state.columnTypes[state.nodeColorVariable] === 'number') {
+        let minNodeValue = 0;
+        let maxNodeValue = 1;
+
+        if (state.network !== null) {
+          const values = state.network.nodes.map((node) => node[state.nodeColorVariable]);
+          minNodeValue = Math.min(...values);
+          maxNodeValue = Math.max(...values);
+        }
+
+        return scaleSequential(interpolateBlues)
+          .domain([minNodeValue, maxNodeValue]);
+      }
+
+      return scaleOrdinal(schemeCategory10);
+    },
+
     linkColorScale(state) {
       if (Object.keys(state.columnTypes).length > 0 && state.columnTypes[state.linkVariables.color] === 'number') {
         let minLinkValue = 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,7 @@ export interface State {
   nodeColorVariable: string;
   attributeRanges: AttributeRanges;
   simulation: Simulation<Node, SimulationLink> | null;
+  nodeColorScale: ScaleSequential<string> | ScaleOrdinal<string, string>;
   nodeBarColorScale: ScaleOrdinal<string, string>;
   nodeGlyphColorScale: ScaleOrdinal<string, string>;
   linkWidthScale: ScaleLinear<number, number>;


### PR DESCRIPTION
Adds support for continuous color mapping for node color. This means we can now map continuous variables to the node color.

I also noticed some unnecessary code for modifying the fill of the glyphs.

This will benefit #228 