### PR TITLE
Add brushing to the legend to limit domains of mapped variables

### DIFF
--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -36,6 +36,10 @@ export default defineComponent({
       type: String,
       default: '',
     },
+    filter: {
+      type: String,
+      default: '',
+    },
   },
 
   setup(props) {
@@ -561,7 +565,8 @@ export default defineComponent({
                 :var-name="varName"
                 :selected="false"
                 :brushable="true"
-                :type="'node'"
+                :filter="mappedTo"
+                :type="type"
                 class="pb-4"
               />
             </v-card>

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -466,8 +466,17 @@ export default defineComponent({
               return;
             }
 
-            // Update the link width domain
             if (props.filter === 'width' && props.type === 'link') {
+              // Update the link width domain
+              const currentAttributeRange = attributeRanges.value[props.varName];
+
+              // Total extent is 30,226
+              const newMin = ((extent[0] - 30) / (226 - 30)) * (currentAttributeRange.max - currentAttributeRange.min);
+              const newMax = ((extent[1] - 30) / (226 - 30)) * (currentAttributeRange.max - currentAttributeRange.min);
+
+              store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
+            } else if (props.filter === 'color' && props.type === 'link') {
+              // Update the link color domain
               const currentAttributeRange = attributeRanges.value[props.varName];
 
               // Total extent is 30,226

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -475,6 +475,15 @@ export default defineComponent({
               const newMax = ((extent[1] - 30) / (226 - 30)) * (currentAttributeRange.max - currentAttributeRange.min);
 
               store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
+            } else if (props.filter === 'color' && props.type === 'node') {
+              // Update the link width domain
+              const currentAttributeRange = attributeRanges.value[props.varName];
+
+              // Total extent is 30,226
+              const newMin = ((extent[0] - 30) / (226 - 30)) * (currentAttributeRange.max - currentAttributeRange.min);
+              const newMax = ((extent[1] - 30) / (226 - 30)) * (currentAttributeRange.max - currentAttributeRange.min);
+
+              store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
             } else if (props.filter === 'width' && props.type === 'link') {
               // Update the link width domain
               const currentAttributeRange = attributeRanges.value[props.varName];

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -521,7 +521,7 @@ export default defineComponent({
         (variableSvg as any)
           .call(brush)
           // start with the whole graph brushed
-          .call(brush.move, [yAxisPadding, variableSvgWidth - yAxisPadding]);
+          .call(brush.move, [yAxisPadding, variableSvgWidth]);
       }
     });
 
@@ -599,7 +599,7 @@ export default defineComponent({
                 </v-icon>
               </v-btn>
             </template>
-            <v-card :width="256">
+            <v-card :width="300">
               <legend-chart
                 :var-name="varName"
                 :selected="false"

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -470,8 +470,8 @@ export default defineComponent({
             if (props.filter === 'glyphs' && props.type === 'node') {
               const currentAttributeRange = attributeRanges.value[props.varName];
               // Update the glyph domain
-              const firstIndex = Math.floor(((extent[0] - 30) / (226 - 30)) * attributeRanges.value[props.varName].binLabels.length);
-              const secondIndex = Math.ceil(((extent[1] - 30) / (226 - 30)) * attributeRanges.value[props.varName].binLabels.length);
+              const firstIndex = Math.floor(((extent[0] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * attributeRanges.value[props.varName].binLabels.length);
+              const secondIndex = Math.ceil(((extent[1] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * attributeRanges.value[props.varName].binLabels.length);
 
               store.commit.addAttributeRange({
                 ...currentAttributeRange,
@@ -482,36 +482,32 @@ export default defineComponent({
               // Update the node size domain
               const currentAttributeRange = attributeRanges.value[props.varName];
 
-              // Total extent is 30,226
-              const newMin = ((extent[0] - 30) / (226 - 30)) * (currentAttributeRange.max - currentAttributeRange.min);
-              const newMax = ((extent[1] - 30) / (226 - 30)) * (currentAttributeRange.max - currentAttributeRange.min);
+              const newMin = (((extent[0] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
+              const newMax = (((extent[1] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
 
               store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
             } else if (props.filter === 'color' && props.type === 'node') {
               // Update the node color domain
               const currentAttributeRange = attributeRanges.value[props.varName];
 
-              // Total extent is 30,226
-              const newMin = ((extent[0] - 30) / (226 - 30)) * (currentAttributeRange.max - currentAttributeRange.min);
-              const newMax = ((extent[1] - 30) / (226 - 30)) * (currentAttributeRange.max - currentAttributeRange.min);
+              const newMin = (((extent[0] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
+              const newMax = (((extent[1] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
 
               store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
             } else if (props.filter === 'width' && props.type === 'link') {
               // Update the link width domain
               const currentAttributeRange = attributeRanges.value[props.varName];
 
-              // Total extent is 30,226
-              const newMin = ((extent[0] - 30) / (226 - 30)) * (currentAttributeRange.max - currentAttributeRange.min);
-              const newMax = ((extent[1] - 30) / (226 - 30)) * (currentAttributeRange.max - currentAttributeRange.min);
+              const newMin = (((extent[0] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
+              const newMax = (((extent[1] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
 
               store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
             } else if (props.filter === 'color' && props.type === 'link') {
               // Update the link color domain
               const currentAttributeRange = attributeRanges.value[props.varName];
 
-              // Total extent is 30,226
-              const newMin = ((extent[0] - 30) / (226 - 30)) * (currentAttributeRange.max - currentAttributeRange.min);
-              const newMax = ((extent[1] - 30) / (226 - 30)) * (currentAttributeRange.max - currentAttributeRange.min);
+              const newMin = (((extent[0] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
+              const newMax = (((extent[1] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
 
               store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
             }

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -466,7 +466,16 @@ export default defineComponent({
               return;
             }
 
-            if (props.filter === 'width' && props.type === 'link') {
+            if (props.filter === 'size' && props.type === 'node') {
+              // Update the link width domain
+              const currentAttributeRange = attributeRanges.value[props.varName];
+
+              // Total extent is 30,226
+              const newMin = ((extent[0] - 30) / (226 - 30)) * (currentAttributeRange.max - currentAttributeRange.min);
+              const newMax = ((extent[1] - 30) / (226 - 30)) * (currentAttributeRange.max - currentAttributeRange.min);
+
+              store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
+            } else if (props.filter === 'width' && props.type === 'link') {
               // Update the link width domain
               const currentAttributeRange = attributeRanges.value[props.varName];
 

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -248,7 +248,8 @@ export default defineComponent({
             .attr('width', (xScale.range()[1] || 0) - (xScale.range()[0] || 0))
             .attr('x', xScale.range()[0] || 0)
             .attr('y', 20)
-            .attr('fill', 'url(#grad)');
+            .attr('fill', 'url(#grad)')
+            .style('opacity', 0.7);
         } else {
           // Swatches
           const binLabels = [...new Set(network.value.nodes.map((d: Node | Link) => d[props.varName]))];

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -467,8 +467,19 @@ export default defineComponent({
               return;
             }
 
-            if (props.filter === 'size' && props.type === 'node') {
-              // Update the link width domain
+            if (props.filter === 'glyphs' && props.type === 'node') {
+              const currentAttributeRange = attributeRanges.value[props.varName];
+              // Update the glyph domain
+              const firstIndex = Math.floor(((extent[0] - 30) / (226 - 30)) * attributeRanges.value[props.varName].binLabels.length);
+              const secondIndex = Math.ceil(((extent[1] - 30) / (226 - 30)) * attributeRanges.value[props.varName].binLabels.length);
+
+              store.commit.addAttributeRange({
+                ...currentAttributeRange,
+                currentBinLabels: currentAttributeRange.binLabels.slice(firstIndex, secondIndex),
+                currentBinValues: currentAttributeRange.binValues.slice(firstIndex, secondIndex),
+              });
+            } else if (props.filter === 'size' && props.type === 'node') {
+              // Update the node size domain
               const currentAttributeRange = attributeRanges.value[props.varName];
 
               // Total extent is 30,226
@@ -477,7 +488,7 @@ export default defineComponent({
 
               store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
             } else if (props.filter === 'color' && props.type === 'node') {
-              // Update the link width domain
+              // Update the node color domain
               const currentAttributeRange = attributeRanges.value[props.varName];
 
               // Total extent is 30,226

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -49,7 +49,7 @@ export default defineComponent({
     const nodeColorScale = computed(() => store.getters.nodeColorScale);
     const nodeBarColorScale = computed(() => store.state.nodeBarColorScale);
     const nodeGlyphColorScale = computed(() => store.state.nodeGlyphColorScale);
-    const linkWidthScale = computed(() => store.state.linkWidthScale);
+    const linkWidthScale = computed(() => store.getters.linkWidthScale);
     const linkColorScale = computed(() => store.getters.linkColorScale);
     const attributeRanges = computed(() => store.state.attributeRanges);
 

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -168,7 +168,7 @@ export default Vue.extend({
     },
 
     linkWidthScale() {
-      return store.state.linkWidthScale;
+      return store.getters.linkWidthScale;
     },
 
     svgDimensions(): Dimensions {

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -432,7 +432,7 @@ export default Vue.extend({
       const linkColor = this.linkVariables.color === '' ? '#888888' : this.linkColorScale(link[this.linkVariables.color]);
       const linkWidth = this.linkVariables.width === '' ? 1 : this.linkWidthScale(link[this.linkVariables.width]);
 
-      return `stroke: ${linkColor}; stroke-width: ${linkWidth}px;`;
+      return `stroke: ${linkColor}; stroke-width: ${(linkWidth > 20 || linkWidth < 1) ? 0 : linkWidth}px; opacity: 0.7;`;
     },
 
     calculateNodeSize(node: Node) {

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -447,6 +447,20 @@ export default Vue.extend({
       `;
     },
 
+    glyphFill(node: Node, glyphVar: string) {
+      // Figure out what values should be mapped to colors
+      const possibleValues = [
+        ...(this.attributeRanges[this.nestedVariables.glyph[0]].currentBinLabels || this.attributeRanges[this.nestedVariables.glyph[0]].binLabels),
+      ];
+      if (this.nestedVariables.glyph[1]) {
+        possibleValues.push(...(this.attributeRanges[this.nestedVariables.glyph[1]].currentBinLabels || this.attributeRanges[this.nestedVariables.glyph[1]].binLabels));
+      }
+      const scaleContainsValue = possibleValues.find((domainElement) => domainElement === node[glyphVar]);
+
+      // If outside the doamin, return black
+      return scaleContainsValue ? this.nodeGlyphColorScale(node[glyphVar]) : '#000000';
+    },
+
     calculateNodeSize(node: Node) {
       // Don't render dynamic node size if the size variable is empty or
       // we want to display charts
@@ -690,7 +704,7 @@ export default Vue.extend({
               :x="((nestedBarWidth + nestedPadding) * nestedVariables.bar.length) + nestedPadding"
               rx="100"
               ry="100"
-              :fill="nodeGlyphColorScale(node[glyphVar])"
+              :fill="glyphFill(node, glyphVar)"
             />
             <g />
           </g>

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -429,10 +429,15 @@ export default Vue.extend({
     },
 
     linkStyle(link: Link): string {
+      const linkColorScaleDomain = this.linkColorScale.domain();
       const linkColor = this.linkVariables.color === '' ? '#888888' : this.linkColorScale(link[this.linkVariables.color]);
       const linkWidth = this.linkVariables.width === '' ? 1 : this.linkWidthScale(link[this.linkVariables.width]);
 
-      return `stroke: ${linkColor}; stroke-width: ${(linkWidth > 20 || linkWidth < 1) ? 0 : linkWidth}px; opacity: 0.7;`;
+      return `
+        stroke: ${(link[this.linkVariables.color] < linkColorScaleDomain[0] || link[this.linkVariables.color] > linkColorScaleDomain[1]) ? '#888888' : linkColor};
+        stroke-width: ${(linkWidth > 20 || linkWidth < 1) ? 0 : linkWidth}px;
+        opacity: 0.7;
+      `;
     },
 
     calculateNodeSize(node: Node) {

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -419,6 +419,13 @@ export default Vue.extend({
       return `node nodeBox ${selectedClass}`;
     },
 
+    nodeFill(node: Node) {
+      const calculatedValue = node[this.nodeColorVariable];
+      const useCalculatedValue = !(this.displayCharts || calculatedValue < this.nodeColorScale.domain()[0] || calculatedValue > this.nodeColorScale.domain()[1]) && this.nodeColorVariable !== '';
+
+      return useCalculatedValue ? this.nodeColorScale(calculatedValue) : '#DDDDDD';
+    },
+
     linkGroupClass(link: Link): string {
       if (this.selectedNodes.size > 0) {
         const selected = this.isSelected(link._from) || this.isSelected(link._to);
@@ -620,7 +627,7 @@ export default Vue.extend({
             :class="nodeClass(node)"
             :width="calculateNodeSize(node)"
             :height="calculateNodeSize(node)"
-            :fill="!displayCharts ? nodeColorScale(node[nodeColorVariable]) : '#DDDDDD'"
+            :fill="nodeFill(node)"
             :rx="!displayCharts ? (calculateNodeSize(node) / 2) : 0"
             :ry="!displayCharts ? (calculateNodeSize(node) / 2) : 0"
             @click="selectNode(node)"

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -447,7 +447,9 @@ export default Vue.extend({
         return this.markerSize;
       }
 
-      return this.nodeSizeScale(node[this.nodeSizeVariable]);
+      const calculatedValue = this.nodeSizeScale(node[this.nodeSizeVariable]);
+
+      return calculatedValue > 40 || calculatedValue < 10 ? 0 : calculatedValue;
     },
 
     rectSelectDrag(event: MouseEvent) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -113,13 +113,11 @@ const {
     },
 
     nodeSizeScale(state) {
-      if (state.network === null) {
-        return scaleLinear();
-      }
-      const values = state.network.nodes.map((node) => node[state.nodeSizeVariable]);
+      const minValue = state.attributeRanges[state.nodeSizeVariable].currentMin || state.attributeRanges[state.nodeSizeVariable].min;
+      const maxValue = state.attributeRanges[state.nodeSizeVariable].currentMax || state.attributeRanges[state.nodeSizeVariable].max;
 
       return scaleLinear()
-        .domain([Math.min(...values), Math.max(...values)])
+        .domain([minValue, maxValue])
         .range([10, 40]);
     },
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -6,7 +6,7 @@ import {
 } from 'd3-force';
 
 import {
-  Link, Node, Network, NetworkMetadata, SimulationLink, State, LinkStyleVariables, LoadError, NestedVariables, ProvenanceEventTypes, Dimensions,
+  Link, Node, Network, NetworkMetadata, SimulationLink, State, LinkStyleVariables, LoadError, NestedVariables, ProvenanceEventTypes, Dimensions, AttributeRange,
 } from '@/types';
 import api from '@/api';
 import {
@@ -302,7 +302,7 @@ const {
       }
     },
 
-    addAttributeRange(state, attributeRange: { attr: string; min: number; max: number; binLabels: string[]; binValues: number[] }) {
+    addAttributeRange(state, attributeRange: AttributeRange) {
       state.attributeRanges = { ...state.attributeRanges, [attributeRange.attr]: attributeRange };
     },
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -61,7 +61,7 @@ const {
     nodeColorScale: scaleOrdinal(schemeCategory10),
     nodeBarColorScale: scaleOrdinal(schemeCategory10),
     nodeGlyphColorScale: scaleOrdinal(schemeCategory10),
-    linkWidthScale: scaleLinear().range([1, 20]),
+    linkWidthScale: scaleLinear(),
     linkColorScale: scaleOrdinal(schemeCategory10),
     provenance: null,
     directionalEdges: false,
@@ -127,6 +127,13 @@ const {
       return scaleLinear()
         .domain([Math.min(...values), Math.max(...values)])
         .range([10, 40]);
+    },
+
+    linkWidthScale(state) {
+      const minValue = state.attributeRanges[state.linkVariables.width].currentMin || state.attributeRanges[state.linkVariables.width].min;
+      const maxValue = state.attributeRanges[state.linkVariables.width].currentMax || state.attributeRanges[state.linkVariables.width].max;
+
+      return state.linkWidthScale.domain([minValue, maxValue]).range([1, 20]);
     },
   },
   mutations: {
@@ -285,12 +292,6 @@ const {
 
     setLinkVariables(state, linkVariables: LinkStyleVariables) {
       state.linkVariables = linkVariables;
-
-      if (state.network !== null) {
-        const values = state.network.edges.map((d) => parseFloat(d[state.linkVariables.width])) || [];
-        const domain = [Math.min(...values), Math.max(...values)];
-        state.linkWidthScale.domain(domain);
-      }
     },
 
     setNodeSizeVariable(state, nodeSizeVariable: string) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -102,17 +102,11 @@ const {
 
     linkColorScale(state) {
       if (Object.keys(state.columnTypes).length > 0 && state.columnTypes[state.linkVariables.color] === 'number') {
-        let minLinkValue = 0;
-        let maxLinkValue = 1;
-
-        if (state.network !== null) {
-          const values = state.network.edges.map((link) => link[state.linkVariables.color]);
-          minLinkValue = Math.min(...values);
-          maxLinkValue = Math.max(...values);
-        }
+        const minValue = state.attributeRanges[state.linkVariables.color].currentMin || state.attributeRanges[state.linkVariables.color].min;
+        const maxValue = state.attributeRanges[state.linkVariables.color].currentMax || state.attributeRanges[state.linkVariables.color].max;
 
         return scaleSequential(interpolateReds)
-          .domain([minLinkValue, maxLinkValue]);
+          .domain([minValue, maxValue]);
       }
 
       return scaleOrdinal(schemeCategory10);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -84,17 +84,11 @@ const {
   getters: {
     nodeColorScale(state) {
       if (Object.keys(state.columnTypes).length > 0 && state.columnTypes[state.nodeColorVariable] === 'number') {
-        let minNodeValue = 0;
-        let maxNodeValue = 1;
-
-        if (state.network !== null) {
-          const values = state.network.nodes.map((node) => node[state.nodeColorVariable]);
-          minNodeValue = Math.min(...values);
-          maxNodeValue = Math.max(...values);
-        }
+        const minValue = state.attributeRanges[state.nodeColorVariable].currentMin || state.attributeRanges[state.nodeColorVariable].min;
+        const maxValue = state.attributeRanges[state.nodeColorVariable].currentMax || state.attributeRanges[state.nodeColorVariable].max;
 
         return scaleSequential(interpolateBlues)
-          .domain([minNodeValue, maxNodeValue]);
+          .domain([minValue, maxValue]);
       }
 
       return scaleOrdinal(schemeCategory10);

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,8 @@ export interface AttributeRange {
   binValues: number[];
   currentMax?: number;
   currentMin?: number;
+  currentBinLabels?: string[];
+  currentBinValues?: number[];
 }
 
 export interface AttributeRanges {

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,8 +55,18 @@ export interface LinkStyleVariables {
   color: string;
 }
 
+export interface AttributeRange {
+  attr: string;
+  min: number;
+  max: number;
+  binLabels: string[];
+  binValues: number[];
+  currentMax?: number;
+  currentMin?: number;
+}
+
 export interface AttributeRanges {
-  [key: string]: {attr: string; min: number; max: number; binLabels: string[]; binValues: number[]};
+  [key: string]: AttributeRange;
 }
 
 export interface NetworkMetadata { [tableName: string]: TableMetadata }


### PR DESCRIPTION
Closes #184 
Closes #186 

In this PR, I'm adding brushing support for the legend charts. I've added support for glyphs (must be categorical), numeric node color, numeric link color, node size (must be numeric), link width (must be numeric). The chart brushing updates domains as necessary and is reflected in the visualization. There are a couple of other brushing interactions that I've pushed to issues for another PR -- I didn't want to make this too long. Once I've added the additional mappings, we could likely refactor this to reduce the duplication of some common logic (#248).

Many TODOS:
- [x] Add brushing for bars (#245)
- [x] Add brushing for glyphs
- [x] Add brushing for node color
- [x] Add brushing for node size
- [x] Add brushing for link width
- [x] Add brushing for link color
- [x] Links now have `opacity: 0.7;`, this means that the color scales in the legend are now slightly off compared to the nodes. We can fix it by adding the same opacity to the scales in the legend
- [x] Brushing chart extent doesn't match the width of the chart
- [x] A group with a common name across glyph variables will be visualized if it only is brushed in one of the scale (bug! fix this in a follow up) (#246)
- [x] Fix categorical filtering for node color and link color (#247)