### PR TITLE
Allow for the breaking of layout scales when we have very skewed data

### DIFF
--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -629,14 +629,14 @@ export default defineComponent({
             maxValue = maxCandidate;
             clipHigh = true;
             select(`#${axis}-high-clip`).style('visibility', 'visible');
-            select(`#${axis}-high-clip > text`).text(`nodes > ${maxCandidate}`);
+            select(`#${axis}-high-clip > text`).text(`> ${maxCandidate}`);
           }
 
           if (minCandidate > minValue) {
             minValue = minCandidate;
             clipLow = true;
             select(`#${axis}-low-clip`).style('visibility', 'visible');
-            select(`#${axis}-low-clip > text`).text(`nodes < ${minCandidate}`);
+            select(`#${axis}-low-clip > text`).text(`< ${minCandidate}`);
           }
         }
 

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -605,10 +605,10 @@ export default defineComponent({
       }
 
       if (axis === 'x') {
-        positionScale = scaleLinear()
+        positionScale = positionScale
           .range([yAxisPadding, maxPosition]);
       } else {
-        positionScale = scaleBand()
+        positionScale = positionScale
           .range([maxPosition, 10]);
       }
 

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -675,7 +675,12 @@ export default defineComponent({
               if (axis === 'x') {
                 position = position > scaleRange[1] ? scaleRange[1] + (clipRegionSize / 2) + 10 : position;
                 position = position < scaleRange[0] ? scaleRange[0] - (clipRegionSize / 2) - 10 : position;
+              } else {
+                position = position < scaleRange[1] ? scaleRange[1] - (clipRegionSize / 2) - 10 : position;
+                position = position > scaleRange[0] ? scaleRange[0] + (clipRegionSize / 2) + 10 : position;
               }
+              position -= (markerSize.value / 2);
+
               // eslint-disable-next-line no-param-reassign
               node[axis] = position;
               // eslint-disable-next-line no-param-reassign

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -716,8 +716,19 @@ export default defineComponent({
 
       return positionScale;
     }
-    watch(layoutVars, () => {
+
+    function resetAxesClipRegions() {
       select('#axes').selectAll('g').remove();
+
+      select('#x-low-clip').style('visibility', 'hidden');
+      select('#x-high-clip').style('visibility', 'hidden');
+      select('#y-low-clip').style('visibility', 'hidden');
+      select('#y-high-clip').style('visibility', 'hidden');
+    }
+
+    watch(layoutVars, () => {
+      resetAxesClipRegions();
+
       const xAxisPadding = 60;
       const yAxisPadding = 80;
 
@@ -866,6 +877,42 @@ export default defineComponent({
       />
 
       <g id="axes" />
+
+      <!-- High and low clip regions -->
+      <g>
+        <rect
+          id="x-low-clip"
+          class="clip-region"
+          x="0"
+          y="0"
+          :height="svgDimensions.height"
+          width="50"
+        />
+        <rect
+          id="x-high-clip"
+          class="clip-region"
+          :x="svgDimensions.width - 50"
+          y="0"
+          :height="svgDimensions.height"
+          width="50"
+        />
+        <rect
+          id="y-low-clip"
+          class="clip-region"
+          x="0"
+          :y="svgDimensions.height - 50"
+          height="50"
+          :width="svgDimensions.width"
+        />
+        <rect
+          id="y-high-clip"
+          class="clip-region"
+          x="0"
+          y="0"
+          height="50"
+          :width="svgDimensions.width"
+        />
+      </g>
 
       <g
         class="edges"
@@ -1024,5 +1071,11 @@ export default defineComponent({
 .node.selected {
   stroke-width: 6px;
   stroke: #F8CF91;
+}
+
+.clip-region {
+  visibility: hidden;
+  fill: #000000;
+  opacity: 0.2;
 }
 </style>

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -628,7 +628,6 @@ export default defineComponent({
           if (maxCandidate < maxValue) {
             maxValue = maxCandidate;
             clipHigh = true;
-
             select(`#${axis}-high-clip`).style('visibility', 'visible');
           }
 

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -597,7 +597,7 @@ export default defineComponent({
     function makePositionScale(axis: 'x' | 'y', type: ColumnType, range: AttributeRange, maxPosition: number, yAxisPadding: number) {
       const varName = layoutVars.value[axis];
       let clipLow = false;
-      let clipHigh = true;
+      let clipHigh = false;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let positionScale: any;
 

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -68,6 +68,7 @@ export default defineComponent({
     const controlsWidth = computed(() => store.state.controlsWidth);
     const directionalEdges = computed(() => store.state.directionalEdges);
     const edgeColorScale = computed(() => store.getters.edgeColorScale);
+    const clipRegionSize = 100;
 
     // Update height and width as the window size changes
     // Also update center attraction forces as the size changes
@@ -621,6 +622,7 @@ export default defineComponent({
           const iqr = q3 - q1;
           const maxCandidate = q3 + iqr * 1.5;
           const minCandidate = q1 - iqr * 1.5;
+
           if (maxCandidate < maxValue) {
             maxValue = maxCandidate;
             clipHigh = true;
@@ -643,11 +645,11 @@ export default defineComponent({
       }
 
       if (axis === 'x') {
-        const minMax = [clipLow ? yAxisPadding + 50 : yAxisPadding, clipHigh ? maxPosition - 50 : maxPosition];
+        const minMax = [clipLow ? yAxisPadding + clipRegionSize : yAxisPadding, clipHigh ? maxPosition - clipRegionSize : maxPosition];
         positionScale = positionScale
           .range(minMax);
       } else {
-        const minMax = [clipLow ? maxPosition + 50 : maxPosition, clipHigh ? 10 - 50 : 10];
+        const minMax = [clipLow ? maxPosition - clipRegionSize : maxPosition, clipHigh ? 10 + clipRegionSize : 10];
         positionScale = positionScale
           .range(minMax);
       }
@@ -670,8 +672,10 @@ export default defineComponent({
             const scaleRange = positionScale.range();
             store.state.network.nodes.forEach((node) => {
               let position = positionScale(node[varName]);
-              position = position > scaleRange[1] ? scaleRange[1] + 25 : position;
-              position = position < scaleRange[0] ? scaleRange[0] - 25 : position;
+              if (axis === 'x') {
+                position = position > scaleRange[1] ? scaleRange[1] + (clipRegionSize / 2) + 10 : position;
+                position = position < scaleRange[0] ? scaleRange[0] - (clipRegionSize / 2) - 10 : position;
+              }
               // eslint-disable-next-line no-param-reassign
               node[axis] = position;
               // eslint-disable-next-line no-param-reassign
@@ -849,6 +853,7 @@ export default defineComponent({
       nestedPadding,
       nodeBarColorScale,
       glyphFill,
+      clipRegionSize,
     };
   },
 });
@@ -886,22 +891,22 @@ export default defineComponent({
           x="0"
           y="0"
           :height="svgDimensions.height"
-          width="50"
+          :width="clipRegionSize"
         />
         <rect
           id="x-high-clip"
           class="clip-region"
-          :x="svgDimensions.width - 50"
+          :x="svgDimensions.width - clipRegionSize"
           y="0"
           :height="svgDimensions.height"
-          width="50"
+          :width="clipRegionSize"
         />
         <rect
           id="y-low-clip"
           class="clip-region"
           x="0"
-          :y="svgDimensions.height - 50"
-          height="50"
+          :y="svgDimensions.height - clipRegionSize"
+          :height="clipRegionSize"
           :width="svgDimensions.width"
         />
         <rect
@@ -909,7 +914,7 @@ export default defineComponent({
           class="clip-region"
           x="0"
           y="0"
-          height="50"
+          :height="clipRegionSize"
           :width="svgDimensions.width"
         />
       </g>

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -629,12 +629,14 @@ export default defineComponent({
             maxValue = maxCandidate;
             clipHigh = true;
             select(`#${axis}-high-clip`).style('visibility', 'visible');
+            select(`#${axis}-high-clip > text`).text(`nodes > ${maxCandidate}`);
           }
 
           if (minCandidate > minValue) {
             minValue = minCandidate;
             clipLow = true;
             select(`#${axis}-low-clip`).style('visibility', 'visible');
+            select(`#${axis}-low-clip > text`).text(`nodes < ${minCandidate}`);
           }
         }
 
@@ -890,38 +892,81 @@ export default defineComponent({
 
       <!-- High and low clip regions -->
       <g>
-        <rect
+        <g
           id="x-low-clip"
-          class="clip-region"
-          :x="xAxisPadding + 20"
-          y="0"
-          :height="svgDimensions.height"
-          :width="clipRegionSize"
-        />
-        <rect
+        >
+          <rect
+            class="clip-region"
+            :x="xAxisPadding + 20"
+            y="0"
+            :height="svgDimensions.height"
+            :width="clipRegionSize"
+          />
+          <text
+            :x="xAxisPadding + 20 + (clipRegionSize / 2)"
+            :y="svgDimensions.height - yAxisPadding + 50"
+            dominant-baseline="hanging"
+            text-anchor="middle"
+          >low values
+          </text>
+        </g>
+
+        <g
           id="x-high-clip"
-          class="clip-region"
-          :x="svgDimensions.width - clipRegionSize"
-          y="0"
-          :height="svgDimensions.height"
-          :width="clipRegionSize"
-        />
-        <rect
+        >
+          <rect
+            class="clip-region"
+            :x="svgDimensions.width - clipRegionSize"
+            y="0"
+            :height="svgDimensions.height"
+            :width="clipRegionSize"
+          />
+          <text
+            :x="svgDimensions.width - (clipRegionSize / 2)"
+            :y="svgDimensions.height - yAxisPadding + 50"
+            dominant-baseline="hanging"
+            text-anchor="middle"
+          >high values
+          </text>
+        </g>
+
+        <g
           id="y-low-clip"
-          class="clip-region"
-          x="0"
-          :y="svgDimensions.height - yAxisPadding + 20 - clipRegionSize"
-          :height="clipRegionSize"
-          :width="svgDimensions.width"
-        />
-        <rect
+        >
+          <rect
+            class="clip-region"
+            x="0"
+            :y="svgDimensions.height - yAxisPadding + 20 - clipRegionSize"
+            :height="clipRegionSize"
+            :width="svgDimensions.width"
+          />
+          <text
+            :x="xAxisPadding + 20"
+            :y="svgDimensions.height - yAxisPadding + 20 - (clipRegionSize / 2)"
+            dominant-baseline="middle"
+            text-anchor="end"
+          >low values
+          </text>
+        </g>
+
+        <g
           id="y-high-clip"
-          class="clip-region"
-          x="0"
-          y="0"
-          :height="clipRegionSize"
-          :width="svgDimensions.width"
-        />
+        >
+          <rect
+            class="clip-region"
+            x="0"
+            y="0"
+            :height="clipRegionSize"
+            :width="svgDimensions.width"
+          />
+          <text
+            :x="xAxisPadding + 20"
+            :y="clipRegionSize / 2"
+            dominant-baseline="middle"
+            text-anchor="end"
+          >high values
+          </text>
+        </g>
       </g>
 
       <g
@@ -1084,7 +1129,6 @@ export default defineComponent({
 }
 
 .clip-region {
-  visibility: hidden;
   fill: #000000;
   opacity: 0.2;
 }

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -677,12 +677,13 @@ export default defineComponent({
             store.state.network.nodes.forEach((node) => {
               const nodeVal = node[varName];
               let position = positionScale(nodeVal);
+
               if (axis === 'x') {
-                position = nodeVal > scaleDomain[1] ? scaleRange[1] + (clipRegionSize / 2) : position;
-                position = nodeVal < scaleDomain[0] ? scaleRange[0] - (clipRegionSize / 2) : position;
+                position = nodeVal > scaleDomain[1] ? scaleRange[1] + ((clipRegionSize - 10) * ((nodeVal - scaleDomain[1]) / (range.max - 1 - scaleDomain[1]))) : position;
+                position = nodeVal < scaleDomain[0] ? scaleRange[0] - ((clipRegionSize - 10) * ((scaleDomain[0] - nodeVal) / (scaleDomain[0] - range.min))) : position;
               } else {
-                position = nodeVal > scaleDomain[1] ? scaleRange[1] - (clipRegionSize / 2) : position;
-                position = nodeVal < scaleDomain[0] ? scaleRange[0] + (clipRegionSize / 2) : position;
+                position = nodeVal > scaleDomain[1] ? scaleRange[1] - ((clipRegionSize - 10) * ((nodeVal - scaleDomain[1]) / (range.max - 1 - scaleDomain[1]))) : position;
+                position = nodeVal < scaleDomain[0] ? scaleRange[0] + ((clipRegionSize - 10) * ((scaleDomain[0] - nodeVal) / (scaleDomain[0] - range.min))) : position;
               }
               position -= (markerSize.value / 2);
 

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -605,7 +605,7 @@ export default defineComponent({
 
       if (type === 'number') {
         let minValue = range.min;
-        let maxValue = range.max;
+        let maxValue = range.max - 1; // subtract 1, because of the + 1 on the legend chart scale
 
         // Check IQR for outliers
         if (network.value !== null && varName !== null) {
@@ -671,15 +671,17 @@ export default defineComponent({
           const otherAxisPadding = axis === 'x' ? 80 : 60;
 
           if (type === 'number') {
+            const scaleDomain = positionScale.domain();
             const scaleRange = positionScale.range();
             store.state.network.nodes.forEach((node) => {
-              let position = positionScale(node[varName]);
+              const nodeVal = node[varName];
+              let position = positionScale(nodeVal);
               if (axis === 'x') {
-                position = position > scaleRange[1] ? scaleRange[1] + (clipRegionSize / 2) + 10 : position;
-                position = position < scaleRange[0] ? scaleRange[0] - (clipRegionSize / 2) - 10 : position;
+                position = nodeVal > scaleDomain[1] ? scaleRange[1] + (clipRegionSize / 2) : position;
+                position = nodeVal < scaleDomain[0] ? scaleRange[0] - (clipRegionSize / 2) : position;
               } else {
-                position = position < scaleRange[1] ? scaleRange[1] - (clipRegionSize / 2) - 10 : position;
-                position = position > scaleRange[0] ? scaleRange[0] + (clipRegionSize / 2) + 10 : position;
+                position = nodeVal > scaleDomain[1] ? scaleRange[1] - (clipRegionSize / 2) : position;
+                position = nodeVal < scaleDomain[0] ? scaleRange[0] + (clipRegionSize / 2) : position;
               }
               position -= (markerSize.value / 2);
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -572,6 +572,9 @@ const {
         commit.setMarkerSize({ markerSize: 11, updateProv: false });
 
         dispatch.applyVariableLayout({ varName: state.layoutVars[otherAxis], axis: otherAxis });
+      } else if (varName === null && state.layoutVars[otherAxis] === null) {
+        // If both null, release
+        dispatch.releaseNodes();
       }
     },
   },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,7 +11,7 @@ import {
 import api from '@/api';
 import { ColumnTypes, NetworkSpec, UserSpec } from 'multinet';
 import {
-  ScaleBand, scaleBand, ScaleLinear, scaleLinear, scaleOrdinal, scaleSequential,
+  scaleLinear, scaleOrdinal, scaleSequential,
 } from 'd3-scale';
 import { interpolateBlues, interpolateReds, schemeCategory10 } from 'd3-scale-chromatic';
 import { initProvenance, Provenance } from '@visdesignlab/trrack';
@@ -559,84 +559,6 @@ const {
         varName, axis,
       } = payload;
       const otherAxis = axis === 'x' ? 'y' : 'x';
-
-      if (varName !== null) {
-      // Set node size smaller
-        commit.setMarkerSize({ markerSize: 10, updateProv: true });
-
-        // Clear the label variable
-        commit.setLabelVariable(undefined);
-
-        commit.stopSimulation();
-
-        if (state.network !== null && state.columnTypes !== null) {
-          const type = state.columnTypes[varName];
-          const range = state.attributeRanges[varName];
-          const otherAxisPadding = axis === 'x' ? 80 : 60;
-          const maxPosition = axis === 'x' ? state.svgDimensions.width - 10 : state.svgDimensions.height - otherAxisPadding - state.markerSize;
-
-          if (type === 'number') {
-            let positionScale: ScaleLinear<number, number>;
-
-            if (axis === 'x') {
-              positionScale = scaleLinear()
-                .domain([range.min, range.max])
-                .range([otherAxisPadding, maxPosition]);
-            } else {
-              positionScale = scaleLinear()
-                .domain([range.min, range.max])
-                .range([maxPosition, 10]);
-            }
-
-            state.network.nodes.forEach((node) => {
-            // eslint-disable-next-line no-param-reassign
-              node[axis] = positionScale(node[varName]);
-              // eslint-disable-next-line no-param-reassign
-              node[`f${axis}`] = positionScale(node[varName]);
-
-              if (state.layoutVars[otherAxis] === null) {
-                const otherSvgDimension = axis === 'x' ? state.svgDimensions.height : state.svgDimensions.width;
-                // eslint-disable-next-line no-param-reassign
-                node[otherAxis] = otherSvgDimension / 2;
-                // eslint-disable-next-line no-param-reassign
-                node[`f${otherAxis}`] = otherSvgDimension / 2;
-              }
-            });
-          } else {
-            let positionScale: ScaleBand<string>;
-            let positionOffset: number;
-
-            if (axis === 'x') {
-              positionScale = scaleBand()
-                .domain(range.binLabels)
-                .range([otherAxisPadding, maxPosition]);
-              positionOffset = (maxPosition - otherAxisPadding) / ((range.binLabels.length) * 2);
-            } else {
-              positionScale = scaleBand()
-                .domain(range.binLabels)
-                .range([maxPosition, 10]);
-              positionOffset = (maxPosition - 10) / ((range.binLabels.length) * 2);
-            }
-
-            state.network.nodes.forEach((node) => {
-            // eslint-disable-next-line no-param-reassign
-              node[axis] = (positionScale(node[varName]) || 0) + positionOffset;
-              // eslint-disable-next-line no-param-reassign
-              node[`f${axis}`] = (positionScale(node[varName]) || 0) + positionOffset;
-
-              if (state.layoutVars[otherAxis] === null) {
-                const otherSvgDimension = axis === 'x' ? state.svgDimensions.height : state.svgDimensions.width;
-                // eslint-disable-next-line no-param-reassign
-                node[otherAxis] = otherSvgDimension / 2;
-                // eslint-disable-next-line no-param-reassign
-                node[`f${otherAxis}`] = otherSvgDimension / 2;
-              }
-            });
-          }
-        }
-      } else if (state.layoutVars[otherAxis] === null) {
-        dispatch.releaseNodes();
-      }
 
       const updatedLayoutVars = { [axis]: varName, [otherAxis]: state.layoutVars[otherAxis] } as {
         x: string | null;


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #295

### Give a longer description of what this PR addresses and why it's needed
This allows for breaking scales when we have outliers on the extreme high and low end of the data. This means that the data fits into the view better

As suggested in #295, I use the IQR to calculate a cut off and break the scales there.

### Provide pictures/videos of the behavior before and after these changes (optional)
All clip regions active:
![image](https://user-images.githubusercontent.com/36867477/175844088-76ef22ee-432c-455f-890d-d4623537887f.png)

Just high clip regions active:
![image](https://user-images.githubusercontent.com/36867477/175844146-cbbf7cff-3383-48cc-8f32-4003a0c0a126.png)


### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [x] Applying 2 layouts (x and y) seems to be broken
- [x] Allow using different scale types (log, etc.). Probably open new issue + PR for this (#315)
- [x] Make sure nodes release when there's no layout applied (maybe reset marker size + label?)
- [x] Verify low and high clipping work as intended 
- [x] Add label for nodes outside of range
- [x] Decide if IQR is best metric (IQR would give outliers on normal distributed data, but maybe that's okay. Check with Alex) (#316)
- [x] Make clipRegions larger (now larger and tunable by changing 1 variable. Check with team on Monday for confirmation that they're large enough)
- [x] Plot the outliers in the order they are in the data