### PR TITLE
Move layout by variable UI to the legend from context menu

### DIFF
--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -8,27 +8,6 @@ export default defineComponent({
   setup() {
     const network = computed(() => store.state.network);
 
-    const numericVariables = computed(() => Object.entries(store.state.columnTypes || {})
-      .filter(([, value]) => value === 'number')
-      .map(([key]) => key)
-      .filter((key) => {
-        if (network.value !== null) {
-          return network.value.nodes[0][key] !== undefined;
-        }
-        return true;
-      })
-      .sort());
-    const categoricalVariables = computed(() => Object.entries(store.state.columnTypes || {})
-      .filter(([, value]) => value !== 'number' && value !== 'label')
-      .map(([key]) => key)
-      .filter((key) => {
-        if (network.value !== null) {
-          return network.value.nodes[0][key] !== undefined;
-        }
-        return true;
-      })
-      .sort());
-
     const selectedNodes = computed(() => store.state.selectedNodes);
     function clearSelection() {
       store.commit.setSelected(new Set());
@@ -59,27 +38,12 @@ export default defineComponent({
     }
 
     const rightClickMenu = computed(() => store.state.rightClickMenu);
-    function changeLayout(varName: string, axis: 'x' | 'y') {
-      // Close the menu
-      store.commit.updateRightClickMenu({
-        show: false,
-        top: rightClickMenu.value.top,
-        left: rightClickMenu.value.left,
-      });
-
-      store.commit.applyVariableLayout({
-        varName, axis,
-      });
-    }
 
     return {
       rightClickMenu,
-      numericVariables,
-      categoricalVariables,
       clearSelection,
       pinSelectedNodes,
       unPinSelectedNodes,
-      changeLayout,
     };
   },
 });
@@ -120,194 +84,6 @@ export default defineComponent({
           <v-list-item-content>
             <v-list-item-title>Un-Pin Selected Nodes</v-list-item-title>
           </v-list-item-content>
-        </v-list-item>
-
-        <v-list-item
-          dense
-        >
-          <v-menu
-            allow-overflow
-            offset-x
-          >
-            <template #activator="{ on, attrs }">
-              <v-list-item-title
-                v-bind="attrs"
-                v-on="on"
-              >
-                Lay Out By
-                <v-icon
-                  dense
-                  right
-                >
-                  mdi-chevron-right
-                </v-icon>
-              </v-list-item-title>
-            </template>
-
-            <v-list :width="175">
-              <v-list-item
-                dense
-              >
-                <v-list-item-content>
-                  <v-menu
-                    offset-x
-                    :disabled="numericVariables.length === 0"
-                  >
-                    <template #activator="{ on, attrs }">
-                      <v-list-item-title
-                        v-bind="attrs"
-                        :class="numericVariables.length === 0 ? 'grey--text text--lighten-1' : ''"
-                        v-on="on"
-                      >
-                        Numerical Variable
-                        <v-icon
-                          dense
-                          right
-                          :color="numericVariables.length === 0 ? 'grey lighten-1' : ''"
-                        >
-                          mdi-chevron-right
-                        </v-icon>
-                      </v-list-item-title>
-                    </template>
-
-                    <v-list>
-                      <v-list-item
-                        v-for="numVar in numericVariables"
-                        :key="numVar"
-                        dense
-                      >
-                        <v-list-item-content>
-                          <v-menu
-                            offset-x
-                          >
-                            <template #activator="{ on, attrs }">
-                              <v-list-item-title
-                                v-bind="attrs"
-                                v-on="on"
-                              >
-                                {{ numVar }}
-                                <v-icon
-                                  dense
-                                  right
-                                >
-                                  mdi-chevron-right
-                                </v-icon>
-                              </v-list-item-title>
-                            </template>
-
-                            <v-list>
-                              <v-list-item
-                                dense
-                                @click="changeLayout(numVar, 'x')"
-                              >
-                                <v-list-item-content>
-                                  <v-list-item-title>
-                                    X-axis
-                                  </v-list-item-title>
-                                </v-list-item-content>
-                              </v-list-item>
-
-                              <v-list-item
-                                dense
-                                @click="changeLayout(numVar, 'y')"
-                              >
-                                <v-list-item-content>
-                                  <v-list-item-title>
-                                    Y-axis
-                                  </v-list-item-title>
-                                </v-list-item-content>
-                              </v-list-item>
-                            </v-list>
-                          </v-menu>
-                        </v-list-item-content>
-                      </v-list-item>
-                    </v-list>
-                  </v-menu>
-                </v-list-item-content>
-              </v-list-item>
-
-              <v-list-item
-                dense
-              >
-                <v-list-item-content>
-                  <v-menu
-                    offset-x
-                    :disabled="categoricalVariables.length === 0"
-                  >
-                    <template #activator="{ on, attrs }">
-                      <v-list-item-title
-                        v-bind="attrs"
-                        :class="categoricalVariables.length === 0 ? 'grey--text text--lighten-1' : ''"
-                        v-on="on"
-                      >
-                        Categorical Variable
-                        <v-icon
-                          dense
-                          right
-                          :color="categoricalVariables.length === 0 ? 'grey lighten-1' : ''"
-                        >
-                          mdi-chevron-right
-                        </v-icon>
-                      </v-list-item-title>
-                    </template>
-
-                    <v-list>
-                      <v-list-item
-                        v-for="catVar in categoricalVariables"
-                        :key="catVar"
-                        dense
-                      >
-                        <v-list-item-content>
-                          <v-menu
-                            offset-x
-                          >
-                            <template #activator="{ on, attrs }">
-                              <v-list-item-title
-                                v-bind="attrs"
-                                v-on="on"
-                              >
-                                {{ catVar }}
-                                <v-icon
-                                  dense
-                                  right
-                                >
-                                  mdi-chevron-right
-                                </v-icon>
-                              </v-list-item-title>
-                            </template>
-
-                            <v-list>
-                              <v-list-item
-                                dense
-                                @click="changeLayout(catVar, 'x')"
-                              >
-                                <v-list-item-content>
-                                  <v-list-item-title>
-                                    X-axis
-                                  </v-list-item-title>
-                                </v-list-item-content>
-                              </v-list-item>
-
-                              <v-list-item
-                                dense
-                                @click="changeLayout(catVar, 'y')"
-                              >
-                                <v-list-item-content>
-                                  <v-list-item-title>
-                                    Y-axis
-                                  </v-list-item-title>
-                                </v-list-item-content>
-                              </v-list-item>
-                            </v-list>
-                          </v-menu>
-                        </v-list-item-content>
-                      </v-list-item>
-                    </v-list>
-                  </v-menu>
-                </v-list-item-content>
-              </v-list-item>
-            </v-list>
-          </v-menu>
         </v-list-item>
       </v-list>
     </v-menu>

--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -443,20 +443,6 @@ export default defineComponent({
           </v-list-item>
         </div>
 
-        <v-subheader class="grey darken-3 py-0 white--text">
-          Legend
-
-          <v-spacer />
-
-          <v-switch
-            v-model="displayCharts"
-            append-icon="mdi-chart-bar"
-            class="mr-0"
-            dense
-            dark
-            color="blue darken-1"
-          />
-        </v-subheader>
         <Legend v-if="columnTypes !== null" />
       </v-list>
     </v-navigation-drawer>

--- a/src/components/DragTarget.vue
+++ b/src/components/DragTarget.vue
@@ -46,11 +46,11 @@ export default defineComponent({
       } else if (props.type === 'node' && props.title === 'color') {
         store.commit.setNodeColorVariable(droppedVarName);
       } else if (props.type === 'node' && props.title === 'x variable') {
-        store.commit.applyVariableLayout({
+        store.dispatch.applyVariableLayout({
           varName: droppedVarName, axis: 'x',
         });
       } else if (props.type === 'node' && props.title === 'y variable') {
-        store.commit.applyVariableLayout({
+        store.dispatch.applyVariableLayout({
           varName: droppedVarName, axis: 'y',
         });
       } else if (props.type === 'edge' && props.title === 'width') {

--- a/src/components/DragTarget.vue
+++ b/src/components/DragTarget.vue
@@ -45,6 +45,14 @@ export default defineComponent({
         store.commit.setNodeSizeVariable(droppedVarName);
       } else if (props.type === 'node' && props.title === 'color') {
         store.commit.setNodeColorVariable(droppedVarName);
+      } else if (props.type === 'node' && props.title === 'x variable') {
+        store.commit.applyVariableLayout({
+          varName: droppedVarName, axis: 'x',
+        });
+      } else if (props.type === 'node' && props.title === 'y variable') {
+        store.commit.applyVariableLayout({
+          varName: droppedVarName, axis: 'y',
+        });
       } else if (props.type === 'edge' && props.title === 'width') {
         const updatedEdgeVars = {
           width: droppedVarName,

--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -230,6 +230,10 @@ export default defineComponent({
           <v-divider />
         </div>
 
+        <v-subheader class="grey py-0 white--text">
+          Attributes
+        </v-subheader>
+
         <div v-if="cleanedNodeVariables.size === 0">
           No node attributes to visualize
         </div>
@@ -283,6 +287,10 @@ export default defineComponent({
 
           <v-divider />
         </div>
+
+        <v-subheader class="grey py-0 white--text">
+          Attributes
+        </v-subheader>
 
         <div v-if="cleanedEdgeVariables.size === 0">
           No edge attributes to visualize

--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -68,6 +68,8 @@ export default defineComponent({
 
     const displayCharts = computed(() => store.state.displayCharts);
 
+    const layoutVars = computed(() => store.state.layoutVars);
+
     return {
       tab,
       nestedVariables,
@@ -77,6 +79,7 @@ export default defineComponent({
       displayCharts,
       cleanedNodeVariables,
       cleanedEdgeVariables,
+      layoutVars,
     };
   },
 });
@@ -194,6 +197,36 @@ export default defineComponent({
             />
           </div>
 
+          <v-divider />
+
+          <drag-target
+            v-if="layoutVars.x === null"
+            :title="'x variable'"
+            :type="'node'"
+          />
+
+          <legend-chart
+            v-else
+            :var-name="layoutVars.x"
+            :type="'node'"
+            :selected="true"
+            :mapped-to="'x'"
+          />
+          <v-divider />
+
+          <drag-target
+            v-if="layoutVars.y === null"
+            :title="'y variable'"
+            :type="'node'"
+          />
+
+          <legend-chart
+            v-else
+            :var-name="layoutVars.y"
+            :type="'node'"
+            :selected="true"
+            :mapped-to="'y'"
+          />
           <v-divider />
         </div>
 

--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -66,8 +66,16 @@ export default defineComponent({
       return new Set();
     });
 
-    const displayCharts = computed(() => store.state.displayCharts);
+    const displayCharts = computed({
+      get() {
+        return store.state.displayCharts;
+      },
+      set(value: boolean) {
+        return store.commit.setDisplayCharts(value);
+      },
+    });
 
+    const attributeLayout = ref(false);
     const layoutVars = computed(() => store.state.layoutVars);
 
     return {
@@ -79,6 +87,7 @@ export default defineComponent({
       displayCharts,
       cleanedNodeVariables,
       cleanedEdgeVariables,
+      attributeLayout,
       layoutVars,
     };
   },
@@ -87,6 +96,32 @@ export default defineComponent({
 
 <template>
   <div id="legend">
+    <v-subheader class="grey darken-3 py-0 white--text">
+      Legend
+
+      <v-spacer />
+
+      <v-switch
+        v-model="attributeLayout"
+        append-icon="mdi-chart-scatter-plot"
+        class="mr-0"
+        dense
+        dark
+        color="blue darken-1"
+      />
+
+      <v-spacer />
+
+      <v-switch
+        v-model="displayCharts"
+        append-icon="mdi-chart-bar"
+        class="mr-0"
+        dense
+        dark
+        color="blue darken-1"
+      />
+    </v-subheader>
+
     <v-tabs
       v-model="tab"
       background-color="grey darken-2"
@@ -199,35 +234,37 @@ export default defineComponent({
 
           <v-divider />
 
-          <drag-target
-            v-if="layoutVars.x === null"
-            :title="'x variable'"
-            :type="'node'"
-          />
+          <div v-if="attributeLayout">
+            <drag-target
+              v-if="layoutVars.x === null"
+              :title="'x variable'"
+              :type="'node'"
+            />
 
-          <legend-chart
-            v-else
-            :var-name="layoutVars.x"
-            :type="'node'"
-            :selected="true"
-            :mapped-to="'x'"
-          />
-          <v-divider />
+            <legend-chart
+              v-else
+              :var-name="layoutVars.x"
+              :type="'node'"
+              :selected="true"
+              :mapped-to="'x'"
+            />
+            <v-divider />
 
-          <drag-target
-            v-if="layoutVars.y === null"
-            :title="'y variable'"
-            :type="'node'"
-          />
+            <drag-target
+              v-if="layoutVars.y === null"
+              :title="'y variable'"
+              :type="'node'"
+            />
 
-          <legend-chart
-            v-else
-            :var-name="layoutVars.y"
-            :type="'node'"
-            :selected="true"
-            :mapped-to="'y'"
-          />
-          <v-divider />
+            <legend-chart
+              v-else
+              :var-name="layoutVars.y"
+              :type="'node'"
+              :selected="true"
+              :mapped-to="'y'"
+            />
+            <v-divider />
+          </div>
         </div>
 
         <v-subheader class="grey py-0 white--text">

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -106,7 +106,7 @@ export default defineComponent({
             glyph: newGlyphVars,
           });
         } else if (props.mappedTo === 'x' || props.mappedTo === 'y') {
-          store.commit.applyVariableLayout({
+          store.dispatch.applyVariableLayout({
             varName: null, axis: props.mappedTo,
           });
         }

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -105,6 +105,10 @@ export default defineComponent({
             bar: nestedVariables.value.bar,
             glyph: newGlyphVars,
           });
+        } else if (props.mappedTo === 'x' || props.mappedTo === 'y') {
+          store.commit.applyVariableLayout({
+            varName: null, axis: props.mappedTo,
+          });
         }
       } else if (props.type === 'edge') {
         if (props.mappedTo === 'width') {

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -98,11 +98,11 @@ export default defineComponent({
       const xLayout = store.state.layoutVars.x !== null;
       const yLayout = store.state.layoutVars.y !== null;
       if (xLayout) {
-        store.commit.applyVariableLayout({ varName: store.state.layoutVars.x || '', axis: 'x' });
+        store.dispatch.applyVariableLayout({ varName: store.state.layoutVars.x || '', axis: 'x' });
       }
 
       if (yLayout) {
-        store.commit.applyVariableLayout({ varName: store.state.layoutVars.y || '', axis: 'y' });
+        store.dispatch.applyVariableLayout({ varName: store.state.layoutVars.y || '', axis: 'y' });
       }
 
       if (!xLayout && !yLayout) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -643,6 +643,11 @@ const {
         y: string | null;
       };
       commit.setLayoutVars(updatedLayoutVars);
+
+      // Reapply the layout if there is still a variable
+      if (varName === null && state.layoutVars[otherAxis] !== null) {
+        dispatch.applyVariableLayout({ varName: state.layoutVars[otherAxis], axis: otherAxis });
+      }
     },
   },
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -334,99 +334,12 @@ const {
       state.userInfo = userInfo;
     },
 
-    applyVariableLayout(state: State, payload: { varName: string | null; axis: 'x' | 'y'}) {
-      const {
-        varName, axis,
-      } = payload;
-      const otherAxis = axis === 'x' ? 'y' : 'x';
-
-      if (varName !== null) {
-      // Set node size smaller
-        store.commit.setMarkerSize({ markerSize: 10, updateProv: true });
-
-        // Clear the label variable
-        store.commit.setLabelVariable(undefined);
-
-        store.commit.stopSimulation();
-
-        if (state.network !== null && state.columnTypes !== null) {
-          const type = state.columnTypes[varName];
-          const range = state.attributeRanges[varName];
-          const otherAxisPadding = axis === 'x' ? 80 : 60;
-          const maxPosition = axis === 'x' ? state.svgDimensions.width - 10 : state.svgDimensions.height - otherAxisPadding - state.markerSize;
-
-          if (type === 'number') {
-            let positionScale: ScaleLinear<number, number>;
-
-            if (axis === 'x') {
-              positionScale = scaleLinear()
-                .domain([range.min, range.max])
-                .range([otherAxisPadding, maxPosition]);
-            } else {
-              positionScale = scaleLinear()
-                .domain([range.min, range.max])
-                .range([maxPosition, 10]);
-            }
-
-            state.network.nodes.forEach((node) => {
-            // eslint-disable-next-line no-param-reassign
-              node[axis] = positionScale(node[varName]);
-              // eslint-disable-next-line no-param-reassign
-              node[`f${axis}`] = positionScale(node[varName]);
-
-              if (state.layoutVars[otherAxis] === null) {
-                const otherSvgDimension = axis === 'x' ? state.svgDimensions.height : state.svgDimensions.width;
-                // eslint-disable-next-line no-param-reassign
-                node[otherAxis] = otherSvgDimension / 2;
-                // eslint-disable-next-line no-param-reassign
-                node[`f${otherAxis}`] = otherSvgDimension / 2;
-              }
-            });
-          } else {
-            let positionScale: ScaleBand<string>;
-            let positionOffset: number;
-
-            if (axis === 'x') {
-              positionScale = scaleBand()
-                .domain(range.binLabels)
-                .range([otherAxisPadding, maxPosition]);
-              positionOffset = (maxPosition - otherAxisPadding) / ((range.binLabels.length) * 2);
-            } else {
-              positionScale = scaleBand()
-                .domain(range.binLabels)
-                .range([maxPosition, 10]);
-              positionOffset = (maxPosition - 10) / ((range.binLabels.length) * 2);
-            }
-
-            state.network.nodes.forEach((node) => {
-            // eslint-disable-next-line no-param-reassign
-              node[axis] = (positionScale(node[varName]) || 0) + positionOffset;
-              // eslint-disable-next-line no-param-reassign
-              node[`f${axis}`] = (positionScale(node[varName]) || 0) + positionOffset;
-
-              if (state.layoutVars[otherAxis] === null) {
-                const otherSvgDimension = axis === 'x' ? state.svgDimensions.height : state.svgDimensions.width;
-                // eslint-disable-next-line no-param-reassign
-                node[otherAxis] = otherSvgDimension / 2;
-                // eslint-disable-next-line no-param-reassign
-                node[`f${otherAxis}`] = otherSvgDimension / 2;
-              }
-            });
-          }
-        }
-      } else if (state.layoutVars[otherAxis] === null) {
-        store.dispatch.releaseNodes();
-      }
-
-      const updatedLayoutVars = { [axis]: varName, [otherAxis]: state.layoutVars[otherAxis] } as {
-        x: string | null;
-        y: string | null;
-      };
-      state.layoutVars = updatedLayoutVars;
-    },
-
     setSvgDimensions(state: State, payload: Dimensions) {
       state.svgDimensions = payload;
+    },
+
+    setLayoutVars(state, layoutVars: { x: string | null; y: string | null }) {
+      state.layoutVars = layoutVars;
     },
   },
   actions: {
@@ -637,6 +550,99 @@ const {
 
       // Use the label variable we found or _key if we didn't find one
       commit.setLabelVariable(bestLabelVar || '_key');
+    },
+
+    applyVariableLayout(context, payload: { varName: string | null; axis: 'x' | 'y'}) {
+      const { commit, dispatch, state } = rootActionContext(context);
+
+      const {
+        varName, axis,
+      } = payload;
+      const otherAxis = axis === 'x' ? 'y' : 'x';
+
+      if (varName !== null) {
+      // Set node size smaller
+        commit.setMarkerSize({ markerSize: 10, updateProv: true });
+
+        // Clear the label variable
+        commit.setLabelVariable(undefined);
+
+        commit.stopSimulation();
+
+        if (state.network !== null && state.columnTypes !== null) {
+          const type = state.columnTypes[varName];
+          const range = state.attributeRanges[varName];
+          const otherAxisPadding = axis === 'x' ? 80 : 60;
+          const maxPosition = axis === 'x' ? state.svgDimensions.width - 10 : state.svgDimensions.height - otherAxisPadding - state.markerSize;
+
+          if (type === 'number') {
+            let positionScale: ScaleLinear<number, number>;
+
+            if (axis === 'x') {
+              positionScale = scaleLinear()
+                .domain([range.min, range.max])
+                .range([otherAxisPadding, maxPosition]);
+            } else {
+              positionScale = scaleLinear()
+                .domain([range.min, range.max])
+                .range([maxPosition, 10]);
+            }
+
+            state.network.nodes.forEach((node) => {
+            // eslint-disable-next-line no-param-reassign
+              node[axis] = positionScale(node[varName]);
+              // eslint-disable-next-line no-param-reassign
+              node[`f${axis}`] = positionScale(node[varName]);
+
+              if (state.layoutVars[otherAxis] === null) {
+                const otherSvgDimension = axis === 'x' ? state.svgDimensions.height : state.svgDimensions.width;
+                // eslint-disable-next-line no-param-reassign
+                node[otherAxis] = otherSvgDimension / 2;
+                // eslint-disable-next-line no-param-reassign
+                node[`f${otherAxis}`] = otherSvgDimension / 2;
+              }
+            });
+          } else {
+            let positionScale: ScaleBand<string>;
+            let positionOffset: number;
+
+            if (axis === 'x') {
+              positionScale = scaleBand()
+                .domain(range.binLabels)
+                .range([otherAxisPadding, maxPosition]);
+              positionOffset = (maxPosition - otherAxisPadding) / ((range.binLabels.length) * 2);
+            } else {
+              positionScale = scaleBand()
+                .domain(range.binLabels)
+                .range([maxPosition, 10]);
+              positionOffset = (maxPosition - 10) / ((range.binLabels.length) * 2);
+            }
+
+            state.network.nodes.forEach((node) => {
+            // eslint-disable-next-line no-param-reassign
+              node[axis] = (positionScale(node[varName]) || 0) + positionOffset;
+              // eslint-disable-next-line no-param-reassign
+              node[`f${axis}`] = (positionScale(node[varName]) || 0) + positionOffset;
+
+              if (state.layoutVars[otherAxis] === null) {
+                const otherSvgDimension = axis === 'x' ? state.svgDimensions.height : state.svgDimensions.width;
+                // eslint-disable-next-line no-param-reassign
+                node[otherAxis] = otherSvgDimension / 2;
+                // eslint-disable-next-line no-param-reassign
+                node[`f${otherAxis}`] = otherSvgDimension / 2;
+              }
+            });
+          }
+        }
+      } else if (state.layoutVars[otherAxis] === null) {
+        dispatch.releaseNodes();
+      }
+
+      const updatedLayoutVars = { [axis]: varName, [otherAxis]: state.layoutVars[otherAxis] } as {
+        x: string | null;
+        y: string | null;
+      };
+      commit.setLayoutVars(updatedLayoutVars);
     },
   },
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -334,90 +334,95 @@ const {
       state.userInfo = userInfo;
     },
 
-    applyVariableLayout(state: State, payload: { varName: string; axis: 'x' | 'y'}) {
+    applyVariableLayout(state: State, payload: { varName: string | null; axis: 'x' | 'y'}) {
+      const {
+        varName, axis,
+      } = payload;
+      const otherAxis = axis === 'x' ? 'y' : 'x';
+
+      if (varName !== null) {
       // Set node size smaller
-      store.commit.setMarkerSize({ markerSize: 10, updateProv: true });
+        store.commit.setMarkerSize({ markerSize: 10, updateProv: true });
 
-      // Clear the label variable
-      store.commit.setLabelVariable(undefined);
+        // Clear the label variable
+        store.commit.setLabelVariable(undefined);
 
-      store.commit.stopSimulation();
+        store.commit.stopSimulation();
 
-      if (state.network !== null && state.columnTypes !== null) {
-        const {
-          varName, axis,
-        } = payload;
-        const type = state.columnTypes[varName];
-        const range = state.attributeRanges[varName];
-        const otherAxis = axis === 'x' ? 'y' : 'x';
-        const otherAxisPadding = axis === 'x' ? 80 : 60;
-        const maxPosition = axis === 'x' ? state.svgDimensions.width - 10 : state.svgDimensions.height - otherAxisPadding - state.markerSize;
+        if (state.network !== null && state.columnTypes !== null) {
+          const type = state.columnTypes[varName];
+          const range = state.attributeRanges[varName];
+          const otherAxisPadding = axis === 'x' ? 80 : 60;
+          const maxPosition = axis === 'x' ? state.svgDimensions.width - 10 : state.svgDimensions.height - otherAxisPadding - state.markerSize;
 
-        if (type === 'number') {
-          let positionScale: ScaleLinear<number, number>;
+          if (type === 'number') {
+            let positionScale: ScaleLinear<number, number>;
 
-          if (axis === 'x') {
-            positionScale = scaleLinear()
-              .domain([range.min, range.max])
-              .range([otherAxisPadding, maxPosition]);
-          } else {
-            positionScale = scaleLinear()
-              .domain([range.min, range.max])
-              .range([maxPosition, 10]);
-          }
-
-          state.network.nodes.forEach((node) => {
-            // eslint-disable-next-line no-param-reassign
-            node[axis] = positionScale(node[varName]);
-            // eslint-disable-next-line no-param-reassign
-            node[`f${axis}`] = positionScale(node[varName]);
-
-            if (state.layoutVars[otherAxis] === null) {
-              const otherSvgDimension = axis === 'x' ? state.svgDimensions.height : state.svgDimensions.width;
-              // eslint-disable-next-line no-param-reassign
-              node[otherAxis] = otherSvgDimension / 2;
-              // eslint-disable-next-line no-param-reassign
-              node[`f${otherAxis}`] = otherSvgDimension / 2;
+            if (axis === 'x') {
+              positionScale = scaleLinear()
+                .domain([range.min, range.max])
+                .range([otherAxisPadding, maxPosition]);
+            } else {
+              positionScale = scaleLinear()
+                .domain([range.min, range.max])
+                .range([maxPosition, 10]);
             }
-          });
-        } else {
-          let positionScale: ScaleBand<string>;
-          let positionOffset: number;
 
-          if (axis === 'x') {
-            positionScale = scaleBand()
-              .domain(range.binLabels)
-              .range([otherAxisPadding, maxPosition]);
-            positionOffset = (maxPosition - otherAxisPadding) / ((range.binLabels.length) * 2);
+            state.network.nodes.forEach((node) => {
+            // eslint-disable-next-line no-param-reassign
+              node[axis] = positionScale(node[varName]);
+              // eslint-disable-next-line no-param-reassign
+              node[`f${axis}`] = positionScale(node[varName]);
+
+              if (state.layoutVars[otherAxis] === null) {
+                const otherSvgDimension = axis === 'x' ? state.svgDimensions.height : state.svgDimensions.width;
+                // eslint-disable-next-line no-param-reassign
+                node[otherAxis] = otherSvgDimension / 2;
+                // eslint-disable-next-line no-param-reassign
+                node[`f${otherAxis}`] = otherSvgDimension / 2;
+              }
+            });
           } else {
-            positionScale = scaleBand()
-              .domain(range.binLabels)
-              .range([maxPosition, 10]);
-            positionOffset = (maxPosition - 10) / ((range.binLabels.length) * 2);
-          }
+            let positionScale: ScaleBand<string>;
+            let positionOffset: number;
 
-          state.network.nodes.forEach((node) => {
-            // eslint-disable-next-line no-param-reassign
-            node[axis] = (positionScale(node[varName]) || 0) + positionOffset;
-            // eslint-disable-next-line no-param-reassign
-            node[`f${axis}`] = (positionScale(node[varName]) || 0) + positionOffset;
-
-            if (state.layoutVars[otherAxis] === null) {
-              const otherSvgDimension = axis === 'x' ? state.svgDimensions.height : state.svgDimensions.width;
-              // eslint-disable-next-line no-param-reassign
-              node[otherAxis] = otherSvgDimension / 2;
-              // eslint-disable-next-line no-param-reassign
-              node[`f${otherAxis}`] = otherSvgDimension / 2;
+            if (axis === 'x') {
+              positionScale = scaleBand()
+                .domain(range.binLabels)
+                .range([otherAxisPadding, maxPosition]);
+              positionOffset = (maxPosition - otherAxisPadding) / ((range.binLabels.length) * 2);
+            } else {
+              positionScale = scaleBand()
+                .domain(range.binLabels)
+                .range([maxPosition, 10]);
+              positionOffset = (maxPosition - 10) / ((range.binLabels.length) * 2);
             }
-          });
+
+            state.network.nodes.forEach((node) => {
+            // eslint-disable-next-line no-param-reassign
+              node[axis] = (positionScale(node[varName]) || 0) + positionOffset;
+              // eslint-disable-next-line no-param-reassign
+              node[`f${axis}`] = (positionScale(node[varName]) || 0) + positionOffset;
+
+              if (state.layoutVars[otherAxis] === null) {
+                const otherSvgDimension = axis === 'x' ? state.svgDimensions.height : state.svgDimensions.width;
+                // eslint-disable-next-line no-param-reassign
+                node[otherAxis] = otherSvgDimension / 2;
+                // eslint-disable-next-line no-param-reassign
+                node[`f${otherAxis}`] = otherSvgDimension / 2;
+              }
+            });
+          }
         }
-
-        const updatedLayoutVars = { [axis]: varName, [otherAxis]: state.layoutVars[otherAxis] } as {
-          x: string | null;
-          y: string | null;
-        };
-        state.layoutVars = updatedLayoutVars;
+      } else if (state.layoutVars[otherAxis] === null) {
+        store.dispatch.releaseNodes();
       }
+
+      const updatedLayoutVars = { [axis]: varName, [otherAxis]: state.layoutVars[otherAxis] } as {
+        x: string | null;
+        y: string | null;
+      };
+      state.layoutVars = updatedLayoutVars;
     },
 
     setSvgDimensions(state: State, payload: Dimensions) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -646,6 +646,9 @@ const {
 
       // Reapply the layout if there is still a variable
       if (varName === null && state.layoutVars[otherAxis] !== null) {
+        // Set marker size to 11 to trigger re-render (will get reset to 10 in dispatch again)
+        commit.setMarkerSize({ markerSize: 11, updateProv: false });
+
         dispatch.applyVariableLayout({ varName: state.layoutVars[otherAxis], axis: otherAxis });
       }
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,5 +124,5 @@ export type ProvenanceEventTypes =
   'Set Directional Edges' |
   'Set Edge Length';
 
-export const internalFieldNames = ['_from', '_to', '_id', '_rev'] as const;
+export const internalFieldNames = ['_from', '_to', '_id', '_rev', 'fx', 'fy'] as const;
 export type InternalField = (typeof internalFieldNames)[number];


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #286

### Give a longer description of what this PR addresses and why it's needed
Moves the layout to the legend and uses the framework we have in place for dragging and dropping variables to assign them.

### Provide pictures/videos of the behavior before and after these changes (optional)
New look:
![image](https://user-images.githubusercontent.com/36867477/160888624-3e4add6f-5911-4b1e-a99b-70e32774ef37.png)

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [x] When there are 2 axes assigned and we remove only 1, it should switch back to the one axis layout
- [x] Check reactivity issues
- [x] Add metadata (like degree) (tracking elsewhere)
- [ ] #295 
- [x] #296