### PR TITLE
Refactor applyNumericLayout to update existing nodes

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -361,8 +361,7 @@ const {
           .domain([range.min, range.max])
           .range([0, axis === 'x' ? state.svgDimensions.width : state.svgDimensions.height]);
 
-        const newNodes = state.network.nodes.map((oldNode) => {
-          const node = { ...oldNode };
+        state.network.nodes.forEach((node) => {
           // eslint-disable-next-line no-param-reassign
           node[axis] = positionScale(node[varName]);
           // eslint-disable-next-line no-param-reassign
@@ -376,13 +375,6 @@ const {
             // eslint-disable-next-line no-param-reassign
             node[`f${otherAxis}`] = otherSvgDimension / 2;
           }
-
-          return node;
-        });
-
-        store.commit.setNetwork({
-          nodes: newNodes,
-          edges: state.network.edges,
         });
       }
     },


### PR DESCRIPTION
Closes #264 

Previously if the network was laid out by a numeric variable, it was impossible to release nodes. I traced this back the whole node array being overwritten, which meant that the references to the nodes to release had been deleted.

The solution was to update the existing node positions, instead of replacing the node array.