### PR TITLE
When selectNeighbors is false, don't mute other nodes/edges

### DIFF
--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -321,7 +321,7 @@ export default defineComponent({
       if (selectedNodes.value.size > 0) {
         const selected = isSelected(node._id);
         const inOneHop = selectNeighbors.value ? oneHop.value.has(node._id) : false;
-        const selectedClass = selected || inOneHop ? '' : 'muted';
+        const selectedClass = selected || inOneHop || !selectNeighbors.value ? '' : 'muted';
         return `nodeGroup ${selectedClass}`;
       }
       return 'nodeGroup';
@@ -361,7 +361,7 @@ export default defineComponent({
     function edgeGroupClass(edge: Edge): string {
       if (selectedNodes.value.size > 0) {
         const selected = isSelected(edge._from) || isSelected(edge._to);
-        const selectedClass = selected && selectNeighbors.value ? '' : 'muted';
+        const selectedClass = selected || !selectNeighbors.value ? '' : 'muted';
         return `edgeGroup ${selectedClass}`;
       }
       return 'edgeGroup';


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #298

### Give a longer description of what this PR addresses and why it's needed
Don't mute nodes when "Autoselect neighbors" is disabled. Instead, keep all nodes the same opacity and just highlight with the ring around the node.

### Provide pictures/videos of the behavior before and after these changes (optional)
Before:
![image](https://user-images.githubusercontent.com/2039375/149524558-04ce1e10-8130-4511-a520-a1a7c1bd0676.png)

After:
![image](https://user-images.githubusercontent.com/36867477/149565210-9f6bc183-5f5f-4cdf-9bbe-2db27024d776.png)

### Are there any additional TODOs before this PR is ready to go?
No