### PR TITLE
Fix D3 force simulation forces, and some misc bugs

### DIFF
--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -3,7 +3,7 @@ import {
   scaleLinear, ScaleLinear,
 } from 'd3-scale';
 import {
-  forceCenter, forceCollide, forceLink, forceManyBody, forceSimulation,
+  forceCollide, forceLink, forceManyBody, forceSimulation, forceX, forceY,
 } from 'd3-force';
 
 import store from '@/store';
@@ -117,8 +117,13 @@ export default defineComponent({
 
       applyForceToSimulation(
         store.state.simulation,
-        'center',
-        forceCenter<Node>(width / 2, height / 2),
+        'x',
+        forceX<Node>(width / 2),
+      );
+      applyForceToSimulation(
+        store.state.simulation,
+        'y',
+        forceY<Node>(height / 2),
       );
       store.commit.startSimulation();
 
@@ -505,7 +510,8 @@ export default defineComponent({
       if (network.value !== null) {
       // Make the simulation
         const simulation = forceSimulation<Node, SimulationLink>()
-          .force('center', forceCenter(svgDimensions.value.width / 2, svgDimensions.value.height / 2))
+          .force('x', forceX(svgDimensions.value.width / 2))
+          .force('y', forceY(svgDimensions.value.height / 2))
           .force('charge', forceManyBody<Node>().strength(-250))
           .force('link', forceLink<Node, SimulationLink>().id((d) => { const datum = (d as Link); return datum._id; }))
           .force('collision', forceCollide((markerSize.value / 2) * 1.5));

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -513,10 +513,8 @@ export default defineComponent({
           .force('link', forceLink<Node, SimulationLink>(simulationLinks.value).id((d) => { const datum = (d as Link); return datum._id; }).strength(0.5))
           .force('x', forceX(svgDimensions.value.width / 2))
           .force('y', forceY(svgDimensions.value.height / 2))
-          .force('charge', forceManyBody<Node>().strength(-250))
-          .force('collision', forceCollide((markerSize.value / 2) * 1.5));
-
-        simulation
+          .force('charge', forceManyBody<Node>().strength(-100))
+          .force('collision', forceCollide((markerSize.value / 2) * 1.5))
           .on('tick', () => {
             if (currentInstance !== null) {
               currentInstance.proxy.$forceUpdate();

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -507,21 +507,14 @@ export default defineComponent({
     }
 
     onMounted(() => {
-      if (network.value !== null) {
+      if (network.value !== null && simulationLinks.value !== null) {
       // Make the simulation
-        const simulation = forceSimulation<Node, SimulationLink>()
+        const simulation = forceSimulation<Node, SimulationLink>(network.value.nodes)
+          .force('link', forceLink<Node, SimulationLink>(simulationLinks.value).id((d) => { const datum = (d as Link); return datum._id; }).strength(0.5))
           .force('x', forceX(svgDimensions.value.width / 2))
           .force('y', forceY(svgDimensions.value.height / 2))
           .force('charge', forceManyBody<Node>().strength(-250))
-          .force('link', forceLink<Node, SimulationLink>().id((d) => { const datum = (d as Link); return datum._id; }))
           .force('collision', forceCollide((markerSize.value / 2) * 1.5));
-
-        simulation
-          .nodes(network.value.nodes);
-
-        (simulation
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .force('link') as any).links(simulationLinks.value);
 
         simulation
           .on('tick', () => {

--- a/src/lib/d3ForceUtils.ts
+++ b/src/lib/d3ForceUtils.ts
@@ -6,11 +6,19 @@ import {
 export function applyForceToSimulation(
   simulation: Simulation<Node, SimulationLink> | null,
   forceType: 'x' | 'y' | 'charge' | 'link' | 'collision',
-  forceValue: ForceX<Node> | ForceY<Node> | ForceManyBody<Node> | ForceLink<Node, SimulationLink> | ForceCollide<Node>,
+  forceValue: ForceX<Node> | ForceY<Node> | ForceManyBody<Node> | ForceLink<Node, SimulationLink> | ForceCollide<Node> | undefined,
+  linkDistance?: number,
 ) {
   if (simulation === null) {
     return;
   }
 
-  simulation.force(forceType, forceValue);
+  if (forceType === 'link' && linkDistance !== undefined) {
+    const linkForce = simulation.force<ForceLink<Node, SimulationLink>>('link');
+    if (linkForce !== undefined) {
+      linkForce.distance(linkDistance);
+    }
+  } else if (forceValue !== undefined) {
+    simulation.force(forceType, forceValue);
+  }
 }

--- a/src/lib/d3ForceUtils.ts
+++ b/src/lib/d3ForceUtils.ts
@@ -1,12 +1,12 @@
 import { Node, SimulationLink } from '@/types';
 import {
-  ForceCenter, ForceManyBody, ForceLink, ForceCollide, Simulation,
+  ForceManyBody, ForceLink, ForceCollide, Simulation, ForceX, ForceY,
 } from 'd3-force';
 
 export function applyForceToSimulation(
   simulation: Simulation<Node, SimulationLink> | null,
-  forceType: 'center' | 'charge' | 'link' | 'collision',
-  forceValue: ForceCenter<Node> | ForceManyBody<Node> | ForceLink<Node, SimulationLink> | ForceCollide<Node>,
+  forceType: 'x' | 'y' | 'charge' | 'link' | 'collision',
+  forceValue: ForceX<Node> | ForceY<Node> | ForceManyBody<Node> | ForceLink<Node, SimulationLink> | ForceCollide<Node>,
 ) {
   if (simulation === null) {
     return;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -74,7 +74,7 @@ const {
       left: 0,
     },
     userInfo: null,
-    linkLength: 50,
+    linkLength: 10,
     svgDimensions: {
       height: 0,
       width: 0,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -559,6 +559,11 @@ const {
             'directionalEdges',
             'linkLength',
           ].forEach((primitiveVariable) => {
+            // If not modified, don't update
+            if (provenanceState[primitiveVariable] === storeState[primitiveVariable]) {
+              return;
+            }
+
             if (primitiveVariable === 'markerSize') {
               commit.setMarkerSize({ markerSize: provenanceState[primitiveVariable], updateProv: false });
             } else if (primitiveVariable === 'linkLength') {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -190,6 +190,11 @@ const {
     },
 
     addSelectedNode(state, nodesToAdd: string[]) {
+      // If no nodes, do nothing
+      if (nodesToAdd.length === 0) {
+        return;
+      }
+
       state.selectedNodes = new Set([...state.selectedNodes, ...nodesToAdd]);
 
       if (state.provenance !== null) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import Vuex from 'vuex';
 import { createDirectStore } from 'direct-vuex';
 import {
-  forceCollide, forceManyBody, Simulation,
+  forceCollide, Simulation,
 } from 'd3-force';
 
 import {
@@ -308,14 +308,12 @@ const {
       const { linkLength, updateProv } = payload;
       state.linkLength = linkLength;
 
-      // Scale value to between -500, 0 for d3
-      const linkLengthForce = (linkLength * -5);
-
       // Apply force to simulation and restart it
       applyForceToSimulation(
         state.simulation,
-        'charge',
-        forceManyBody<Node>().strength(linkLengthForce),
+        'link',
+        undefined,
+        linkLength * 10,
       );
       store.commit.startSimulation();
 


### PR DESCRIPTION
Fix link forces by binding it to simulation and then just updating the properties of the force instead of reapplying the whole force (causing us to lose the link binding).

I chose to use force x and force y instead of force center, since we can now define different parameters for each. I'm not sure this is necessary.

I also noticed a bunch of misc bugs:
- Setting a parameter in the vuex store would update the trrack store. The update to the trrack store would trigger the global observer and then re-set the same value back to vuex. This was causing the simulation to restart when you wouldn't want it to (e.g. selecting a node). I fixed this by adding a check to see if the value actually had changed.
- Node selection took an array and would show a provenance node for selecting nodes, even though no nodeID was in the array. The fix is just to return if the array is empty.