### PR TITLE
Use force directed layout for categorical variables

### DIFF
--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -642,8 +642,6 @@ export default defineComponent({
         // Clear the label variable
         store.commit.setLabelVariable(undefined);
 
-        store.commit.stopSimulation();
-
         if (store.state.network !== null && store.state.columnTypes !== null) {
           const otherAxisPadding = axis === 'x' ? 80 : 60;
 
@@ -685,22 +683,18 @@ export default defineComponent({
               positionOffset = (store.state.svgDimensions.height - xAxisPadding - 10) / ((range.binLabels.length) * 2);
             }
 
-            store.state.network.nodes.forEach((node) => {
-            // eslint-disable-next-line no-param-reassign
-              node[axis] = (positionScale(node[varName]) || 0) + positionOffset;
-              // eslint-disable-next-line no-param-reassign
-              node[`f${axis}`] = (positionScale(node[varName]) || 0) + positionOffset;
-
-              if (store.state.layoutVars[otherAxis] === null) {
-                const otherSvgDimension = axis === 'x' ? store.state.svgDimensions.height : store.state.svgDimensions.width;
-
-                const randomJitter = axis === 'x' ? Math.random() * (otherSvgDimension - otherAxisPadding) : Math.random() * (otherSvgDimension - otherAxisPadding) + otherAxisPadding;
-                // eslint-disable-next-line no-param-reassign
-                node[otherAxis] = randomJitter;
-                // eslint-disable-next-line no-param-reassign
-                node[`f${otherAxis}`] = randomJitter;
-              }
-            });
+            const force = axis === 'x' ? forceX<Node>((d) => positionScale(d[varName]) + positionOffset).strength(2) : forceY<Node>((d) => positionScale(d[varName]) + positionOffset).strength(2);
+            applyForceToSimulation(
+              store.state.simulation,
+              axis,
+              force,
+            );
+            applyForceToSimulation(
+              store.state.simulation,
+              'edge',
+              forceLink<Node, SimulationEdge>(),
+            );
+            store.commit.startSimulation();
           }
         }
       } else if (store.state.layoutVars[otherAxis] === null) {

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -717,10 +717,12 @@ export default defineComponent({
 
               if (store.state.layoutVars[otherAxis] === null) {
                 const otherSvgDimension = axis === 'x' ? store.state.svgDimensions.height : store.state.svgDimensions.width;
+
+                const randomJitter = Math.random() * otherSvgDimension;
                 // eslint-disable-next-line no-param-reassign
-                node[otherAxis] = otherSvgDimension / 2;
+                node[otherAxis] = randomJitter;
                 // eslint-disable-next-line no-param-reassign
-                node[`f${otherAxis}`] = otherSvgDimension / 2;
+                node[`f${otherAxis}`] = randomJitter;
               }
             });
           }

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -680,7 +680,7 @@ export default defineComponent({
             if (axis === 'x') {
               positionOffset = (store.state.svgDimensions.width - otherAxisPadding) / ((range.binLabels.length) * 2);
             } else {
-              positionOffset = (store.state.svgDimensions.height - xAxisPadding - 10) / ((range.binLabels.length) * 2);
+              positionOffset = ((store.state.svgDimensions.height - xAxisPadding) / ((range.binLabels.length) * 2)) - 10;
             }
 
             const force = axis === 'x' ? forceX<Node>((d) => positionScale(d[varName]) + positionOffset).strength(2) : forceY<Node>((d) => positionScale(d[varName]) + positionOffset).strength(2);
@@ -693,6 +693,11 @@ export default defineComponent({
               store.state.simulation,
               'edge',
               forceLink<Node, SimulationEdge>(),
+            );
+            applyForceToSimulation(
+              store.state.simulation,
+              'charge',
+              forceManyBody<Node>(),
             );
             store.commit.startSimulation();
           }
@@ -734,6 +739,11 @@ export default defineComponent({
           store.state.simulation,
           'edge',
           forceLink<Node, SimulationEdge>(simulationEdges.value).id((d) => { const datum = (d as Edge); return datum._id; }).strength(1),
+        );
+        applyForceToSimulation(
+          store.state.simulation,
+          'charge',
+          forceManyBody<Node>().strength(-500),
         );
       }
 

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -716,6 +716,27 @@ export default defineComponent({
     watch(layoutVars, () => {
       resetAxesClipRegions();
 
+      // Reset forces before applying (if there are layout vars)
+      if (simulationEdges.value !== null) {
+        // Double force to the middle of each axis if there's a layout var. Causes the nodes to be pulled to the middle.
+        const forceStrength = layoutVars.value.x === null && layoutVars.value.y === null ? 1 : 2;
+        applyForceToSimulation(
+          store.state.simulation,
+          'x',
+          forceX<Node>(svgDimensions.value.width / 2).strength(forceStrength),
+        );
+        applyForceToSimulation(
+          store.state.simulation,
+          'y',
+          forceY<Node>(svgDimensions.value.height / 2).strength(forceStrength),
+        );
+        applyForceToSimulation(
+          store.state.simulation,
+          'edge',
+          forceLink<Node, SimulationEdge>(simulationEdges.value).id((d) => { const datum = (d as Edge); return datum._id; }).strength(1),
+        );
+      }
+
       // Add x layout
       if (store.state.columnTypes !== null && layoutVars.value.x !== null) {
         const type = store.state.columnTypes[layoutVars.value.x];

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -718,7 +718,7 @@ export default defineComponent({
               if (store.state.layoutVars[otherAxis] === null) {
                 const otherSvgDimension = axis === 'x' ? store.state.svgDimensions.height : store.state.svgDimensions.width;
 
-                const randomJitter = Math.random() * otherSvgDimension;
+                const randomJitter = axis === 'x' ? Math.random() * (otherSvgDimension - otherAxisPadding) : Math.random() * (otherSvgDimension - otherAxisPadding) + otherAxisPadding;
                 // eslint-disable-next-line no-param-reassign
                 node[otherAxis] = randomJitter;
                 // eslint-disable-next-line no-param-reassign

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -69,6 +69,7 @@ export default defineComponent({
     const directionalEdges = computed(() => store.state.directionalEdges);
     const edgeColorScale = computed(() => store.getters.edgeColorScale);
     const clipRegionSize = 100;
+    const layoutVars = computed(() => store.state.layoutVars);
 
     // Update height and width as the window size changes
     // Also update center attraction forces as the size changes
@@ -552,7 +553,7 @@ export default defineComponent({
       return null;
     });
     watch(attributeRanges, () => {
-      if (simulationEdges.value !== null) {
+      if (simulationEdges.value !== null && layoutVars.value.x !== null && layoutVars.value.y !== null) {
         const simEdges = simulationEdges.value.filter((edge: Edge) => {
           if (edgeVariables.value.width !== '') {
             const widthValue = edgeWidthScale.value(edge[edgeVariables.value.width]);
@@ -571,7 +572,6 @@ export default defineComponent({
 
     const xAxisPadding = 60;
     const yAxisPadding = 80;
-    const layoutVars = computed(() => store.state.layoutVars);
     function makePositionScale(axis: 'x' | 'y', type: ColumnType, range: AttributeRange) {
       const varName = layoutVars.value[axis];
       let clipLow = false;

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -827,6 +827,7 @@ export default defineComponent({
 
         store.commit.setSimulation(simulation);
         store.commit.startSimulation();
+        resetAxesClipRegions();
       }
     });
 

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -553,7 +553,7 @@ export default defineComponent({
       return null;
     });
     watch(attributeRanges, () => {
-      if (simulationEdges.value !== null && layoutVars.value.x !== null && layoutVars.value.y !== null) {
+      if (simulationEdges.value !== null && layoutVars.value.x === null && layoutVars.value.y === null) {
         const simEdges = simulationEdges.value.filter((edge: Edge) => {
           if (edgeVariables.value.width !== '') {
             const widthValue = edgeWidthScale.value(edge[edgeVariables.value.width]);

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -568,30 +568,6 @@ export default defineComponent({
         );
       }
     });
-    onMounted(() => {
-      if (network.value !== null && simulationEdges.value !== null) {
-        // Make the simulation
-        const simulation = forceSimulation<Node, SimulationEdge>(network.value.nodes)
-          .force('edge', forceLink<Node, SimulationEdge>(simulationEdges.value).id((d) => { const datum = (d as Edge); return datum._id; }).strength(1))
-          .force('x', forceX(svgDimensions.value.width / 2))
-          .force('y', forceY(svgDimensions.value.height / 2))
-          .force('charge', forceManyBody<Node>().strength(-500))
-          .force('collision', forceCollide((markerSize.value / 2) * 1.5))
-          .on('tick', () => {
-            if (currentInstance !== null) {
-              currentInstance.proxy.$forceUpdate();
-            }
-          })
-        // The next line handles the start stop button change in the controls.
-        // It's not explicitly necessary for the simulation to work
-          .on('end', () => {
-            store.commit.stopSimulation();
-          });
-
-        store.commit.setSimulation(simulation);
-        store.commit.startSimulation();
-      }
-    });
 
     const xAxisPadding = 60;
     const yAxisPadding = 80;
@@ -826,6 +802,31 @@ export default defineComponent({
           .attr('width', labelRectPos.width)
           .attr('height', labelRectPos.height)
           .attr('fill', 'white');
+      }
+    });
+
+    onMounted(() => {
+      if (network.value !== null && simulationEdges.value !== null) {
+        // Make the simulation
+        const simulation = forceSimulation<Node, SimulationEdge>(network.value.nodes)
+          .force('edge', forceLink<Node, SimulationEdge>(simulationEdges.value).id((d) => { const datum = (d as Edge); return datum._id; }).strength(1))
+          .force('x', forceX(svgDimensions.value.width / 2))
+          .force('y', forceY(svgDimensions.value.height / 2))
+          .force('charge', forceManyBody<Node>().strength(-500))
+          .force('collision', forceCollide((markerSize.value / 2) * 1.5))
+          .on('tick', () => {
+            if (currentInstance !== null) {
+              currentInstance.proxy.$forceUpdate();
+            }
+          })
+        // The next line handles the start stop button change in the controls.
+        // It's not explicitly necessary for the simulation to work
+          .on('end', () => {
+            store.commit.stopSimulation();
+          });
+
+        store.commit.setSimulation(simulation);
+        store.commit.startSimulation();
       }
     });
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -167,8 +167,6 @@ const {
         state.simulation.alpha(0.2);
         state.simulation.restart();
         state.simulationRunning = true;
-
-        state.layoutVars = { x: null, y: null };
       }
     },
 


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
This PR makes the categorical layout use the force directed layout for jittering the nodes of one group. This means that the nodes are no longer overlapping each other when rendering in this manner.

### Provide pictures/videos of the behavior before and after these changes (optional)
I find this so satisfying:
https://user-images.githubusercontent.com/36867477/177649981-fe40bf4a-1be2-4852-959d-bd809b4facd3.mp4

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [x] Fix weird behavior with forces returning wrong value on first application
- [x] Fix charge force on closer layouts by removing it