### PR TITLE
Remove node backgrounds

### DIFF
--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -811,19 +811,12 @@ export default defineComponent({
             @mouseout="hideTooltip"
             @mousedown="dragNode(node, $event)"
           />
-          <rect
-            v-if="labelVariable !== undefined"
-            class="labelBackground"
-            height="1em"
-            :y="!displayCharts ? (calculateNodeSize(node) / 2) - 8 : 0"
-            :width="calculateNodeSize(node)"
-          />
           <text
             class="label"
             dominant-baseline="middle"
             fill="#3a3a3a"
             text-anchor="middle"
-            :dy="!displayCharts ? calculateNodeSize(node) / 2 + 2: 10"
+            :dy="!displayCharts ? calculateNodeSize(node) / 2: 10"
             :dx="calculateNodeSize(node) / 2"
             :style="nodeTextStyle"
           >{{ node[labelVariable] }}</text>
@@ -901,7 +894,6 @@ export default defineComponent({
 }
 
 .label,
-.labelBackground,
 .bar,
 .glyph {
   pointer-events: none;
@@ -923,11 +915,5 @@ export default defineComponent({
 .node.selected {
   stroke-width: 6px;
   stroke: #F8CF91;
-}
-
-.labelBackground {
-  fill: #E0E0E0;
-  stroke-width: 1px;
-  stroke: #9E9E9E;
 }
 </style>


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
Removes label background from nodes so that the nodes are no longer occluded when a size variable makes them too small to be seen

### Provide pictures/videos of the behavior before and after these changes (optional)
Without size applied:
![image](https://user-images.githubusercontent.com/36867477/152255663-99839678-a0f2-4fe6-b87e-9c8a6bc585c4.png)

With size applied:
![image](https://user-images.githubusercontent.com/36867477/152255605-53b64d09-a2c3-429c-881f-b044ddb142a6.png)

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [x] Check in with Alex to see how he feels about this change