### PR TITLE
Don't drag nodes on right click

### DIFF
--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -173,6 +173,11 @@ export default defineComponent({
     }
 
     function dragNode(node: Node, event: MouseEvent) {
+      // Only drag on left clicks
+      if (event.button !== 0) {
+        return;
+      }
+
       if (!(svg.value instanceof Element)) {
         throw new Error('SVG is not of type Element');
       }


### PR DESCRIPTION
Closes #269

Uses the same logic from rectSelectDrag to not drag nodes on right or middle click