### PR TITLE
Allow layout by categorical variables

### DIFF
--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -19,6 +19,16 @@ export default defineComponent({
         return true;
       })
       .sort());
+    const categoricalVariables = computed(() => Object.entries(store.state.columnTypes || {})
+      .filter(([, value]) => value !== 'number' && value !== 'label')
+      .map(([key]) => key)
+      .filter((key) => {
+        if (network.value !== null) {
+          return network.value.nodes[0][key] !== undefined;
+        }
+        return true;
+      })
+      .sort());
 
     function clearSelection() {
       store.commit.setSelected(new Set());
@@ -75,6 +85,7 @@ export default defineComponent({
     return {
       rightClickMenu,
       numericVariables,
+      categoricalVariables,
       clearSelection,
       pinSelectedNodes,
       unPinSelectedNodes,
@@ -230,18 +241,20 @@ export default defineComponent({
               >
                 <v-list-item-content>
                   <v-menu
-                    disabled
                     offset-x
+                    :disabled="categoricalVariables.length === 0"
                   >
                     <template #activator="{ on, attrs }">
                       <v-list-item-title
                         v-bind="attrs"
+                        :class="categoricalVariables.length === 0 ? 'grey--text text--lighten-1' : ''"
                         v-on="on"
                       >
                         Categorical Variable
                         <v-icon
                           dense
                           right
+                          :color="categoricalVariables.length === 0 ? 'grey lighten-1' : ''"
                         >
                           mdi-chevron-right
                         </v-icon>
@@ -249,7 +262,56 @@ export default defineComponent({
                     </template>
 
                     <v-list>
-                      This is where the categorical vars go
+                      <v-list-item
+                        v-for="catVar in categoricalVariables"
+                        :key="catVar"
+                        dense
+                      >
+                        <v-list-item-content>
+                          <v-menu
+                            offset-x
+                          >
+                            <template #activator="{ on, attrs }">
+                              <v-list-item-title
+                                v-bind="attrs"
+                                v-on="on"
+                              >
+                                {{ catVar }}
+                                <v-icon
+                                  dense
+                                  right
+                                >
+                                  mdi-chevron-right
+                                </v-icon>
+                              </v-list-item-title>
+                            </template>
+
+                            <v-list>
+                              <v-list-item
+                                dense
+                                @click="changeLayout(catVar, 'x')"
+                              >
+                                <v-list-item-content>
+                                  <v-list-item-title>
+                                    X-axis
+                                  </v-list-item-title>
+                                </v-list-item-content>
+                              </v-list-item>
+
+                              <v-list-item
+                                dense
+                                @click="changeLayout(catVar, 'y')"
+                              >
+                                <v-list-item-content>
+                                  <v-list-item-title>
+                                    Y-axis
+                                  </v-list-item-title>
+                                </v-list-item-content>
+                              </v-list-item>
+                            </v-list>
+                          </v-menu>
+                        </v-list-item-content>
+                      </v-list-item>
                     </v-list>
                   </v-menu>
                 </v-list-item-content>

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -69,7 +69,7 @@ export default defineComponent({
       }
     });
 
-    function changeLayout(numVar: string, axis: 'x' | 'y') {
+    function changeLayout(varName: string, axis: 'x' | 'y', type: 'numeric' | 'categorical') {
       // Close the menu
       store.commit.updateRightClickMenu({
         show: false,
@@ -77,7 +77,9 @@ export default defineComponent({
         left: rightClickMenu.value.left,
       });
 
-      store.commit.applyNumericLayout({ varName: numVar, axis, firstLayout: firstLayout.value });
+      store.commit.applyVariableLayout({
+        varName, axis, firstLayout: firstLayout.value, type,
+      });
 
       firstLayout.value = false;
     }
@@ -208,7 +210,7 @@ export default defineComponent({
                             <v-list>
                               <v-list-item
                                 dense
-                                @click="changeLayout(numVar, 'x')"
+                                @click="changeLayout(numVar, 'x', 'numeric')"
                               >
                                 <v-list-item-content>
                                   <v-list-item-title>
@@ -219,7 +221,7 @@ export default defineComponent({
 
                               <v-list-item
                                 dense
-                                @click="changeLayout(numVar, 'y')"
+                                @click="changeLayout(numVar, 'y', 'numeric')"
                               >
                                 <v-list-item-content>
                                   <v-list-item-title>
@@ -289,7 +291,7 @@ export default defineComponent({
                             <v-list>
                               <v-list-item
                                 dense
-                                @click="changeLayout(catVar, 'x')"
+                                @click="changeLayout(catVar, 'x', 'categorical')"
                               >
                                 <v-list-item-content>
                                   <v-list-item-title>
@@ -300,7 +302,7 @@ export default defineComponent({
 
                               <v-list-item
                                 dense
-                                @click="changeLayout(catVar, 'y')"
+                                @click="changeLayout(catVar, 'y', 'categorical')"
                               >
                                 <v-list-item-content>
                                   <v-list-item-title>

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -156,7 +156,7 @@ export default defineComponent({
               </v-list-item-title>
             </template>
 
-            <v-list>
+            <v-list :width="175">
               <v-list-item
                 dense
               >


### PR DESCRIPTION
Closes #220

Adds layout by categorical variables to the context menu.

There were a few changes required to enable these layouts. The first is finding the categorical variables. Second is adding the menu options. Third is changing the layout function to work with categorical variables. 

We'll still need to add scales for the layouts so we know what is where. We might also want to add some jitter so it's visible

@alexsb we'll need to chat about some of this design, but hopefully the required changes are small.