### PR TITLE
Update logic for color scale brushing for categorical variables

### DIFF
--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -487,13 +487,26 @@ export default defineComponent({
 
               store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
             } else if (props.filter === 'color' && props.type === 'node') {
+              if (isQuantitative(props.varName, props.type)) {
               // Update the node color domain
-              const currentAttributeRange = attributeRanges.value[props.varName];
+                const currentAttributeRange = attributeRanges.value[props.varName];
 
-              const newMin = (((extent[0] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
-              const newMax = (((extent[1] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
+                const newMin = (((extent[0] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
+                const newMax = (((extent[1] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
 
-              store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
+                store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
+              } else {
+                const currentAttributeRange = attributeRanges.value[props.varName];
+                // Update the glyph domain
+                const firstIndex = Math.floor(((extent[0] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * attributeRanges.value[props.varName].binLabels.length);
+                const secondIndex = Math.ceil(((extent[1] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * attributeRanges.value[props.varName].binLabels.length);
+
+                store.commit.addAttributeRange({
+                  ...currentAttributeRange,
+                  currentBinLabels: currentAttributeRange.binLabels.slice(firstIndex, secondIndex),
+                  currentBinValues: currentAttributeRange.binValues.slice(firstIndex, secondIndex),
+                });
+              }
             } else if (props.filter === 'width' && props.type === 'link') {
               // Update the link width domain
               const currentAttributeRange = attributeRanges.value[props.varName];

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -251,8 +251,10 @@ export default defineComponent({
             .attr('fill', 'url(#grad)')
             .style('opacity', 0.7);
         } else {
+          const currentData = props.type === 'node' ? network.value.nodes : network.value.edges;
+
           // Swatches
-          const binLabels = [...new Set(network.value.nodes.map((d: Node | Link) => d[props.varName]))];
+          const binLabels = [...new Set(currentData.map((d) => d[props.varName]))];
 
           xScale = scaleBand()
             .domain(binLabels)

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -254,7 +254,8 @@ export default defineComponent({
           const currentData = props.type === 'node' ? network.value.nodes : network.value.edges;
 
           // Swatches
-          const binLabels = [...new Set(currentData.map((d) => d[props.varName]))];
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const binLabels: string[] = [...new Set<string>((currentData as any).map((d: Node | Link) => d[props.varName]))];
 
           xScale = scaleBand()
             .domain(binLabels)

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -516,13 +516,26 @@ export default defineComponent({
 
               store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
             } else if (props.filter === 'color' && props.type === 'link') {
-              // Update the link color domain
-              const currentAttributeRange = attributeRanges.value[props.varName];
+              if (isQuantitative(props.varName, props.type)) {
+              // Update the node color domain
+                const currentAttributeRange = attributeRanges.value[props.varName];
 
-              const newMin = (((extent[0] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
-              const newMax = (((extent[1] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
+                const newMin = (((extent[0] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
+                const newMax = (((extent[1] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
 
-              store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
+                store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
+              } else {
+                const currentAttributeRange = attributeRanges.value[props.varName];
+                // Update the glyph domain
+                const firstIndex = Math.floor(((extent[0] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * attributeRanges.value[props.varName].binLabels.length);
+                const secondIndex = Math.ceil(((extent[1] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * attributeRanges.value[props.varName].binLabels.length);
+
+                store.commit.addAttributeRange({
+                  ...currentAttributeRange,
+                  currentBinLabels: currentAttributeRange.binLabels.slice(firstIndex, secondIndex),
+                  currentBinValues: currentAttributeRange.binValues.slice(firstIndex, secondIndex),
+                });
+              }
             }
           });
 

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -154,6 +154,10 @@ export default Vue.extend({
       return store.state.attributeRanges;
     },
 
+    columnTypes() {
+      return store.state.columnTypes;
+    },
+
     attributeScales() {
       const scales: {[key: string]: ScaleLinear<number, number>} = {};
 
@@ -421,7 +425,22 @@ export default Vue.extend({
 
     nodeFill(node: Node) {
       const calculatedValue = node[this.nodeColorVariable];
-      const useCalculatedValue = !(this.displayCharts || calculatedValue < this.nodeColorScale.domain()[0] || calculatedValue > this.nodeColorScale.domain()[1]) && this.nodeColorVariable !== '';
+      const useCalculatedValue = !this.displayCharts
+      && (
+        // Numeric check
+        (
+          this.columnTypes[this.nodeColorVariable] === 'number'
+          && !(calculatedValue < this.nodeColorScale.domain()[0] || calculatedValue > this.nodeColorScale.domain()[1])
+          && this.nodeColorVariable !== ''
+        )
+        // Categorical check
+        || (
+          this.columnTypes[this.nodeColorVariable] !== 'number'
+          && this.attributeRanges[this.nodeColorVariable]
+          && (this.attributeRanges[this.nodeColorVariable].currentBinLabels || this.attributeRanges[this.nodeColorVariable].binLabels)
+            .find((label) => label.toString() === calculatedValue.toString())
+        )
+      );
 
       return useCalculatedValue ? this.nodeColorScale(calculatedValue) : '#DDDDDD';
     },

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -455,12 +455,27 @@ export default Vue.extend({
     },
 
     linkStyle(link: Link): string {
-      const linkColorScaleDomain = this.linkColorScale.domain();
-      const linkColor = this.linkVariables.color === '' ? '#888888' : this.linkColorScale(link[this.linkVariables.color]);
       const linkWidth = this.linkVariables.width === '' ? 1 : this.linkWidthScale(link[this.linkVariables.width]);
 
+      const calculatedColorValue = link[this.linkVariables.color];
+      const useCalculatedColorValue = this.linkVariables.color !== ''
+      && (
+        // Numeric check
+        (
+          this.columnTypes[this.linkVariables.color] === 'number'
+          && !(calculatedColorValue < this.linkColorScale.domain()[0] || calculatedColorValue > this.linkColorScale.domain()[1])
+        )
+        // Categorical check
+        || (
+          this.columnTypes[this.linkVariables.color] !== 'number'
+          && this.attributeRanges[this.linkVariables.color]
+          && (this.attributeRanges[this.linkVariables.color].currentBinLabels || this.attributeRanges[this.linkVariables.color].binLabels)
+            .find((label) => label.toString() === calculatedColorValue.toString())
+        )
+      );
+
       return `
-        stroke: ${(link[this.linkVariables.color] < linkColorScaleDomain[0] || link[this.linkVariables.color] > linkColorScaleDomain[1]) ? '#888888' : linkColor};
+        stroke: ${useCalculatedColorValue ? this.linkColorScale(calculatedColorValue) : '#888888'};
         stroke-width: ${(linkWidth > 20 || linkWidth < 1) ? 0 : linkWidth}px;
         opacity: 0.7;
       `;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -91,7 +91,8 @@ const {
           .domain([minValue, maxValue]);
       }
 
-      return scaleOrdinal(schemeCategory10);
+      const { binLabels } = state.attributeRanges[state.nodeColorVariable];
+      return scaleOrdinal(schemeCategory10).domain(binLabels);
     },
 
     linkColorScale(state) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -91,8 +91,7 @@ const {
           .domain([minValue, maxValue]);
       }
 
-      const { binLabels } = state.attributeRanges[state.nodeColorVariable];
-      return scaleOrdinal(schemeCategory10).domain(binLabels);
+      return state.nodeGlyphColorScale;
     },
 
     linkColorScale(state) {
@@ -104,7 +103,7 @@ const {
           .domain([minValue, maxValue]);
       }
 
-      return scaleOrdinal(schemeCategory10);
+      return state.nodeGlyphColorScale;
     },
 
     nodeSizeScale(state) {


### PR DESCRIPTION
Closes #247

Update the logic to fix color scale brushing for categorical node and link variables mapped to color. Since we're using `nodeGlyphColorScale` in the legend, we return that if we're not using the numeric scales for color.