### PR TITLE
Fix the movement amplification by using .fx and .fy when available

### DIFF
--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -203,9 +203,9 @@ export default defineComponent({
                 // eslint-disable-next-line no-param-reassign
                 innerNode.y = (innerNode.y || 0) + dy;
                 // eslint-disable-next-line no-param-reassign
-                innerNode.fx = (innerNode.x || 0) + dx;
+                innerNode.fx = (innerNode.fx || innerNode.x || 0) + dx;
                 // eslint-disable-next-line no-param-reassign
-                innerNode.fy = (innerNode.y || 0) + dy;
+                innerNode.fy = (innerNode.fy || innerNode.y || 0) + dy;
               });
           }
         }


### PR DESCRIPTION
Closes #263

The movment logic was using .x and .y, which are updated by the simulation. To fix the amplification, I used .fx and .fy which are not updated when the simulation is running. This pins the node at the end of the move, but that's okay