### PR TITLE
Only compute forces on links that are visible

### DIFF
--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -544,6 +544,23 @@ export default defineComponent({
       }
       return null;
     });
+    watch(attributeRanges, () => {
+      if (simulationEdges.value !== null) {
+        const simEdges = simulationEdges.value.filter((edge: Edge) => {
+          if (edgeVariables.value.width !== '') {
+            const widthValue = edgeWidthScale.value(edge[edgeVariables.value.width]);
+            return widthValue < 20 && widthValue > 1;
+          }
+          return true;
+        });
+
+        applyForceToSimulation(
+          store.state.simulation,
+          'edge',
+          forceLink<Node, SimulationEdge>(simEdges).id((d) => { const datum = (d as Edge); return datum._id; }).strength(0.5),
+        );
+      }
+    });
     onMounted(() => {
       if (network.value !== null && simulationEdges.value !== null) {
         // Make the simulation

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -565,10 +565,10 @@ export default defineComponent({
       if (network.value !== null && simulationEdges.value !== null) {
         // Make the simulation
         const simulation = forceSimulation<Node, SimulationEdge>(network.value.nodes)
-          .force('edge', forceLink<Node, SimulationEdge>(simulationEdges.value).id((d) => { const datum = (d as Edge); return datum._id; }).strength(0.5))
+          .force('edge', forceLink<Node, SimulationEdge>(simulationEdges.value).id((d) => { const datum = (d as Edge); return datum._id; }).strength(1))
           .force('x', forceX(svgDimensions.value.width / 2))
           .force('y', forceY(svgDimensions.value.height / 2))
-          .force('charge', forceManyBody<Node>().strength(-100))
+          .force('charge', forceManyBody<Node>().strength(-500))
           .force('collision', forceCollide((markerSize.value / 2) * 1.5))
           .on('tick', () => {
             if (currentInstance !== null) {


### PR DESCRIPTION
Closes #258

Adds a watcher for the edge scale that recomputes the edges that should be included in the d3.force calculations. This means when an edge is removed by brushing, it doesn't keep pulling the nodes together