### PR TITLE
Add axes to variable driven layouts

### DIFF
--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -6,9 +6,8 @@ import {
 
 export default defineComponent({
   setup() {
-    const rightClickMenu = computed(() => store.state.rightClickMenu);
-    const selectedNodes = computed(() => store.state.selectedNodes);
     const network = computed(() => store.state.network);
+
     const numericVariables = computed(() => Object.entries(store.state.columnTypes || {})
       .filter(([, value]) => value === 'number')
       .map(([key]) => key)
@@ -30,10 +29,10 @@ export default defineComponent({
       })
       .sort());
 
+    const selectedNodes = computed(() => store.state.selectedNodes);
     function clearSelection() {
       store.commit.setSelected(new Set());
     }
-
     function pinSelectedNodes() {
       if (network.value !== null) {
         network.value.nodes
@@ -46,7 +45,6 @@ export default defineComponent({
           });
       }
     }
-
     function unPinSelectedNodes() {
       if (network.value !== null) {
         network.value.nodes
@@ -60,6 +58,7 @@ export default defineComponent({
       }
     }
 
+    const rightClickMenu = computed(() => store.state.rightClickMenu);
     function changeLayout(varName: string, axis: 'x' | 'y') {
       // Close the menu
       store.commit.updateRightClickMenu({

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -524,6 +524,10 @@ export default defineComponent({
         }
       });
     }
+    if (network.value !== null) {
+      generateNodePositions(network.value.nodes);
+    }
+
     const simulationEdges = computed(() => {
       if (network.value !== null) {
         return network.value.edges.map((edge: Edge) => {
@@ -539,8 +543,6 @@ export default defineComponent({
     });
     onMounted(() => {
       if (network.value !== null && simulationEdges.value !== null) {
-        generateNodePositions(network.value.nodes);
-
         // Make the simulation
         const simulation = forceSimulation<Node, SimulationEdge>(network.value.nodes)
           .force('edge', forceLink<Node, SimulationEdge>(simulationEdges.value).id((d) => { const datum = (d as Edge); return datum._id; }).strength(0.5))
@@ -574,18 +576,18 @@ export default defineComponent({
       if (store.state.columnTypes !== null && layoutVars.value.x !== null) {
         const type = store.state.columnTypes[layoutVars.value.x];
         const range = store.state.attributeRanges[layoutVars.value.x];
-        const maxPosition = store.state.svgDimensions.width;
+        const maxPosition = store.state.svgDimensions.width - 10;
 
         let positionScale;
 
         if (type === 'number') {
           positionScale = scaleLinear()
             .domain([range.min, range.max])
-            .range([yAxisPadding, maxPosition - 10]);
+            .range([yAxisPadding, maxPosition]);
         } else {
           positionScale = scaleBand()
             .domain(range.binLabels)
-            .range([yAxisPadding, maxPosition - 10]);
+            .range([yAxisPadding, maxPosition]);
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -90,6 +90,9 @@ export default defineComponent({
       };
       store.commit.setSvgDimensions(dimensions);
 
+      return dimensions;
+    });
+    watch([svgDimensions], () => {
       // If we're in a static layout, then redraw the layout
       const xLayout = store.state.layoutVars.x !== null;
       const yLayout = store.state.layoutVars.y !== null;
@@ -104,8 +107,6 @@ export default defineComponent({
       if (!xLayout && !yLayout) {
         store.commit.startSimulation();
       }
-
-      return dimensions;
     });
 
     function selectNode(node: Node) {

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -596,6 +596,28 @@ export default defineComponent({
         axisGroup
           .attr('transform', `translate(0, ${svgDimensions.value.height - xAxisPadding})`)
           .call(xAxis);
+
+        // Add the axis label
+        const labelGroup = axisGroup
+          .append('g');
+
+        const label = labelGroup
+          .append('text')
+          .text(layoutVars.value.x)
+          .attr('fill', 'currentColor')
+          .attr('font-size', '14px')
+          .attr('font-weight', 'bold')
+          .attr('x', (maxPosition - yAxisPadding) / 2)
+          .attr('y', xAxisPadding - 20);
+
+        const labelRectPos = (label.node() as SVGTextElement).getBBox();
+        labelGroup
+          .insert('rect', 'text')
+          .attr('x', labelRectPos.x)
+          .attr('y', labelRectPos.y)
+          .attr('width', labelRectPos.width)
+          .attr('height', labelRectPos.height)
+          .attr('fill', 'white');
       }
 
       // Add y layout
@@ -626,6 +648,27 @@ export default defineComponent({
           .attr('transform', `translate(${yAxisPadding}, 0)`)
           .call(yAxis);
 
+        // Add the axis label
+        const labelGroup = axisGroup
+          .attr('transform', 'rotate(90)');
+
+        const label = labelGroup
+          .append('text')
+          .text(layoutVars.value.y)
+          .attr('fill', 'currentColor')
+          .attr('font-size', '14px')
+          .attr('font-weight', 'bold')
+          .attr('x', (maxPosition) / 2)
+          .attr('y', yAxisPadding - 20);
+
+        const labelRectPos = (label.node() as SVGTextElement).getBBox();
+        labelGroup
+          .insert('rect', 'text')
+          .attr('x', labelRectPos.x)
+          .attr('y', labelRectPos.y)
+          .attr('width', labelRectPos.width)
+          .attr('height', labelRectPos.height)
+          .attr('fill', 'white');
       }
     });
 

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -566,6 +566,8 @@ export default defineComponent({
     const layoutVars = computed(() => store.state.layoutVars);
     watch(layoutVars, () => {
       select('#axes').selectAll('g').remove();
+      const xAxisPadding = 60;
+      const yAxisPadding = 80;
 
       // Add x layout
       if (store.state.columnTypes !== null && layoutVars.value.x !== null) {
@@ -578,18 +580,21 @@ export default defineComponent({
         if (type === 'number') {
           positionScale = scaleLinear()
             .domain([range.min, range.max])
-            .range([60, maxPosition - 10]);
+            .range([yAxisPadding, maxPosition - 10]);
         } else {
           positionScale = scaleBand()
             .domain(range.binLabels)
-            .range([60, maxPosition - 10]);
+            .range([yAxisPadding, maxPosition - 10]);
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const xAxis = axisBottom(positionScale as any);
-        select('#axes')
-          .append('g')
-          .attr('transform', `translate(0, ${svgDimensions.value.height - 30})`)
+        const axisGroup = select('#axes')
+          .append('g');
+
+        // Add the axis
+        axisGroup
+          .attr('transform', `translate(0, ${svgDimensions.value.height - xAxisPadding})`)
           .call(xAxis);
       }
 
@@ -597,26 +602,30 @@ export default defineComponent({
       if (store.state.columnTypes !== null && layoutVars.value.y !== null) {
         const type = store.state.columnTypes[layoutVars.value.y];
         const range = store.state.attributeRanges[layoutVars.value.y];
-        const maxPosition = store.state.svgDimensions.height;
+        const maxPosition = store.state.svgDimensions.height - xAxisPadding;
 
         let positionScale;
 
         if (type === 'number') {
           positionScale = scaleLinear()
             .domain([range.min, range.max])
-            .range([10, maxPosition - 30]);
+            .range([maxPosition, 10]);
         } else {
           positionScale = scaleBand()
             .domain(range.binLabels)
-            .range([10, maxPosition - 30]);
+            .range([maxPosition, 10]);
         }
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const xAxis = axisLeft(positionScale as any);
-        select('#axes')
-          .append('g')
-          .attr('transform', 'translate(60, 0)')
-          .call(xAxis);
+        const yAxis = axisLeft(positionScale as any);
+        const axisGroup = select('#axes')
+          .append('g');
+
+        // Add the axis
+        axisGroup
+          .attr('transform', `translate(${yAxisPadding}, 0)`)
+          .call(yAxis);
+
       }
     });
 

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -610,7 +610,7 @@ export default defineComponent({
           .attr('fill', 'currentColor')
           .attr('font-size', '14px')
           .attr('font-weight', 'bold')
-          .attr('x', (maxPosition - yAxisPadding) / 2)
+          .attr('x', ((maxPosition - yAxisPadding) / 2) + yAxisPadding)
           .attr('y', xAxisPadding - 20);
 
         const labelRectPos = (label.node() as SVGTextElement).getBBox();
@@ -662,7 +662,8 @@ export default defineComponent({
           .attr('fill', 'currentColor')
           .attr('font-size', '14px')
           .attr('font-weight', 'bold')
-          .attr('x', (maxPosition) / 2)
+          .attr('text-anchor', 'middle')
+          .attr('x', ((maxPosition - 10) / 2) + 10)
           .attr('y', yAxisPadding - 20);
 
         const labelRectPos = (label.node() as SVGTextElement).getBBox();

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -565,7 +565,6 @@ export default defineComponent({
 
     const layoutVars = computed(() => store.state.layoutVars);
     watch(layoutVars, () => {
-      console.log('updating');
       select('#axes').selectAll('g').remove();
 
       // Add x layout

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -648,12 +648,9 @@ export default defineComponent({
           .attr('transform', `translate(${yAxisPadding}, 0)`)
           .call(yAxis);
 
-        // Add the axis label
-        const labelGroup = axisGroup
-          .attr('transform', 'rotate(90)');
-
-        const label = labelGroup
+        const label = axisGroup
           .append('text')
+          .attr('transform', 'rotate(90)')
           .text(layoutVars.value.y)
           .attr('fill', 'currentColor')
           .attr('font-size', '14px')
@@ -662,7 +659,7 @@ export default defineComponent({
           .attr('y', yAxisPadding - 20);
 
         const labelRectPos = (label.node() as SVGTextElement).getBBox();
-        labelGroup
+        axisGroup
           .insert('rect', 'text')
           .attr('x', labelRectPos.x)
           .attr('y', labelRectPos.y)

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -23,62 +23,16 @@ export default defineComponent({
   },
 
   setup() {
+    // Commonly used variables
     const currentInstance = getCurrentInstance();
-
-    const svg: Ref<Element | null> = ref(null);
-    const straightEdges = ref(false);
-    const tooltipMessage = ref('');
-    const toggleTooltip = ref(false);
-    const tooltipPosition = ref({ x: 0, y: 0 });
-    const nestedPadding = ref(5);
-    const rectSelect = ref({
-      x: 0,
-      y: 0,
-      width: 0,
-      height: 0,
-      transformX: 0,
-      transformY: 0,
-    });
-
     const network = computed(() => store.state.network);
-    const simulationEdges = computed(() => {
-      if (network.value !== null) {
-        return network.value.edges.map((edge: Edge) => {
-          const newEdge: SimulationEdge = {
-            ...JSON.parse(JSON.stringify(edge)),
-            source: edge._from,
-            target: edge._to,
-          };
-          return newEdge;
-        });
-      }
-      return null;
-    });
+    const svg: Ref<Element | null> = ref(null);
     const selectedNodes = computed(() => store.state.selectedNodes);
-    const oneHop = computed(() => {
-      if (network.value !== null) {
-        const inNodes = network.value.edges.map((edge) => (selectedNodes.value.has(edge._to) ? edge._from : null));
-        const outNodes = network.value.edges.map((edge) => (selectedNodes.value.has(edge._from) ? edge._to : null));
-
-        const oneHopNodeIDs: Set<string | null> = new Set([...outNodes, ...inNodes]);
-
-        // Remove null if it exists
-        if (oneHopNodeIDs.has(null)) {
-          oneHopNodeIDs.delete(null);
-        }
-
-        return oneHopNodeIDs;
-      }
-      return new Set();
-    });
-    const nodeColorScale = computed(() => store.getters.nodeColorScale);
     const nodeBarColorScale = computed(() => store.state.nodeBarColorScale);
-    const nodeGlyphColorScale = computed(() => store.state.nodeGlyphColorScale);
-    const tooltipStyle = computed(() => `left: ${tooltipPosition.value.x}px; top: ${tooltipPosition.value.y}px`);
-    const fontSize = computed(() => store.state.fontSize || 0);
-    const nodeTextStyle = computed(() => `font-size: ${fontSize.value}pt;`);
+    const nodeTextStyle = computed(() => `font-size: ${store.state.fontSize || 0}pt;`);
     const nestedVariables = computed(() => store.state.nestedVariables);
     const markerSize = computed(() => store.state.markerSize || 0);
+    const nestedPadding = ref(5);
     const nestedBarWidth = computed(() => {
       const hasGlyphs = nestedVariables.value.glyph.length !== 0;
       const totalColumns = nestedVariables.value.bar.length + (hasGlyphs ? 1 : 0);
@@ -91,10 +45,7 @@ export default defineComponent({
     const nestedBarHeight = computed(() => markerSize.value - 24);
     const displayCharts = computed(() => store.state.displayCharts);
     const labelVariable = computed(() => store.state.labelVariable);
-    const nodeColorVariable = computed(() => store.state.nodeColorVariable);
     const selectNeighbors = computed(() => store.state.selectNeighbors);
-    const edgeVariables = computed(() => store.state.edgeVariables);
-    const nodeSizeVariable = computed(() => store.state.nodeSizeVariable);
     const attributeRanges = computed(() => store.state.attributeRanges);
     const columnTypes = computed(() => store.state.columnTypes);
     const attributeScales = computed(() => {
@@ -109,8 +60,12 @@ export default defineComponent({
       }
       return scales;
     });
-    const edgeWidthScale = computed(() => store.getters.edgeWidthScale);
     const controlsWidth = computed(() => store.state.controlsWidth);
+    const directionalEdges = computed(() => store.state.directionalEdges);
+    const edgeColorScale = computed(() => store.getters.edgeColorScale);
+
+    // Update height and width as the window size changes
+    // Also update center attraction forces as the size changes
     const svgDimensions = computed(() => {
       const height = currentInstance !== null ? currentInstance.proxy.$vuetify.breakpoint.height : 0;
       const width = currentInstance !== null ? currentInstance.proxy.$vuetify.breakpoint.width - controlsWidth.value : 0;
@@ -149,21 +104,6 @@ export default defineComponent({
 
       return dimensions;
     });
-    const directionalEdges = computed(() => store.state.directionalEdges);
-    const nodeSizeScale = computed(() => store.getters.nodeSizeScale);
-    const edgeColorScale = computed(() => store.getters.edgeColorScale);
-
-    function generateNodePositions(nodes: Node[]) {
-      nodes.forEach((node) => {
-        // If the position is not defined for x or y, generate it
-        if (node.x === undefined || node.y === undefined) {
-          // eslint-disable-next-line no-param-reassign
-          node.x = Math.random() * svgDimensions.value.width;
-          // eslint-disable-next-line no-param-reassign
-          node.y = Math.random() * svgDimensions.value.height;
-        }
-      });
-    }
 
     function selectNode(node: Node) {
       if (selectedNodes.value.has(node._id)) {
@@ -173,6 +113,8 @@ export default defineComponent({
       }
     }
 
+    const nodeSizeVariable = computed(() => store.state.nodeSizeVariable);
+    const nodeSizeScale = computed(() => store.getters.nodeSizeScale);
     function calculateNodeSize(node: Node) {
       // Don't render dynamic node size if the size variable is empty or
       // we want to display charts
@@ -271,6 +213,10 @@ export default defineComponent({
       svg.value.addEventListener('mouseup', stopFn);
     }
 
+    const tooltipMessage = ref('');
+    const toggleTooltip = ref(false);
+    const tooltipPosition = ref({ x: 0, y: 0 });
+    const tooltipStyle = computed(() => `left: ${tooltipPosition.value.x}px; top: ${tooltipPosition.value.y}px`);
     function showTooltip(element: Node | Edge, event: MouseEvent) {
       tooltipPosition.value = {
         x: event.clientX - controlsWidth.value,
@@ -339,9 +285,6 @@ export default defineComponent({
         const xRotation = 0;
         const largeArc = 0;
 
-        if (straightEdges.value) {
-          return (`M ${x1} ${y1} L ${x2} ${y2}`);
-        }
         return (`M ${x1}, ${y1} A ${dr}, ${dr} ${xRotation}, ${largeArc}, ${sweep} ${x2},${y2}`);
       }
       return '';
@@ -351,6 +294,22 @@ export default defineComponent({
       return selectedNodes.value.has(nodeID);
     }
 
+    const oneHop = computed(() => {
+      if (network.value !== null) {
+        const inNodes = network.value.edges.map((edge) => (selectedNodes.value.has(edge._to) ? edge._from : null));
+        const outNodes = network.value.edges.map((edge) => (selectedNodes.value.has(edge._from) ? edge._to : null));
+
+        const oneHopNodeIDs: Set<string | null> = new Set([...outNodes, ...inNodes]);
+
+        // Remove null if it exists
+        if (oneHopNodeIDs.has(null)) {
+          oneHopNodeIDs.delete(null);
+        }
+
+        return oneHopNodeIDs;
+      }
+      return new Set();
+    });
     function nodeGroupClass(node: Node): string {
       if (selectedNodes.value.size > 0) {
         const selected = isSelected(node._id);
@@ -368,6 +327,8 @@ export default defineComponent({
       return `node nodeBox ${selectedClass}`;
     }
 
+    const nodeColorVariable = computed(() => store.state.nodeColorVariable);
+    const nodeColorScale = computed(() => store.getters.nodeColorScale);
     function nodeFill(node: Node) {
       const calculatedValue = node[nodeColorVariable.value];
       const useCalculatedValue = !displayCharts.value && columnTypes.value !== null
@@ -399,6 +360,8 @@ export default defineComponent({
       return 'edgeGroup';
     }
 
+    const edgeWidthScale = computed(() => store.getters.edgeWidthScale);
+    const edgeVariables = computed(() => store.state.edgeVariables);
     function edgeStyle(edge: Edge): string {
       const edgeWidth = edgeVariables.value.width === '' ? 1 : edgeWidthScale.value(edge[edgeVariables.value.width]);
 
@@ -426,6 +389,7 @@ export default defineComponent({
       `;
     }
 
+    const nodeGlyphColorScale = computed(() => store.state.nodeGlyphColorScale);
     function glyphFill(node: Node, glyphVar: string) {
       // Figure out what values should be mapped to colors
       const possibleValues = [
@@ -440,6 +404,14 @@ export default defineComponent({
       return scaleContainsValue ? nodeGlyphColorScale.value(node[glyphVar]) : '#000000';
     }
 
+    const rectSelect = ref({
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      transformX: 0,
+      transformY: 0,
+    });
     function rectSelectDrag(event: MouseEvent) {
       // Only drag on left clicks
       if (event.button !== 0) {
@@ -537,13 +509,35 @@ export default defineComponent({
       event.preventDefault();
     }
 
-    if (network.value !== null) {
-      generateNodePositions(network.value.nodes);
+    function generateNodePositions(nodes: Node[]) {
+      nodes.forEach((node) => {
+        // If the position is not defined for x or y, generate it
+        if (node.x === undefined || node.y === undefined) {
+          // eslint-disable-next-line no-param-reassign
+          node.x = Math.random() * svgDimensions.value.width;
+          // eslint-disable-next-line no-param-reassign
+          node.y = Math.random() * svgDimensions.value.height;
+        }
+      });
     }
-
+    const simulationEdges = computed(() => {
+      if (network.value !== null) {
+        return network.value.edges.map((edge: Edge) => {
+          const newEdge: SimulationEdge = {
+            ...JSON.parse(JSON.stringify(edge)),
+            source: edge._from,
+            target: edge._to,
+          };
+          return newEdge;
+        });
+      }
+      return null;
+    });
     onMounted(() => {
       if (network.value !== null && simulationEdges.value !== null) {
-      // Make the simulation
+        generateNodePositions(network.value.nodes);
+
+        // Make the simulation
         const simulation = forceSimulation<Node, SimulationEdge>(network.value.nodes)
           .force('edge', forceLink<Node, SimulationEdge>(simulationEdges.value).id((d) => { const datum = (d as Edge); return datum._id; }).strength(0.5))
           .force('x', forceX(svgDimensions.value.width / 2))

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -649,9 +649,13 @@ export default defineComponent({
           .attr('transform', `translate(${yAxisPadding}, 0)`)
           .call(yAxis);
 
-        const label = axisGroup
+        // Add the axis label
+        const labelGroup = axisGroup
+          .append('g')
+          .attr('transform', 'rotate(90)');
+
+        const label = labelGroup
           .append('text')
-          .attr('transform', 'rotate(90)')
           .text(layoutVars.value.y)
           .attr('fill', 'currentColor')
           .attr('font-size', '14px')
@@ -660,7 +664,7 @@ export default defineComponent({
           .attr('y', yAxisPadding - 20);
 
         const labelRectPos = (label.node() as SVGTextElement).getBBox();
-        axisGroup
+        labelGroup
           .insert('rect', 'text')
           .attr('x', labelRectPos.x)
           .attr('y', labelRectPos.y)

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -787,6 +787,7 @@ export default defineComponent({
             @mousedown="dragNode(node, $event)"
           />
           <rect
+            v-if="labelVariable !== undefined"
             class="labelBackground"
             height="1em"
             :y="!displayCharts ? (calculateNodeSize(node) / 2) - 8 : 0"

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -349,9 +349,9 @@ const {
         } = payload;
         const type = state.columnTypes[varName];
         const range = state.attributeRanges[varName];
-        const maxPosition = axis === 'x' ? state.svgDimensions.width : state.svgDimensions.height;
         const otherAxis = axis === 'x' ? 'y' : 'x';
-        const axisPadding = axis === 'x' ? 60 : 30;
+        const otherAxisPadding = axis === 'x' ? 80 : 60;
+        const maxPosition = axis === 'x' ? state.svgDimensions.width : state.svgDimensions.height - otherAxisPadding - state.markerSize;
 
         if (type === 'number') {
           let positionScale: ScaleLinear<number, number>;
@@ -359,11 +359,11 @@ const {
           if (axis === 'x') {
             positionScale = scaleLinear()
               .domain([range.min, range.max])
-              .range([axisPadding, maxPosition]);
+              .range([otherAxisPadding, maxPosition - 10]);
           } else {
             positionScale = scaleLinear()
               .domain([range.min, range.max])
-              .range([0, maxPosition - axisPadding]);
+              .range([maxPosition, 10]);
           }
 
           state.network.nodes.forEach((node) => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -168,8 +168,7 @@ const {
         state.simulation.restart();
         state.simulationRunning = true;
 
-        state.layoutVars.x = null;
-        state.layoutVars.y = null;
+        state.layoutVars = { x: null, y: null };
       }
     },
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,7 +11,7 @@ import {
 import api from '@/api';
 import { ColumnTypes, NetworkSpec, UserSpec } from 'multinet';
 import {
-  scaleBand, scaleLinear, scaleOrdinal, scaleSequential,
+  scaleBand, ScaleLinear, scaleLinear, scaleOrdinal, scaleSequential,
 } from 'd3-scale';
 import { interpolateBlues, interpolateReds, schemeCategory10 } from 'd3-scale-chromatic';
 import { initProvenance, Provenance } from '@visdesignlab/trrack';
@@ -351,11 +351,20 @@ const {
         const range = state.attributeRanges[varName];
         const maxPosition = axis === 'x' ? state.svgDimensions.width : state.svgDimensions.height;
         const otherAxis = axis === 'x' ? 'y' : 'x';
+        const axisPadding = axis === 'x' ? 60 : 30;
 
         if (type === 'number') {
-          const positionScale = scaleLinear()
-            .domain([range.min, range.max])
-            .range([0, maxPosition]);
+          let positionScale: ScaleLinear<number, number>;
+
+          if (axis === 'x') {
+            positionScale = scaleLinear()
+              .domain([range.min, range.max])
+              .range([axisPadding, maxPosition]);
+          } else {
+            positionScale = scaleLinear()
+              .domain([range.min, range.max])
+              .range([0, maxPosition - axisPadding]);
+          }
 
           state.network.nodes.forEach((node) => {
             // eslint-disable-next-line no-param-reassign

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,7 +11,7 @@ import {
 import api from '@/api';
 import { ColumnTypes, NetworkSpec, UserSpec } from 'multinet';
 import {
-  scaleBand, ScaleLinear, scaleLinear, scaleOrdinal, scaleSequential,
+  ScaleBand, scaleBand, ScaleLinear, scaleLinear, scaleOrdinal, scaleSequential,
 } from 'd3-scale';
 import { interpolateBlues, interpolateReds, schemeCategory10 } from 'd3-scale-chromatic';
 import { initProvenance, Provenance } from '@visdesignlab/trrack';
@@ -381,10 +381,20 @@ const {
             }
           });
         } else {
-          const positionScale = scaleBand()
-            .domain(range.binLabels)
-            .range([0, maxPosition]);
-          const positionOffset = maxPosition / (2 * range.binLabels.length);
+          let positionScale: ScaleBand<string>;
+
+          if (axis === 'x') {
+            positionScale = scaleBand()
+              .domain(range.binLabels)
+              .range([otherAxisPadding, maxPosition]);
+          } else {
+            positionScale = scaleBand()
+              .domain(range.binLabels)
+              .range([maxPosition, 0]);
+          }
+          const positionOffset = axis === 'x' ? otherAxisPadding : otherAxisPadding / 2;
+
+          console.log('store', positionScale);
 
           state.network.nodes.forEach((node) => {
             // eslint-disable-next-line no-param-reassign

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -372,7 +372,7 @@ const {
             // eslint-disable-next-line no-param-reassign
             node[`f${axis}`] = positionScale(node[varName]);
 
-            if (state.layoutVars.x === null && state.layoutVars.y === null) {
+            if (state.layoutVars[otherAxis] === null) {
               const otherSvgDimension = axis === 'x' ? state.svgDimensions.height : state.svgDimensions.width;
               // eslint-disable-next-line no-param-reassign
               node[otherAxis] = otherSvgDimension / 2;
@@ -400,7 +400,7 @@ const {
             // eslint-disable-next-line no-param-reassign
             node[`f${axis}`] = (positionScale(node[varName]) || 0) + positionOffset;
 
-            if (state.layoutVars.x === null && state.layoutVars.y === null) {
+            if (state.layoutVars[otherAxis] === null) {
               const otherSvgDimension = axis === 'x' ? state.svgDimensions.height : state.svgDimensions.width;
               // eslint-disable-next-line no-param-reassign
               node[otherAxis] = otherSvgDimension / 2;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -394,8 +394,6 @@ const {
           }
           const positionOffset = axis === 'x' ? otherAxisPadding : otherAxisPadding / 2;
 
-          console.log('store', positionScale);
-
           state.network.nodes.forEach((node) => {
             // eslint-disable-next-line no-param-reassign
             node[axis] = (positionScale(node[varName]) || 0) + positionOffset;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -351,7 +351,7 @@ const {
         const range = state.attributeRanges[varName];
         const otherAxis = axis === 'x' ? 'y' : 'x';
         const otherAxisPadding = axis === 'x' ? 80 : 60;
-        const maxPosition = axis === 'x' ? state.svgDimensions.width : state.svgDimensions.height - otherAxisPadding - state.markerSize;
+        const maxPosition = axis === 'x' ? state.svgDimensions.width - 10 : state.svgDimensions.height - otherAxisPadding - state.markerSize;
 
         if (type === 'number') {
           let positionScale: ScaleLinear<number, number>;
@@ -359,7 +359,7 @@ const {
           if (axis === 'x') {
             positionScale = scaleLinear()
               .domain([range.min, range.max])
-              .range([otherAxisPadding, maxPosition - 10]);
+              .range([otherAxisPadding, maxPosition]);
           } else {
             positionScale = scaleLinear()
               .domain([range.min, range.max])
@@ -382,17 +382,19 @@ const {
           });
         } else {
           let positionScale: ScaleBand<string>;
+          let positionOffset: number;
 
           if (axis === 'x') {
             positionScale = scaleBand()
               .domain(range.binLabels)
               .range([otherAxisPadding, maxPosition]);
+            positionOffset = (maxPosition - otherAxisPadding) / ((range.binLabels.length) * 2);
           } else {
             positionScale = scaleBand()
               .domain(range.binLabels)
-              .range([maxPosition, 0]);
+              .range([maxPosition, 10]);
+            positionOffset = (maxPosition - 10) / ((range.binLabels.length) * 2);
           }
-          const positionOffset = axis === 'x' ? otherAxisPadding : otherAxisPadding / 2;
 
           state.network.nodes.forEach((node) => {
             // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
Depends on #281
Closes (Looks like I didn't make this an issue...)


Add d3 axis to the bottom and left that show the values for nodes in a variable driven layout. I added some extra padding on the x and y scale in the index so that the nodes didn't overlap the axes.

There are also a couple small changes to how the variables are grouped together in the multilink file.

TODO:
- [x] Add axis labels
- [x] y-axis is flipped. Correct to lower values at the bottom
- [x] Layout is applied twice
- [x] Node values are off when the screen is resized
- [x] Fix misalignment of axes to node values (they're off an inconsistent amount for each tick, see image below)
![image](https://user-images.githubusercontent.com/36867477/139104598-cbdbf747-dc4d-4721-9f40-35fc58e7f52c.png)
