### PR TITLE
Redirect user to multinet.app on logout

### DIFF
--- a/src/components/LoginMenu.vue
+++ b/src/components/LoginMenu.vue
@@ -92,7 +92,7 @@ export default defineComponent({
       // Redirect the user to the home page.
       // This is to prevent the logged-out user from continuing to look at, e.g.,
       // workspaces or tables they may have been viewing at the time of logout.
-      // TODO: #260
+      window.location.href = 'https://multinet.app';
     }
 
     // Get user info on created


### PR DESCRIPTION
Depends on #267
Closes #260

Redirect to mutinet.app on log out so that a user without privileges is no longer looking at data that might be privileged