### PR TITLE
Bump vue and typescript versions

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   presets: [
-    '@vue/app',
+    '@vue/cli-plugin-babel/preset',
   ],
 };

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-dom": "^17.0.1",
     "sass": "^1.19.0",
     "sass-loader": "^8.0.0",
-    "typescript": "^3.6.3",
+    "typescript": "^4.0.0",
     "vue-cli-plugin-vuetify": "^2.0.2",
     "vue-jest": "^3.0.5",
     "vue-template-compiler": "^2.6.10",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@types/d3": "^5.7.2",
     "@visdesignlab/trrack": "^2.0.0-alpha.10",
     "@visdesignlab/trrack-vis": "^2.0.0-alpha.9",
-    "@vue/composition-api": "^1.0.0-beta.22",
     "core-js": "^3.4.3",
     "d3-array": "^2.8.0",
     "d3-axis": "^2.0.0",
@@ -30,7 +29,7 @@
     "direct-vuex": "^0.12.0",
     "eslint-plugin-vuetify": "^1.0.0-beta.7",
     "multinet": "^0.21.4",
-    "vue": "^2.6.10",
+    "vue": "^2.7.0",
     "vuetify": "^2.1.0",
     "vuex": "^3.5.1"
   },
@@ -41,10 +40,10 @@
     "@vue/cli-plugin-eslint": "^5.0.8",
     "@vue/cli-plugin-typescript": "^3.11.0",
     "@vue/cli-plugin-unit-jest": "^4.1.1",
-    "@vue/cli-service": "^4.1.0",
+    "@vue/cli-service": "^4.5.18",
     "@vue/eslint-config-airbnb": "^6.0.0",
     "@vue/eslint-config-typescript": "^11.0.0",
-    "@vue/test-utils": "^1.0.0-beta.30",
+    "@vue/test-utils": "^2.0.0",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
     "eslint": "^8.19.0",
@@ -60,7 +59,7 @@
     "typescript": "^4.0.0",
     "vue-cli-plugin-vuetify": "^2.0.2",
     "vue-jest": "^3.0.5",
-    "vue-template-compiler": "^2.6.10",
+    "vue-template-compiler": "^2.7.0",
     "vuetify-loader": "^1.3.0"
   },
   "browserslist": [

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,64 +1,29 @@
-<script lang="ts">
+<script setup lang="ts">
 import store from '@/store';
 import { getUrlVars } from '@/lib/utils';
-import {
-  ref, computed, Ref,
-} from '@vue/composition-api';
+import { computed } from 'vue';
 
 import AlertBanner from '@/components/AlertBanner.vue';
 import ControlPanel from '@/components/ControlPanel.vue';
 import MultiLink from '@/components/MultiLink.vue';
 import ProvVis from '@/components/ProvVis.vue';
 
-export default {
-  name: 'App',
+const urlVars = getUrlVars(); // Takes workspacce and network
+store.dispatch.fetchNetwork({
+  workspaceName: urlVars.workspace,
+  networkName: urlVars.network,
+}).then(() => {
+  store.dispatch.createProvenance();
+  store.dispatch.guessLabel();
+});
 
-  components: {
-    AlertBanner,
-    ControlPanel,
-    MultiLink,
-    ProvVis,
-  },
+const network = computed(() => store.state.network);
+const selectedNodes = computed(() => store.state.selectedNodes);
+const loadError = computed(() => store.state.loadError);
 
-  setup() {
-    const network = computed(() => store.state.network);
-    const selectedNodes = computed(() => store.state.selectedNodes);
-    const loadError = computed(() => store.state.loadError);
+// Provenance vis boolean
+const showProvenanceVis = computed(() => store.state.showProvenanceVis);
 
-    const multilinkContainer: Ref<Element | null> = ref(null);
-    const multilinkContainerDimensions = computed(() => {
-      if (multilinkContainer.value !== null) {
-        return {
-          width: multilinkContainer.value.clientWidth - 24,
-          height: multilinkContainer.value.clientHeight - 24,
-        };
-      }
-      return null;
-    });
-
-    const urlVars = getUrlVars(); // Takes workspacce and network
-
-    store.dispatch.fetchNetwork({
-      workspaceName: urlVars.workspace,
-      networkName: urlVars.network,
-    }).then(() => {
-      store.dispatch.createProvenance();
-      store.dispatch.guessLabel();
-    });
-
-    // Provenance vis boolean
-    const showProvenanceVis = computed(() => store.state.showProvenanceVis);
-
-    return {
-      network,
-      selectedNodes,
-      loadError,
-      multilinkContainer,
-      multilinkContainerDimensions,
-      showProvenanceVis,
-    };
-  },
-};
 </script>
 
 <template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,14 +1,13 @@
 <script setup lang="ts">
 import store from '@/store';
 import { getUrlVars } from '@/lib/utils';
-import { computed } from 'vue';
 
 import AlertBanner from '@/components/AlertBanner.vue';
 import ControlPanel from '@/components/ControlPanel.vue';
 import MultiLink from '@/components/MultiLink.vue';
 import ProvVis from '@/components/ProvVis.vue';
 
-const urlVars = getUrlVars(); // Takes workspacce and network
+const urlVars = getUrlVars(); // Takes workspace and network
 store.dispatch.fetchNetwork({
   workspaceName: urlVars.workspace,
   networkName: urlVars.network,
@@ -16,14 +15,6 @@ store.dispatch.fetchNetwork({
   store.dispatch.createProvenance();
   store.dispatch.guessLabel();
 });
-
-const network = computed(() => store.state.network);
-const selectedNodes = computed(() => store.state.selectedNodes);
-const loadError = computed(() => store.state.loadError);
-
-// Provenance vis boolean
-const showProvenanceVis = computed(() => store.state.showProvenanceVis);
-
 </script>
 
 <template>
@@ -32,13 +23,13 @@ const showProvenanceVis = computed(() => store.state.showProvenanceVis);
       <control-panel />
 
       <multi-link
-        v-if="network !== null && selectedNodes !== null"
+        v-if="store.state.network !== null && store.state.selectedNodes !== null"
       />
 
-      <alert-banner v-if="loadError.message !== ''" />
+      <alert-banner v-if="store.state.loadError.message !== ''" />
     </v-main>
 
-    <prov-vis v-if="showProvenanceVis" />
+    <prov-vis v-if="store.state.showProvenanceVis" />
   </v-app>
 </template>
 

--- a/src/components/AboutDialog.vue
+++ b/src/components/AboutDialog.vue
@@ -53,17 +53,8 @@
   </v-dialog>
 </template>
 
-<script lang="ts">
-import { defineComponent, ref } from 'vue';
+<script setup lang="ts">
+import { ref } from 'vue';
 
-export default defineComponent({
-  setup() {
-    const dialog = ref(false);
-
-    return {
-      dialog,
-    };
-  },
-});
-
+const dialog = ref(false);
 </script>

--- a/src/components/AboutDialog.vue
+++ b/src/components/AboutDialog.vue
@@ -54,7 +54,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from '@vue/composition-api';
+import { defineComponent, ref } from 'vue';
 
 export default defineComponent({
   setup() {

--- a/src/components/AlertBanner.vue
+++ b/src/components/AlertBanner.vue
@@ -2,7 +2,7 @@
 import store from '@/store';
 import {
   computed, defineComponent, Ref, ref, watchEffect,
-} from '@vue/composition-api';
+} from 'vue';
 import api from '@/api';
 
 export default defineComponent({

--- a/src/components/AlertBanner.vue
+++ b/src/components/AlertBanner.vue
@@ -1,58 +1,42 @@
-<script lang="ts">
+<script setup lang="ts">
 import store from '@/store';
 import {
-  computed, defineComponent, Ref, ref, watchEffect,
+  computed, Ref, ref, watchEffect,
 } from 'vue';
 import api from '@/api';
 
-export default defineComponent({
-  name: 'AlertBanner',
+const loadError = computed(() => store.state.loadError);
 
-  setup() {
-    const loadError = computed(() => store.state.loadError);
+// Vars to store the selected choices in
+const workspace: Ref<string | null> = ref(null);
+const network: Ref<string | null> = ref(null);
 
-    // Vars to store the selected choices in
-    const workspace: Ref<string | null> = ref(null);
-    const network: Ref<string | null> = ref(null);
+// Compute the workspace/network options
+const workspaceOptions: Ref<string[]> = ref([]);
+watchEffect(async () => {
+  workspaceOptions.value = (await api.workspaces()).results.map((workspaceObj) => workspaceObj.name);
+});
 
-    // Compute the workspace/network options
-    const workspaceOptions: Ref<string[]> = ref([]);
-    watchEffect(async () => {
-      workspaceOptions.value = (await api.workspaces()).results.map((workspaceObj) => workspaceObj.name);
-    });
+const networkOptions: Ref<string[]> = ref([]);
+watchEffect(async () => {
+  if (workspace.value !== null) {
+    networkOptions.value = (await api.networks(workspace.value)).results.map((networkObj) => networkObj.name);
+  }
+});
 
-    const networkOptions: Ref<string[]> = ref([]);
-    watchEffect(async () => {
-      if (workspace.value !== null) {
-        networkOptions.value = (await api.networks(workspace.value)).results.map((networkObj) => networkObj.name);
-      }
-    });
-
-    const buttonHref: Ref<string> = ref(loadError.value.href);
-    const buttonText: Ref<string> = ref('');
-    watchEffect(async () => {
-      if (workspace.value !== null && network.value !== null) {
-        buttonHref.value = `./?workspace=${workspace.value}&network=${network.value}`;
-        buttonText.value = 'Go To Network';
-      } else if (loadError.value.message === 'There was a network issue when getting data') {
-        buttonHref.value = loadError.value.href;
-        buttonText.value = 'Refresh the page';
-      } else {
-        buttonHref.value = loadError.value.href;
-        buttonText.value = 'Back to MultiNet';
-      }
-    });
-
-    return {
-      buttonHref,
-      buttonText,
-      loadError,
-      network,
-      networkOptions,
-      workspace,
-      workspaceOptions,
-    };
-  },
+const buttonHref = ref(loadError.value.href);
+const buttonText = ref('');
+watchEffect(async () => {
+  if (workspace.value !== null && network.value !== null) {
+    buttonHref.value = `./?workspace=${workspace.value}&network=${network.value}`;
+    buttonText.value = 'Go To Network';
+  } else if (loadError.value.message === 'There was a network issue when getting data') {
+    buttonHref.value = loadError.value.href;
+    buttonText.value = 'Refresh the page';
+  } else {
+    buttonHref.value = loadError.value.href;
+    buttonText.value = 'Back to MultiNet';
+  }
 });
 </script>
 

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -2,7 +2,7 @@
 import store from '@/store';
 import {
   computed, defineComponent,
-} from '@vue/composition-api';
+} from 'vue';
 
 export default defineComponent({
   setup() {

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -1,52 +1,36 @@
-<script lang="ts">
+<script setup lang="ts">
 import store from '@/store';
-import {
-  computed, defineComponent,
-} from 'vue';
+import { computed } from 'vue';
 
-export default defineComponent({
-  setup() {
-    const network = computed(() => store.state.network);
+const network = computed(() => store.state.network);
+const selectedNodes = computed(() => store.state.selectedNodes);
 
-    const selectedNodes = computed(() => store.state.selectedNodes);
-    function clearSelection() {
-      store.commit.setSelected(new Set());
-    }
-    function pinSelectedNodes() {
-      if (network.value !== null) {
-        network.value.nodes
-          .filter((node) => selectedNodes.value.has(node._id))
-          .forEach((node) => {
-            // eslint-disable-next-line no-param-reassign
-            node.fx = node.x;
-            // eslint-disable-next-line no-param-reassign
-            node.fy = node.y;
-          });
-      }
-    }
-    function unPinSelectedNodes() {
-      if (network.value !== null) {
-        network.value.nodes
-          .filter((node) => selectedNodes.value.has(node._id))
-          .forEach((node) => {
-            // eslint-disable-next-line no-param-reassign
-            delete node.fx;
-            // eslint-disable-next-line no-param-reassign
-            delete node.fy;
-          });
-      }
-    }
+function pinSelectedNodes() {
+  if (network.value !== null) {
+    network.value.nodes
+      .filter((node) => selectedNodes.value.has(node._id))
+      .forEach((node) => {
+        // eslint-disable-next-line no-param-reassign
+        node.fx = node.x;
+        // eslint-disable-next-line no-param-reassign
+        node.fy = node.y;
+      });
+  }
+}
+function unPinSelectedNodes() {
+  if (network.value !== null) {
+    network.value.nodes
+      .filter((node) => selectedNodes.value.has(node._id))
+      .forEach((node) => {
+        // eslint-disable-next-line no-param-reassign
+        delete node.fx;
+        // eslint-disable-next-line no-param-reassign
+        delete node.fy;
+      });
+  }
+}
 
-    const rightClickMenu = computed(() => store.state.rightClickMenu);
-
-    return {
-      rightClickMenu,
-      clearSelection,
-      pinSelectedNodes,
-      unPinSelectedNodes,
-    };
-  },
-});
+const rightClickMenu = computed(() => store.state.rightClickMenu);
 </script>
 
 <template>
@@ -61,7 +45,7 @@ export default defineComponent({
       <v-list>
         <v-list-item
           dense
-          @click="clearSelection"
+          @click="store.commit.setSelected(new Set())"
         >
           <v-list-item-content>
             <v-list-item-title>Clear Selection</v-list-item-title>

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -7,7 +7,7 @@ import store from '@/store';
 import { Node, internalFieldNames } from '@/types';
 import {
   computed, defineComponent, Ref, ref,
-} from '@vue/composition-api';
+} from 'vue';
 
 export default defineComponent({
   components: {

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -134,7 +134,6 @@ export default defineComponent({
         nodes: network.value.nodes.map((node) => {
           const newNode = { ...node };
           newNode.id = newNode._key;
-          delete newNode._key;
 
           return newNode;
         }),

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -1,216 +1,162 @@
-<script lang="ts">
+<script setup lang="ts">
 import LegendPanel from '@/components/LegendPanel.vue';
 import AboutDialog from '@/components/AboutDialog.vue';
 import LoginMenu from '@/components/LoginMenu.vue';
 
 import store from '@/store';
-import { Node, internalFieldNames } from '@/types';
-import {
-  computed, defineComponent, Ref, ref,
-} from 'vue';
+import { internalFieldNames } from '@/types';
+import { computed, Ref, ref } from 'vue';
 
-export default defineComponent({
-  components: {
-    LegendPanel,
-    AboutDialog,
-    LoginMenu,
+const searchTerm = ref('');
+const searchErrors: Ref<string[]> = ref([]);
+const showMenu = ref(false);
+const network = computed(() => store.state.network);
+
+const multiVariableList = computed(() => {
+  if (network.value !== null) {
+    // Loop through all nodes, flatten the 2d array, and turn it into a set
+    const allVars: Set<string> = new Set();
+    network.value.nodes.forEach((node) => Object.keys(node).forEach((key) => allVars.add(key)));
+
+    internalFieldNames.forEach((field) => allVars.delete(field));
+    allVars.delete('vx');
+    allVars.delete('vy');
+    allVars.delete('x');
+    allVars.delete('y');
+    allVars.delete('index');
+    return allVars;
+  }
+  return new Set();
+});
+
+const displayCharts = computed({
+  get() {
+    return store.state.displayCharts;
   },
-
-  setup() {
-    const searchTerm = ref('');
-    const searchErrors: Ref<string[]> = ref([]);
-    const showMenu = ref(false);
-    const network = computed(() => store.state.network);
-
-    const multiVariableList = computed(() => {
-      if (network.value !== null) {
-        // Loop through all nodes, flatten the 2d array, and turn it into a set
-        const allVars: Set<string> = new Set();
-        network.value.nodes.forEach((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
-
-        internalFieldNames.forEach((field) => allVars.delete(field));
-        allVars.delete('vx');
-        allVars.delete('vy');
-        allVars.delete('x');
-        allVars.delete('y');
-        allVars.delete('index');
-        return allVars;
-      }
-      return new Set();
-    });
-
-    const displayCharts = computed({
-      get() {
-        return store.state.displayCharts;
-      },
-      set(value: boolean) {
-        return store.commit.setDisplayCharts(value);
-      },
-    });
-
-    const layoutVars = computed(() => store.state.layoutVars);
-    const markerSize = computed({
-      get() {
-        return store.state.markerSize || 0;
-      },
-      set(value: number) {
-        store.commit.setMarkerSize({ markerSize: value, updateProv: false });
-      },
-    });
-
-    const fontSize = computed({
-      get() {
-        return store.state.fontSize || 0;
-      },
-      set(value: number) {
-        store.commit.setFontSize({ fontSize: value, updateProv: false });
-      },
-    });
-
-    const labelVariable = computed({
-      get() {
-        return store.state.labelVariable;
-      },
-      set(value: string | undefined) {
-        store.commit.setLabelVariable(value);
-      },
-    });
-
-    const selectNeighbors = computed({
-      get() {
-        return store.state.selectNeighbors;
-      },
-      set(value: boolean) {
-        store.commit.setSelectNeighbors(value);
-      },
-    });
-
-    const directionalEdges = computed({
-      get() {
-        return store.state.directionalEdges;
-      },
-      set(value: boolean) {
-        store.commit.setDirectionalEdges(value);
-      },
-    });
-
-    const edgeLength = computed({
-      get() {
-        return store.state.edgeLength;
-      },
-      set(value: number) {
-        store.commit.setEdgeLength({ edgeLength: value, updateProv: false });
-      },
-    });
-
-    const controlsWidth = computed(() => store.state.controlsWidth);
-    const simulationRunning = computed(() => store.state.simulationRunning);
-    const columnTypes = computed(() => store.state.columnTypes);
-    const autocompleteItems = computed(() => {
-      if (network.value !== null && labelVariable.value !== undefined) {
-        return network.value.nodes.map((node) => (node[labelVariable.value || '']));
-      }
-      return [];
-    });
-
-    function startSimulation() {
-      store.commit.startSimulation();
-    }
-
-    function stopSimulation() {
-      store.commit.stopSimulation();
-    }
-
-    function releaseNodes() {
-      store.dispatch.releaseNodes();
-    }
-
-    function exportNetwork() {
-      if (network.value === null) {
-        return;
-      }
-
-      const networkToExport = {
-        nodes: network.value.nodes.map((node) => {
-          const newNode = { ...node };
-          newNode.id = newNode._key;
-
-          return newNode;
-        }),
-        edges: network.value.edges.map((edge) => {
-          const newEdge = { ...edge };
-          newEdge.source = `${edge._from.split('/')[1]}`;
-          newEdge.target = `${edge._to.split('/')[1]}`;
-          return newEdge;
-        }),
-      };
-
-      const a = document.createElement('a');
-      a.href = URL.createObjectURL(
-        new Blob([JSON.stringify(networkToExport)], {
-          type: 'text/json',
-        }),
-      );
-      a.download = `${store.state.networkName}.json`;
-      a.click();
-    }
-
-    function search() {
-      searchErrors.value = [];
-      if (network.value !== null) {
-        const nodeIDsToSelect = network.value.nodes
-          .filter((node) => (labelVariable.value !== undefined ? node[labelVariable.value] === searchTerm.value : false))
-          .map((node) => node._id);
-
-        if (nodeIDsToSelect.length > 0) {
-          store.commit.addSelectedNode(nodeIDsToSelect);
-        } else {
-          searchErrors.value.push('Enter a valid node to search');
-        }
-      }
-    }
-
-    function updateSliderProv(value: number, type: 'markerSize' | 'fontSize' | 'edgeLength') {
-      if (type === 'markerSize') {
-        store.commit.setMarkerSize({ markerSize: value, updateProv: true });
-      } else if (type === 'fontSize') {
-        store.commit.setFontSize({ fontSize: value, updateProv: true });
-      } else if (type === 'edgeLength') {
-        store.commit.setEdgeLength({ edgeLength: value, updateProv: true });
-      }
-    }
-
-    function toggleProvVis() {
-      store.commit.toggleShowProvenanceVis();
-    }
-
-    return {
-      searchTerm,
-      searchErrors,
-      showMenu,
-      displayCharts,
-      columnTypes,
-      search,
-      autocompleteItems,
-      controlsWidth,
-      multiVariableList,
-      markerSize,
-      fontSize,
-      toggleProvVis,
-      updateSliderProv,
-      exportNetwork,
-      startSimulation,
-      stopSimulation,
-      releaseNodes,
-      simulationRunning,
-      labelVariable,
-      selectNeighbors,
-      directionalEdges,
-      edgeLength,
-      layoutVars,
-    };
+  set(value: boolean) {
+    return store.commit.setDisplayCharts(value);
   },
 });
+
+const layoutVars = computed(() => store.state.layoutVars);
+const markerSize = computed({
+  get() {
+    return store.state.markerSize || 0;
+  },
+  set(value: number) {
+    store.commit.setMarkerSize({ markerSize: value, updateProv: false });
+  },
+});
+
+const fontSize = computed({
+  get() {
+    return store.state.fontSize || 0;
+  },
+  set(value: number) {
+    store.commit.setFontSize({ fontSize: value, updateProv: false });
+  },
+});
+
+const labelVariable = computed({
+  get() {
+    return store.state.labelVariable;
+  },
+  set(value: string | undefined) {
+    store.commit.setLabelVariable(value);
+  },
+});
+
+const selectNeighbors = computed({
+  get() {
+    return store.state.selectNeighbors;
+  },
+  set(value: boolean) {
+    store.commit.setSelectNeighbors(value);
+  },
+});
+
+const directionalEdges = computed({
+  get() {
+    return store.state.directionalEdges;
+  },
+  set(value: boolean) {
+    store.commit.setDirectionalEdges(value);
+  },
+});
+
+const edgeLength = computed({
+  get() {
+    return store.state.edgeLength;
+  },
+  set(value: number) {
+    store.commit.setEdgeLength({ edgeLength: value, updateProv: false });
+  },
+});
+
+const controlsWidth = computed(() => store.state.controlsWidth);
+const simulationRunning = computed(() => store.state.simulationRunning);
+const columnTypes = computed(() => store.state.columnTypes);
+const autocompleteItems = computed(() => {
+  if (network.value !== null && labelVariable.value !== undefined) {
+    return network.value.nodes.map((node) => (node[labelVariable.value || '']));
+  }
+  return [];
+});
+
+function exportNetwork() {
+  if (network.value === null) {
+    return;
+  }
+
+  const networkToExport = {
+    nodes: network.value.nodes.map((node) => {
+      const newNode = { ...node };
+      newNode.id = newNode._key;
+
+      return newNode;
+    }),
+    edges: network.value.edges.map((edge) => {
+      const newEdge = { ...edge };
+      newEdge.source = `${edge._from.split('/')[1]}`;
+      newEdge.target = `${edge._to.split('/')[1]}`;
+      return newEdge;
+    }),
+  };
+
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(
+    new Blob([JSON.stringify(networkToExport)], {
+      type: 'text/json',
+    }),
+  );
+  a.download = `${store.state.networkName}.json`;
+  a.click();
+}
+
+function search() {
+  searchErrors.value = [];
+  if (network.value !== null) {
+    const nodeIDsToSelect = network.value.nodes
+      .filter((node) => (labelVariable.value !== undefined ? node[labelVariable.value] === searchTerm.value : false))
+      .map((node) => node._id);
+
+    if (nodeIDsToSelect.length > 0) {
+      store.commit.addSelectedNode(nodeIDsToSelect);
+    } else {
+      searchErrors.value.push('Enter a valid node to search');
+    }
+  }
+}
+
+function updateSliderProv(value: number, type: 'markerSize' | 'fontSize' | 'edgeLength') {
+  if (type === 'markerSize') {
+    store.commit.setMarkerSize({ markerSize: value, updateProv: true });
+  } else if (type === 'fontSize') {
+    store.commit.setFontSize({ fontSize: value, updateProv: true });
+  } else if (type === 'edgeLength') {
+    store.commit.setEdgeLength({ edgeLength: value, updateProv: true });
+  }
+}
 </script>
 
 <template>
@@ -371,7 +317,7 @@ export default defineComponent({
                 color="grey darken-2"
                 depressed
                 small
-                @click="releaseNodes"
+                @click="store.dispatch.releaseNodes()"
               >
                 <v-icon
                   left
@@ -389,7 +335,7 @@ export default defineComponent({
                 depressed
                 small
                 width="75"
-                @click="simulationRunning ? stopSimulation() : startSimulation()"
+                @click="simulationRunning ? store.commit.stopSimulation() : store.commit.startSimulation()"
               >
                 <v-icon
                   left
@@ -407,7 +353,7 @@ export default defineComponent({
               color="primary"
               block
               depressed
-              @click="toggleProvVis"
+              @click="store.commit.toggleShowProvenanceVis()"
             >
               Provenance Vis
             </v-btn>

--- a/src/components/DragTarget.vue
+++ b/src/components/DragTarget.vue
@@ -1,78 +1,63 @@
-<script lang="ts">
+<script setup lang="ts">
 import store from '@/store';
-import { computed, defineComponent, PropType } from 'vue';
+import { computed } from 'vue';
 
-export default defineComponent({
-  props: {
-    title: {
-      type: String,
-      required: true,
-    },
-    type: {
-      type: String as PropType<'node' | 'edge'>,
-      required: true,
-    },
-    showTitle: {
-      type: Boolean,
-      default: true,
-    },
-  },
-
-  setup(props) {
-    const edgeVariables = computed(() => store.state.edgeVariables);
-    const nestedVariables = computed(() => store.state.nestedVariables);
-
-    function elementDrop(event: DragEvent) {
-      if (event.dataTransfer === null) {
-        return;
-      }
-
-      const droppedVarName = event.dataTransfer.getData('attr_id').substring(5);
-
-      if (props.type === 'node' && props.title === 'bars') {
-        const updatedNestedVars = {
-          bar: [...nestedVariables.value.bar, droppedVarName],
-          glyph: nestedVariables.value.glyph,
-        };
-        store.commit.setNestedVariables(updatedNestedVars);
-      } else if (props.type === 'node' && props.title === 'glyphs') {
-        const updatedNestedVars = {
-          bar: nestedVariables.value.bar,
-          glyph: [...nestedVariables.value.glyph, droppedVarName],
-        };
-        store.commit.setNestedVariables(updatedNestedVars);
-      } else if (props.type === 'node' && props.title === 'size') {
-        store.commit.setNodeSizeVariable(droppedVarName);
-      } else if (props.type === 'node' && props.title === 'color') {
-        store.commit.setNodeColorVariable(droppedVarName);
-      } else if (props.type === 'node' && props.title === 'x variable') {
-        store.dispatch.applyVariableLayout({
-          varName: droppedVarName, axis: 'x',
-        });
-      } else if (props.type === 'node' && props.title === 'y variable') {
-        store.dispatch.applyVariableLayout({
-          varName: droppedVarName, axis: 'y',
-        });
-      } else if (props.type === 'edge' && props.title === 'width') {
-        const updatedEdgeVars = {
-          width: droppedVarName,
-          color: edgeVariables.value.color,
-        };
-        store.commit.setEdgeVariables(updatedEdgeVars);
-      } else if (props.type === 'edge' && props.title === 'color') {
-        const updatedEdgeVars = {
-          width: edgeVariables.value.width,
-          color: droppedVarName,
-        };
-        store.commit.setEdgeVariables(updatedEdgeVars);
-      }
-    }
-
-    return {
-      elementDrop,
-    };
-  },
+const props = withDefaults(defineProps<{
+  title: string
+  type: 'node' | 'edge',
+  showTitle?: boolean
+}>(), {
+  showTitle: true,
 });
+
+const edgeVariables = computed(() => store.state.edgeVariables);
+const nestedVariables = computed(() => store.state.nestedVariables);
+
+function elementDrop(event: DragEvent) {
+  if (event.dataTransfer === null) {
+    return;
+  }
+
+  const droppedVarName = event.dataTransfer.getData('attr_id').substring(5);
+
+  if (props.type === 'node' && props.title === 'bars') {
+    const updatedNestedVars = {
+      bar: [...nestedVariables.value.bar, droppedVarName],
+      glyph: nestedVariables.value.glyph,
+    };
+    store.commit.setNestedVariables(updatedNestedVars);
+  } else if (props.type === 'node' && props.title === 'glyphs') {
+    const updatedNestedVars = {
+      bar: nestedVariables.value.bar,
+      glyph: [...nestedVariables.value.glyph, droppedVarName],
+    };
+    store.commit.setNestedVariables(updatedNestedVars);
+  } else if (props.type === 'node' && props.title === 'size') {
+    store.commit.setNodeSizeVariable(droppedVarName);
+  } else if (props.type === 'node' && props.title === 'color') {
+    store.commit.setNodeColorVariable(droppedVarName);
+  } else if (props.type === 'node' && props.title === 'x variable') {
+    store.dispatch.applyVariableLayout({
+      varName: droppedVarName, axis: 'x',
+    });
+  } else if (props.type === 'node' && props.title === 'y variable') {
+    store.dispatch.applyVariableLayout({
+      varName: droppedVarName, axis: 'y',
+    });
+  } else if (props.type === 'edge' && props.title === 'width') {
+    const updatedEdgeVars = {
+      width: droppedVarName,
+      color: edgeVariables.value.color,
+    };
+    store.commit.setEdgeVariables(updatedEdgeVars);
+  } else if (props.type === 'edge' && props.title === 'color') {
+    const updatedEdgeVars = {
+      width: edgeVariables.value.width,
+      color: droppedVarName,
+    };
+    store.commit.setEdgeVariables(updatedEdgeVars);
+  }
+}
 </script>
 
 <template>

--- a/src/components/DragTarget.vue
+++ b/src/components/DragTarget.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import store from '@/store';
-import { computed, defineComponent, PropType } from '@vue/composition-api';
+import { computed, defineComponent, PropType } from 'vue';
 
 export default defineComponent({
   props: {

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -1,9 +1,7 @@
-<script lang="ts">
+<script setup lang="ts">
 import store from '@/store';
 import { Node, Edge } from '@/types';
-import {
-  computed, defineComponent, onMounted, PropType, watchEffect,
-} from 'vue';
+import { computed, onMounted, watchEffect } from 'vue';
 import { histogram, max, min } from 'd3-array';
 import { axisBottom, axisLeft } from 'd3-axis';
 import { brushX, D3BrushEvent } from 'd3-brush';
@@ -12,509 +10,486 @@ import {
 } from 'd3-scale';
 import { select, selectAll } from 'd3-selection';
 
-export default defineComponent({
-  name: 'LegendChart',
+// Required for recursive definition of LegendChart
+// eslint-disable-next-line import/no-self-import
+import LegendChart from '@/components/LegendChart.vue';
 
-  props: {
-    varName: {
-      type: String,
-      required: true,
-    },
-    type: {
-      type: String as PropType<'node' | 'edge'>,
-      required: true,
-    },
-    selected: {
-      type: Boolean,
-      required: true,
-    },
-    brushable: {
-      type: Boolean,
-      default: false,
-    },
-    mappedTo: {
-      type: String,
-      default: '',
-    },
-    filter: {
-      type: String,
-      default: '',
-    },
-  },
+const props = withDefaults(defineProps<{
+  varName: string
+  type: 'node' | 'edge',
+  selected: boolean,
+  brushable?: boolean,
+  mappedTo?: string,
+  filter?: string,
+}>(), {
+  brushable: false,
+  mappedTo: '',
+  filter: '',
+});
 
-  setup(props) {
-    const yAxisPadding = 30;
-    const svgHeight = props.mappedTo === 'bars' ? 75 : 50;
+const yAxisPadding = 30;
+const svgHeight = props.mappedTo === 'bars' ? 75 : 50;
 
-    const network = computed(() => store.state.network);
-    const columnTypes = computed(() => store.state.columnTypes);
-    const nestedVariables = computed(() => store.state.nestedVariables);
-    const nodeSizeScale = computed(() => store.getters.nodeSizeScale);
-    const nodeColorScale = computed(() => store.getters.nodeColorScale);
-    const nodeBarColorScale = computed(() => store.state.nodeBarColorScale);
-    const nodeGlyphColorScale = computed(() => store.state.nodeGlyphColorScale);
-    const edgeWidthScale = computed(() => store.getters.edgeWidthScale);
-    const edgeColorScale = computed(() => store.getters.edgeColorScale);
-    const attributeRanges = computed(() => store.state.attributeRanges);
+const network = computed(() => store.state.network);
+const columnTypes = computed(() => store.state.columnTypes);
+const nestedVariables = computed(() => store.state.nestedVariables);
+const nodeSizeScale = computed(() => store.getters.nodeSizeScale);
+const nodeColorScale = computed(() => store.getters.nodeColorScale);
+const nodeBarColorScale = computed(() => store.state.nodeBarColorScale);
+const nodeGlyphColorScale = computed(() => store.state.nodeGlyphColorScale);
+const edgeWidthScale = computed(() => store.getters.edgeWidthScale);
+const edgeColorScale = computed(() => store.getters.edgeColorScale);
+const attributeRanges = computed(() => store.state.attributeRanges);
 
-    // TODO: https://github.com/multinet-app/multilink/issues/176
-    // use table name for var selection
-    function isQuantitative(varName: string, type: 'node' | 'edge') {
-      if (columnTypes.value !== null && Object.keys(columnTypes.value).length > 0) {
-        return columnTypes.value[varName] === 'number';
-      }
+// TODO: https://github.com/multinet-app/multilink/issues/176
+// use table name for var selection
+function isQuantitative(varName: string, type: 'node' | 'edge') {
+  if (columnTypes.value !== null && Object.keys(columnTypes.value).length > 0) {
+    return columnTypes.value[varName] === 'number';
+  }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let nodesOrEdges: any[];
+
+  if (network.value !== null) {
+    nodesOrEdges = type === 'node' ? network.value.nodes : network.value.edges;
+    const uniqueValues = [...new Set(nodesOrEdges.map((element) => parseFloat(element[varName])))];
+    return uniqueValues.length > 5;
+  }
+  return false;
+}
+
+function dragStart(event: DragEvent) {
+  if (event.dataTransfer !== null && event.target !== null) {
+    event.dataTransfer.setData('attr_id', (event.target as Element).id);
+  }
+}
+
+function unAssignVar(variable?: string) {
+  if (props.type === 'node') {
+    if (props.mappedTo === 'size') {
+      store.commit.setNodeSizeVariable('');
+    } else if (props.mappedTo === 'color') {
+      store.commit.setNodeColorVariable('');
+    } else if (props.mappedTo === 'bars') {
+      const newBarVars = nestedVariables.value.bar.filter(
+        (barVar) => barVar !== variable,
+      );
+
+      store.commit.setNestedVariables({
+        bar: newBarVars,
+        glyph: nestedVariables.value.glyph,
+      });
+    } else if (props.mappedTo === 'glyphs') {
+      const newGlyphVars = nestedVariables.value.glyph.filter(
+        (glyphVar) => glyphVar !== props.varName,
+      );
+
+      store.commit.setNestedVariables({
+        bar: nestedVariables.value.bar,
+        glyph: newGlyphVars,
+      });
+    } else if (props.mappedTo === 'x' || props.mappedTo === 'y') {
+      store.dispatch.applyVariableLayout({
+        varName: null, axis: props.mappedTo,
+      });
+    }
+  } else if (props.type === 'edge') {
+    if (props.mappedTo === 'width') {
+      store.commit.setEdgeVariables({
+        width: '',
+        color: store.state.edgeVariables.color,
+      });
+    } else if (props.mappedTo === 'color') {
+      store.commit.setEdgeVariables({
+        width: store.state.edgeVariables.width,
+        color: '',
+      });
+    }
+  }
+}
+
+onMounted(() => {
+  const variableSvg = select(`#${props.type}${props.varName}${props.mappedTo}`);
+
+  let variableSvgWidth = (variableSvg
+    .node() as Element)
+    .getBoundingClientRect()
+    .width - yAxisPadding;
+
+  variableSvgWidth = variableSvgWidth < 0 ? 256 : variableSvgWidth;
+
+  let xScale: ScaleLinear<number, number> | ScaleBand<string>;
+  let yScale: ScaleLinear<number, number>;
+
+  if (network.value === null) {
+    return;
+  }
+
+  // Process data for bars/histogram
+  if (props.mappedTo === 'size' && nodeSizeScale.value !== null) { // node size
+    xScale = scaleLinear()
+      .domain(nodeSizeScale.value.domain())
+      .range([yAxisPadding, variableSvgWidth]);
+
+    // Draw circles
+    variableSvg
+      .append('circle')
+      .attr('cx', yAxisPadding)
+      .attr('cy', yAxisPadding + 15)
+      .attr('r', 5)
+      .attr('fill', '#3977AF');
+
+    variableSvg
+      .append('circle')
+      .attr('cx', (variableSvgWidth + yAxisPadding) / 2)
+      .attr('cy', yAxisPadding + 10)
+      .attr('r', 10)
+      .attr('fill', '#3977AF');
+
+    variableSvg
+      .append('circle')
+      .attr('cx', variableSvgWidth)
+      .attr('cy', yAxisPadding)
+      .attr('r', 20)
+      .attr('fill', '#3977AF');
+  } else if (props.mappedTo === 'width') { // edge width
+    yScale = scaleLinear()
+      .domain(edgeWidthScale.value.domain())
+      .range([svgHeight, 10]);
+
+    const minValue = edgeWidthScale.value.range()[0];
+    const maxValue = edgeWidthScale.value.range()[1];
+    const middleValue = (edgeWidthScale.value.range()[1] + edgeWidthScale.value.range()[0]) / 2;
+
+    // Draw width lines
+    variableSvg
+      .append('rect')
+      .attr('height', maxValue)
+      .attr('width', variableSvgWidth)
+      .attr('x', yAxisPadding)
+      .attr('y', 0)
+      .attr('fill', '#888888');
+
+    variableSvg
+      .append('rect')
+      .attr('height', middleValue)
+      .attr('width', variableSvgWidth)
+      .attr('x', yAxisPadding)
+      .attr('y', svgHeight / 2)
+      .attr('fill', '#888888');
+
+    variableSvg
+      .append('rect')
+      .attr('height', minValue + 2)
+      .attr('width', variableSvgWidth)
+      .attr('x', yAxisPadding)
+      .attr('y', svgHeight - 1)
+      .attr('fill', '#888888');
+  } else if (props.mappedTo === 'color') { // node color and edge color
+    if (isQuantitative(props.varName, props.type)) {
+      // Gradient
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let nodesOrEdges: any[];
+      let scale: any;
 
-      if (network.value !== null) {
-        nodesOrEdges = type === 'node' ? network.value.nodes : network.value.edges;
-        const uniqueValues = [...new Set(nodesOrEdges.map((element) => parseFloat(element[varName])))];
-        return uniqueValues.length > 5;
-      }
-      return false;
-    }
-
-    function dragStart(event: DragEvent) {
-      if (event.dataTransfer !== null && event.target !== null) {
-        event.dataTransfer.setData('attr_id', (event.target as Element).id);
-      }
-    }
-
-    function unAssignVar(variable?: string) {
       if (props.type === 'node') {
-        if (props.mappedTo === 'size') {
-          store.commit.setNodeSizeVariable('');
-        } else if (props.mappedTo === 'color') {
-          store.commit.setNodeColorVariable('');
-        } else if (props.mappedTo === 'bars') {
-          const newBarVars = nestedVariables.value.bar.filter(
-            (barVar) => barVar !== variable,
-          );
+        xScale = scaleLinear()
+          .domain(nodeColorScale.value.domain() as number[])
+          .range([yAxisPadding, variableSvgWidth]);
 
-          store.commit.setNestedVariables({
-            bar: newBarVars,
-            glyph: nestedVariables.value.glyph,
-          });
-        } else if (props.mappedTo === 'glyphs') {
-          const newGlyphVars = nestedVariables.value.glyph.filter(
-            (glyphVar) => glyphVar !== props.varName,
-          );
+        scale = nodeColorScale.value;
+      } else {
+        xScale = scaleLinear()
+          .domain(edgeColorScale.value.domain() as number[])
+          .range([yAxisPadding, variableSvgWidth]);
 
-          store.commit.setNestedVariables({
-            bar: nestedVariables.value.bar,
-            glyph: newGlyphVars,
-          });
-        } else if (props.mappedTo === 'x' || props.mappedTo === 'y') {
-          store.dispatch.applyVariableLayout({
-            varName: null, axis: props.mappedTo,
-          });
-        }
-      } else if (props.type === 'edge') {
-        if (props.mappedTo === 'width') {
-          store.commit.setEdgeVariables({
-            width: '',
-            color: store.state.edgeVariables.color,
-          });
-        } else if (props.mappedTo === 'color') {
-          store.commit.setEdgeVariables({
-            width: store.state.edgeVariables.width,
-            color: '',
-          });
-        }
+        scale = edgeColorScale.value;
       }
+
+      const minColor = scale(scale.domain()[0]);
+      const midColor = scale((scale.domain()[0] + scale.domain()[1]) / 2);
+      const maxColor = scale(scale.domain()[1]);
+
+      const gradient = variableSvg
+        .append('defs')
+        .append('linearGradient')
+        .attr('id', 'grad');
+
+      gradient
+        .append('stop')
+        .attr('offset', '0%')
+        .attr('stop-color', minColor);
+
+      gradient
+        .append('stop')
+        .attr('offset', '50%')
+        .attr('stop-color', midColor);
+
+      gradient
+        .append('stop')
+        .attr('offset', '100%')
+        .attr('stop-color', maxColor);
+
+      variableSvg
+        .append('rect')
+        .attr('height', 20)
+        .attr('width', (xScale.range()[1] || 0) - (xScale.range()[0] || 0))
+        .attr('x', xScale.range()[0] || 0)
+        .attr('y', 20)
+        .attr('fill', 'url(#grad)')
+        .style('opacity', 0.7);
+    } else {
+      const currentData = props.type === 'node' ? network.value.nodes : network.value.edges;
+
+      // Swatches
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const binLabels: string[] = [...new Set<string>((currentData as any).map((d: Node | Edge) => d[props.varName]))];
+
+      xScale = scaleBand()
+        .domain(binLabels)
+        .range([yAxisPadding, variableSvgWidth]);
+
+      // Draw swatches
+      const swatchWidth = (variableSvgWidth - yAxisPadding) / binLabels.length;
+
+      variableSvg
+        .selectAll('rect')
+        .data(binLabels)
+        .enter()
+        .append('rect')
+        .attr('height', 15)
+        .attr('width', swatchWidth)
+        .attr('x', (d, i) => (swatchWidth * i) + yAxisPadding)
+        .attr('y', 25)
+        .attr('fill', (d) => nodeGlyphColorScale.value(d))
+        .classed('swatch', true);
+    }
+  } else if (props.mappedTo === 'glyphs') { // node color and edge color
+    // Swatches
+    const binLabels = [...new Set(network.value.nodes.map((d: Node | Edge) => d[props.varName]))];
+
+    xScale = scaleBand()
+      .domain(binLabels)
+      .range([yAxisPadding, variableSvgWidth]);
+
+    // Draw swatches
+    const swatchWidth = (variableSvgWidth - yAxisPadding) / binLabels.length;
+
+    variableSvg
+      .selectAll('rect')
+      .data(binLabels)
+      .enter()
+      .append('rect')
+      .attr('height', 15)
+      .attr('width', swatchWidth)
+      .attr('x', (d, i) => (swatchWidth * i) + yAxisPadding)
+      .attr('y', 25)
+      .attr('fill', (d) => nodeGlyphColorScale.value(d))
+      .classed('swatch', true);
+  } else if (props.mappedTo === 'bars') { // nested bars
+    watchEffect(() => {
+      selectAll('.legend-bars').remove();
+
+      // Draw bars
+      nestedVariables.value.bar.forEach((barVar, index) => {
+        // Bar backgrounds
+        variableSvg
+          .append('rect')
+          .attr('fill', '#EEEEEE')
+          .attr('height', 50)
+          .attr('width', 20)
+          .attr('x', 50 * (index) + 25)
+          .attr('y', 10)
+          .classed('legend-bars', true);
+
+        // Main bar
+        const barHeight = 10 + (Math.random() * 40);
+        variableSvg
+          .append('rect')
+          .attr('fill', nodeBarColorScale.value(barVar))
+          .attr('height', barHeight)
+          .attr('width', 20)
+          .attr('x', 50 * (index) + 25)
+          .attr('y', 60 - barHeight)
+          .classed('legend-bars', true);
+
+        // Label
+        variableSvg
+          .append('foreignObject')
+          .attr('height', 20)
+          .attr('width', 30)
+          .attr('x', 50 * (index) + 15)
+          .attr('y', 60)
+          .classed('legend-bars', true)
+          .append('xhtml:p')
+          .attr('title', barVar)
+          .text(barVar);
+
+        // Axis
+        const barScale = scaleLinear()
+          .domain([attributeRanges.value[barVar].min, attributeRanges.value[barVar].max])
+          .range([59, 10]);
+
+        variableSvg
+          .append('g')
+          .classed('legend-bars', true)
+          .attr('transform', `translate(${50 * (index) + 23},0)`)
+          .call(axisLeft(barScale).ticks(4, 's'))
+          .call((g) => g.select('path').remove());
+      });
+    });
+  } else if (isQuantitative(props.varName, props.type)) { // main numeric legend charts
+    let currentData: number[] = [];
+    if (props.type === 'node') {
+      currentData = network.value.nodes.map((d: Node | Edge) => parseFloat(d[props.varName]));
+    } else {
+      currentData = network.value.edges.map((d: Node | Edge) => parseFloat(d[props.varName]));
     }
 
-    onMounted(() => {
-      const variableSvg = select(`#${props.type}${props.varName}${props.mappedTo}`);
+    xScale = scaleLinear()
+      .domain([Math.min(...currentData), Math.max(...currentData) + 1])
+      .range([yAxisPadding, variableSvgWidth]);
 
-      let variableSvgWidth = (variableSvg
-        .node() as Element)
-        .getBoundingClientRect()
-        .width - yAxisPadding;
+    const binGenerator = histogram()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .domain((xScale as any).domain()) // then the domain of the graphic
+      .thresholds(xScale.ticks(15)); // then the numbers of bins
 
-      variableSvgWidth = variableSvgWidth < 0 ? 256 : variableSvgWidth;
+    const bins = binGenerator(currentData);
 
-      let xScale: ScaleLinear<number, number> | ScaleBand<string>;
-      let yScale: ScaleLinear<number, number>;
-
-      if (network.value === null) {
-        return;
-      }
-
-      // Process data for bars/histogram
-      if (props.mappedTo === 'size' && nodeSizeScale.value !== null) { // node size
-        xScale = scaleLinear()
-          .domain(nodeSizeScale.value.domain())
-          .range([yAxisPadding, variableSvgWidth]);
-
-        // Draw circles
-        variableSvg
-          .append('circle')
-          .attr('cx', yAxisPadding)
-          .attr('cy', yAxisPadding + 15)
-          .attr('r', 5)
-          .attr('fill', '#3977AF');
-
-        variableSvg
-          .append('circle')
-          .attr('cx', (variableSvgWidth + yAxisPadding) / 2)
-          .attr('cy', yAxisPadding + 10)
-          .attr('r', 10)
-          .attr('fill', '#3977AF');
-
-        variableSvg
-          .append('circle')
-          .attr('cx', variableSvgWidth)
-          .attr('cy', yAxisPadding)
-          .attr('r', 20)
-          .attr('fill', '#3977AF');
-      } else if (props.mappedTo === 'width') { // edge width
-        yScale = scaleLinear()
-          .domain(edgeWidthScale.value.domain())
-          .range([svgHeight, 10]);
-
-        const minValue = edgeWidthScale.value.range()[0];
-        const maxValue = edgeWidthScale.value.range()[1];
-        const middleValue = (edgeWidthScale.value.range()[1] + edgeWidthScale.value.range()[0]) / 2;
-
-        // Draw width lines
-        variableSvg
-          .append('rect')
-          .attr('height', maxValue)
-          .attr('width', variableSvgWidth)
-          .attr('x', yAxisPadding)
-          .attr('y', 0)
-          .attr('fill', '#888888');
-
-        variableSvg
-          .append('rect')
-          .attr('height', middleValue)
-          .attr('width', variableSvgWidth)
-          .attr('x', yAxisPadding)
-          .attr('y', svgHeight / 2)
-          .attr('fill', '#888888');
-
-        variableSvg
-          .append('rect')
-          .attr('height', minValue + 2)
-          .attr('width', variableSvgWidth)
-          .attr('x', yAxisPadding)
-          .attr('y', svgHeight - 1)
-          .attr('fill', '#888888');
-      } else if (props.mappedTo === 'color') { // node color and edge color
-        if (isQuantitative(props.varName, props.type)) {
-          // Gradient
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          let scale: any;
-
-          if (props.type === 'node') {
-            xScale = scaleLinear()
-              .domain(nodeColorScale.value.domain() as number[])
-              .range([yAxisPadding, variableSvgWidth]);
-
-            scale = nodeColorScale.value;
-          } else {
-            xScale = scaleLinear()
-              .domain(edgeColorScale.value.domain() as number[])
-              .range([yAxisPadding, variableSvgWidth]);
-
-            scale = edgeColorScale.value;
-          }
-
-          const minColor = scale(scale.domain()[0]);
-          const midColor = scale((scale.domain()[0] + scale.domain()[1]) / 2);
-          const maxColor = scale(scale.domain()[1]);
-
-          const gradient = variableSvg
-            .append('defs')
-            .append('linearGradient')
-            .attr('id', 'grad');
-
-          gradient
-            .append('stop')
-            .attr('offset', '0%')
-            .attr('stop-color', minColor);
-
-          gradient
-            .append('stop')
-            .attr('offset', '50%')
-            .attr('stop-color', midColor);
-
-          gradient
-            .append('stop')
-            .attr('offset', '100%')
-            .attr('stop-color', maxColor);
-
-          variableSvg
-            .append('rect')
-            .attr('height', 20)
-            .attr('width', (xScale.range()[1] || 0) - (xScale.range()[0] || 0))
-            .attr('x', xScale.range()[0] || 0)
-            .attr('y', 20)
-            .attr('fill', 'url(#grad)')
-            .style('opacity', 0.7);
-        } else {
-          const currentData = props.type === 'node' ? network.value.nodes : network.value.edges;
-
-          // Swatches
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const binLabels: string[] = [...new Set<string>((currentData as any).map((d: Node | Edge) => d[props.varName]))];
-
-          xScale = scaleBand()
-            .domain(binLabels)
-            .range([yAxisPadding, variableSvgWidth]);
-
-          // Draw swatches
-          const swatchWidth = (variableSvgWidth - yAxisPadding) / binLabels.length;
-
-          variableSvg
-            .selectAll('rect')
-            .data(binLabels)
-            .enter()
-            .append('rect')
-            .attr('height', 15)
-            .attr('width', swatchWidth)
-            .attr('x', (d, i) => (swatchWidth * i) + yAxisPadding)
-            .attr('y', 25)
-            .attr('fill', (d) => nodeGlyphColorScale.value(d))
-            .classed('swatch', true);
-        }
-      } else if (props.mappedTo === 'glyphs') { // node color and edge color
-        // Swatches
-        const binLabels = [...new Set(network.value.nodes.map((d: Node | Edge) => d[props.varName]))];
-
-        xScale = scaleBand()
-          .domain(binLabels)
-          .range([yAxisPadding, variableSvgWidth]);
-
-        // Draw swatches
-        const swatchWidth = (variableSvgWidth - yAxisPadding) / binLabels.length;
-
-        variableSvg
-          .selectAll('rect')
-          .data(binLabels)
-          .enter()
-          .append('rect')
-          .attr('height', 15)
-          .attr('width', swatchWidth)
-          .attr('x', (d, i) => (swatchWidth * i) + yAxisPadding)
-          .attr('y', 25)
-          .attr('fill', (d) => nodeGlyphColorScale.value(d))
-          .classed('swatch', true);
-      } else if (props.mappedTo === 'bars') { // nested bars
-        watchEffect(() => {
-          selectAll('.legend-bars').remove();
-
-          // Draw bars
-          nestedVariables.value.bar.forEach((barVar, index) => {
-            // Bar backgrounds
-            variableSvg
-              .append('rect')
-              .attr('fill', '#EEEEEE')
-              .attr('height', 50)
-              .attr('width', 20)
-              .attr('x', 50 * (index) + 25)
-              .attr('y', 10)
-              .classed('legend-bars', true);
-
-            // Main bar
-            const barHeight = 10 + (Math.random() * 40);
-            variableSvg
-              .append('rect')
-              .attr('fill', nodeBarColorScale.value(barVar))
-              .attr('height', barHeight)
-              .attr('width', 20)
-              .attr('x', 50 * (index) + 25)
-              .attr('y', 60 - barHeight)
-              .classed('legend-bars', true);
-
-            // Label
-            variableSvg
-              .append('foreignObject')
-              .attr('height', 20)
-              .attr('width', 30)
-              .attr('x', 50 * (index) + 15)
-              .attr('y', 60)
-              .classed('legend-bars', true)
-              .append('xhtml:p')
-              .attr('title', barVar)
-              .text(barVar);
-
-            // Axis
-            const barScale = scaleLinear()
-              .domain([attributeRanges.value[barVar].min, attributeRanges.value[barVar].max])
-              .range([59, 10]);
-
-            variableSvg
-              .append('g')
-              .classed('legend-bars', true)
-              .attr('transform', `translate(${50 * (index) + 23},0)`)
-              .call(axisLeft(barScale).ticks(4, 's'))
-              .call((g) => g.select('path').remove());
-          });
-        });
-      } else if (isQuantitative(props.varName, props.type)) { // main numeric legend charts
-        let currentData: number[] = [];
-        if (props.type === 'node') {
-          currentData = network.value.nodes.map((d: Node | Edge) => parseFloat(d[props.varName]));
-        } else {
-          currentData = network.value.edges.map((d: Node | Edge) => parseFloat(d[props.varName]));
-        }
-
-        xScale = scaleLinear()
-          .domain([Math.min(...currentData), Math.max(...currentData) + 1])
-          .range([yAxisPadding, variableSvgWidth]);
-
-        const binGenerator = histogram()
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .domain((xScale as any).domain()) // then the domain of the graphic
-          .thresholds(xScale.ticks(15)); // then the numbers of bins
-
-        const bins = binGenerator(currentData);
-
-        store.commit.addAttributeRange({
-          attr: props.varName,
-          min: xScale.domain()[0] || 0,
-          max: xScale.domain()[1] || 0,
-          binLabels: xScale.domain().map((label) => label.toString()),
-          binValues: xScale.range(),
-        });
-
-        yScale = scaleLinear()
-          .domain([0, max(bins, (d) => d.length) || 0])
-          .range([svgHeight, 10]);
-
-        variableSvg
-          .selectAll('rect')
-          .data(bins)
-          .enter()
-          .append('rect')
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .attr('x', (d) => xScale(d.x0 as any) || 0)
-          .attr('y', (d) => yScale(d.length))
-          .attr('height', (d) => svgHeight - yScale(d.length))
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .attr('width', (d) => (xScale(d.x1 as any) || 0) - (xScale(d.x0 as any) || 0))
-          .attr('fill', '#82B1FF');
-      } else { // main categorical legend charts
-        let currentData: string[] = [];
-        if (props.type === 'node') {
-          currentData = network.value.nodes.map((d: Node | Edge) => d[props.varName]).sort();
-        } else {
-          currentData = network.value.edges.map((d: Node | Edge) => d[props.varName]).sort();
-        }
-
-        const bins = new Map([...new Set(currentData)].map(
-          (x) => [x, currentData.filter((y) => y === x).length],
-        ));
-
-        const binLabels: string[] = Array.from(bins.keys());
-        const binValues: number[] = Array.from(bins.values());
-
-        store.commit.addAttributeRange({
-          attr: props.varName,
-          min: parseFloat(min(binLabels) || '0'),
-          max: parseFloat(max(binLabels) || '0'),
-          binLabels,
-          binValues,
-        });
-
-        // Generate axis scales
-        yScale = scaleLinear()
-          .domain([min(binValues) || 0, max(binValues) || 0])
-          .range([svgHeight, 0]);
-
-        xScale = scaleBand()
-          .domain(binLabels)
-          .range([yAxisPadding, variableSvgWidth]);
-
-        variableSvg
-          .selectAll('rect')
-          .data(currentData)
-          .enter()
-          .append('rect')
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .attr('x', (d: string) => xScale(d as any) || 0)
-          .attr('y', (d: string) => yScale(bins.get(d) || 0))
-          .attr('height', (d: string) => svgHeight - yScale(bins.get(d) || 0))
-          .attr('width', xScale.bandwidth())
-          .attr('fill', (d: string) => nodeGlyphColorScale.value(d));
-      }
-
-      // Add the axis scales onto the chart
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      if (xScale! !== undefined) {
-        variableSvg
-          .append('g')
-          .attr('transform', `translate(0, ${svgHeight})`)
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .call((axisBottom as any)(xScale).ticks(4, 's'))
-          .call((g) => g.select('path').remove());
-      }
-
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      if (yScale! !== undefined) {
-        variableSvg
-          .append('g')
-          .attr('transform', `translate(${yAxisPadding},0)`)
-          .call(axisLeft(yScale).ticks(3, 's'))
-          .call((g) => g.select('path').remove());
-      }
-
-      // For the brushable charts for filtering add brushing
-      if (props.brushable) {
-        const brush = brushX()
-          .extent([[yAxisPadding, 0], [variableSvgWidth, svgHeight]])
-          .on('end', (event: unknown) => {
-            const brushEvent = event as D3BrushEvent<unknown>;
-            const extent = brushEvent.selection as [number, number];
-
-            if (extent === null) {
-              return;
-            }
-
-            const currentAttributeRange = attributeRanges.value[props.varName];
-
-            if (
-              (props.filter === 'glyphs' && props.type === 'node')
-              || (props.filter === 'color' && !isQuantitative(props.varName, props.type))
-            ) {
-              const firstIndex = Math.floor(((extent[0] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * attributeRanges.value[props.varName].binLabels.length);
-              const secondIndex = Math.ceil(((extent[1] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * attributeRanges.value[props.varName].binLabels.length);
-
-              store.commit.addAttributeRange({
-                ...currentAttributeRange,
-                currentBinLabels: currentAttributeRange.binLabels.slice(firstIndex, secondIndex),
-                currentBinValues: currentAttributeRange.binValues.slice(firstIndex, secondIndex),
-              });
-            } else if (
-              (props.filter === 'size' && props.type === 'node')
-              || (props.filter === 'color' && isQuantitative(props.varName, props.type))
-              || (props.filter === 'width' && props.type === 'edge')
-            ) {
-              const newMin = (((extent[0] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
-              const newMax = (((extent[1] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
-
-              store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
-            }
-          });
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (variableSvg as any)
-          .call(brush)
-          // start with the whole network brushed
-          .call(brush.move, [yAxisPadding, variableSvgWidth]);
-      }
+    store.commit.addAttributeRange({
+      attr: props.varName,
+      min: xScale.domain()[0] || 0,
+      max: xScale.domain()[1] || 0,
+      binLabels: xScale.domain().map((label) => label.toString()),
+      binValues: xScale.range(),
     });
 
-    return {
-      svgHeight,
-      dragStart,
-      unAssignVar,
-      nestedVariables,
-    };
-  },
+    yScale = scaleLinear()
+      .domain([0, max(bins, (d) => d.length) || 0])
+      .range([svgHeight, 10]);
+
+    variableSvg
+      .selectAll('rect')
+      .data(bins)
+      .enter()
+      .append('rect')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .attr('x', (d) => xScale(d.x0 as any) || 0)
+      .attr('y', (d) => yScale(d.length))
+      .attr('height', (d) => svgHeight - yScale(d.length))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .attr('width', (d) => (xScale(d.x1 as any) || 0) - (xScale(d.x0 as any) || 0))
+      .attr('fill', '#82B1FF');
+  } else { // main categorical legend charts
+    let currentData: string[] = [];
+    if (props.type === 'node') {
+      currentData = network.value.nodes.map((d: Node | Edge) => d[props.varName]).sort();
+    } else {
+      currentData = network.value.edges.map((d: Node | Edge) => d[props.varName]).sort();
+    }
+
+    const bins = new Map([...new Set(currentData)].map(
+      (x) => [x, currentData.filter((y) => y === x).length],
+    ));
+
+    const binLabels: string[] = Array.from(bins.keys());
+    const binValues: number[] = Array.from(bins.values());
+
+    store.commit.addAttributeRange({
+      attr: props.varName,
+      min: parseFloat(min(binLabels) || '0'),
+      max: parseFloat(max(binLabels) || '0'),
+      binLabels,
+      binValues,
+    });
+
+    // Generate axis scales
+    yScale = scaleLinear()
+      .domain([min(binValues) || 0, max(binValues) || 0])
+      .range([svgHeight, 0]);
+
+    xScale = scaleBand()
+      .domain(binLabels)
+      .range([yAxisPadding, variableSvgWidth]);
+
+    variableSvg
+      .selectAll('rect')
+      .data(currentData)
+      .enter()
+      .append('rect')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .attr('x', (d: string) => xScale(d as any) || 0)
+      .attr('y', (d: string) => yScale(bins.get(d) || 0))
+      .attr('height', (d: string) => svgHeight - yScale(bins.get(d) || 0))
+      .attr('width', xScale.bandwidth())
+      .attr('fill', (d: string) => nodeGlyphColorScale.value(d));
+  }
+
+  // Add the axis scales onto the chart
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  if (xScale! !== undefined) {
+    variableSvg
+      .append('g')
+      .attr('transform', `translate(0, ${svgHeight})`)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .call((axisBottom as any)(xScale).ticks(4, 's'))
+      .call((g) => g.select('path').remove());
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  if (yScale! !== undefined) {
+    variableSvg
+      .append('g')
+      .attr('transform', `translate(${yAxisPadding},0)`)
+      .call(axisLeft(yScale).ticks(3, 's'))
+      .call((g) => g.select('path').remove());
+  }
+
+  // For the brushable charts for filtering add brushing
+  if (props.brushable) {
+    const brush = brushX()
+      .extent([[yAxisPadding, 0], [variableSvgWidth, svgHeight]])
+      .on('end', (event: unknown) => {
+        const brushEvent = event as D3BrushEvent<unknown>;
+        const extent = brushEvent.selection as [number, number];
+
+        if (extent === null) {
+          return;
+        }
+
+        const currentAttributeRange = attributeRanges.value[props.varName];
+
+        if (
+          (props.filter === 'glyphs' && props.type === 'node')
+              || (props.filter === 'color' && !isQuantitative(props.varName, props.type))
+        ) {
+          const firstIndex = Math.floor(((extent[0] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * attributeRanges.value[props.varName].binLabels.length);
+          const secondIndex = Math.ceil(((extent[1] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * attributeRanges.value[props.varName].binLabels.length);
+
+          store.commit.addAttributeRange({
+            ...currentAttributeRange,
+            currentBinLabels: currentAttributeRange.binLabels.slice(firstIndex, secondIndex),
+            currentBinValues: currentAttributeRange.binValues.slice(firstIndex, secondIndex),
+          });
+        } else if (
+          (props.filter === 'size' && props.type === 'node')
+              || (props.filter === 'color' && isQuantitative(props.varName, props.type))
+              || (props.filter === 'width' && props.type === 'edge')
+        ) {
+          const newMin = (((extent[0] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
+          const newMax = (((extent[1] - yAxisPadding) / (variableSvgWidth - yAxisPadding)) * (currentAttributeRange.max - currentAttributeRange.min)) + currentAttributeRange.min;
+
+          store.commit.addAttributeRange({ ...currentAttributeRange, currentMax: newMax, currentMin: newMin });
+        }
+      });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (variableSvg as any)
+      .call(brush)
+    // start with the whole network brushed
+      .call(brush.move, [yAxisPadding, variableSvgWidth]);
+  }
 });
 </script>
 

--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -3,7 +3,7 @@ import store from '@/store';
 import { Node, Edge } from '@/types';
 import {
   computed, defineComponent, onMounted, PropType, watchEffect,
-} from '@vue/composition-api';
+} from 'vue';
 import { histogram, max, min } from 'd3-array';
 import { axisBottom, axisLeft } from 'd3-axis';
 import { brushX, D3BrushEvent } from 'd3-brush';

--- a/src/components/LegendPanel.vue
+++ b/src/components/LegendPanel.vue
@@ -3,7 +3,7 @@ import store from '@/store';
 import { internalFieldNames, Edge, Node } from '@/types';
 import DragTarget from '@/components/DragTarget.vue';
 import LegendChart from '@/components/LegendChart.vue';
-import { computed, defineComponent, ref } from '@vue/composition-api';
+import { computed, defineComponent, ref } from 'vue';
 
 export default defineComponent({
   components: {

--- a/src/components/LegendPanel.vue
+++ b/src/components/LegendPanel.vue
@@ -1,97 +1,75 @@
-<script lang="ts">
+<script setup lang="ts">
 import store from '@/store';
 import { internalFieldNames, Edge, Node } from '@/types';
 import DragTarget from '@/components/DragTarget.vue';
 import LegendChart from '@/components/LegendChart.vue';
-import { computed, defineComponent, ref } from 'vue';
+import { computed, ref } from 'vue';
 
-export default defineComponent({
-  components: {
-    DragTarget,
-    LegendChart,
-  },
+const tab = ref(undefined);
 
-  setup() {
-    const tab = ref(undefined);
+const network = computed(() => store.state.network);
+const nestedVariables = computed(() => store.state.nestedVariables);
+const edgeVariables = computed(() => store.state.edgeVariables);
+const nodeSizeVariable = computed(() => store.state.nodeSizeVariable);
+const nodeColorVariable = computed(() => store.state.nodeColorVariable);
+const columnTypes = computed(() => store.state.columnTypes);
 
-    const network = computed(() => store.state.network);
-    const nestedVariables = computed(() => store.state.nestedVariables);
-    const edgeVariables = computed(() => store.state.edgeVariables);
-    const nodeSizeVariable = computed(() => store.state.nodeSizeVariable);
-    const nodeColorVariable = computed(() => store.state.nodeColorVariable);
-    const columnTypes = computed(() => store.state.columnTypes);
+function cleanVariableList(list: Set<string>): Set<string> {
+  const cleanedVariables = new Set<string>();
 
-    function cleanVariableList(list: Set<string>): Set<string> {
-      const cleanedVariables = new Set<string>();
-
-      list.forEach((variable) => {
-        if (columnTypes.value !== null && columnTypes.value[variable] !== 'label') {
-          cleanedVariables.add(variable);
-        }
-      });
-
-      return cleanedVariables;
+  list.forEach((variable) => {
+    if (columnTypes.value !== null && columnTypes.value[variable] !== 'label') {
+      cleanedVariables.add(variable);
     }
+  });
 
-    const cleanedNodeVariables = computed(() => {
-      if (network.value !== null) {
-        // Loop through all nodes, flatten the 2d array, and turn it into a set
-        const allVars: Set<string> = new Set();
-        network.value.nodes.forEach((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
+  return cleanedVariables;
+}
 
-        internalFieldNames.forEach((field) => allVars.delete(field));
-        allVars.delete('vx');
-        allVars.delete('vy');
-        allVars.delete('x');
-        allVars.delete('y');
-        allVars.delete('index');
-        return cleanVariableList(allVars);
-      }
-      return new Set();
-    });
+const cleanedNodeVariables = computed(() => {
+  if (network.value !== null) {
+    // Loop through all nodes, flatten the 2d array, and turn it into a set
+    const allVars: Set<string> = new Set();
+    network.value.nodes.forEach((node: Node) => Object.keys(node).forEach((key) => allVars.add(key)));
 
-    const cleanedEdgeVariables = computed(() => {
-      if (network.value !== null) {
-        // Loop through all edges, flatten the 2d array, and turn it into a set
-        const allVars: Set<string> = new Set();
-        network.value.edges.map((edge: Edge) => Object.keys(edge).forEach((key) => allVars.add(key)));
+    internalFieldNames.forEach((field) => allVars.delete(field));
+    allVars.delete('vx');
+    allVars.delete('vy');
+    allVars.delete('x');
+    allVars.delete('y');
+    allVars.delete('index');
+    return cleanVariableList(allVars);
+  }
+  return new Set();
+});
 
-        internalFieldNames.forEach((field) => allVars.delete(field));
-        allVars.delete('source');
-        allVars.delete('target');
-        allVars.delete('index');
+const cleanedEdgeVariables = computed(() => {
+  if (network.value !== null) {
+    // Loop through all edges, flatten the 2d array, and turn it into a set
+    const allVars: Set<string> = new Set();
+    network.value.edges.map((edge: Edge) => Object.keys(edge).forEach((key) => allVars.add(key)));
 
-        return cleanVariableList(allVars);
-      }
-      return new Set();
-    });
+    internalFieldNames.forEach((field) => allVars.delete(field));
+    allVars.delete('source');
+    allVars.delete('target');
+    allVars.delete('index');
 
-    const displayCharts = computed({
-      get() {
-        return store.state.displayCharts;
-      },
-      set(value: boolean) {
-        return store.commit.setDisplayCharts(value);
-      },
-    });
+    return cleanVariableList(allVars);
+  }
+  return new Set();
+});
 
-    const attributeLayout = ref(false);
-    const layoutVars = computed(() => store.state.layoutVars);
-
-    return {
-      tab,
-      nestedVariables,
-      edgeVariables,
-      nodeSizeVariable,
-      nodeColorVariable,
-      displayCharts,
-      cleanedNodeVariables,
-      cleanedEdgeVariables,
-      attributeLayout,
-      layoutVars,
-    };
+const displayCharts = computed({
+  get() {
+    return store.state.displayCharts;
+  },
+  set(value: boolean) {
+    return store.commit.setDisplayCharts(value);
   },
 });
+
+const attributeLayout = ref(false);
+const layoutVars = computed(() => store.state.layoutVars);
 </script>
 
 <template>

--- a/src/components/LoginMenu.vue
+++ b/src/components/LoginMenu.vue
@@ -60,54 +60,39 @@
   </v-menu>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import store from '@/store';
 import oauthClient from '@/oauth';
-import {
-  computed, defineComponent, ref, watchEffect,
-} from 'vue';
+import { computed, ref, watchEffect } from 'vue';
 
-export default defineComponent({
-  setup() {
-    const menu = ref(false);
-    const location = ref('');
+const menu = ref(false);
+const location = ref('');
 
-    const userInfo = computed(() => store.state.userInfo);
-    const userInitials = computed(() => (userInfo.value !== null ? `${userInfo.value.first_name[0] || ''}${userInfo.value.last_name[0] || ''}` : ''));
+const userInfo = computed(() => store.state.userInfo);
+const userInitials = computed(() => (userInfo.value !== null ? `${userInfo.value.first_name[0] || ''}${userInfo.value.last_name[0] || ''}` : ''));
 
-    watchEffect(() => {
-      if (menu.value) {
-        location.value = window.location.href;
-      }
-    });
-
-    async function logout() {
-      // Perform the logout action,
-      await store.dispatch.logout();
-
-      // Redirect the user to the home page.
-      // This is to prevent the logged-out user from continuing to look at, e.g.,
-      // workspaces or tables they may have been viewing at the time of logout.
-      window.location.href = 'https://multinet.app';
-    }
-
-    function login(): void {
-      oauthClient.redirectToLogin();
-    }
-
-    // Get user info on created
-    store.dispatch.fetchUserInfo();
-
-    return {
-      menu,
-      location,
-      login,
-      userInitials,
-      logout,
-      userInfo,
-    };
-  },
+watchEffect(() => {
+  if (menu.value) {
+    location.value = window.location.href;
+  }
 });
+
+async function logout() {
+  // Perform the logout action,
+  await store.dispatch.logout();
+
+  // Redirect the user to the home page.
+  // This is to prevent the logged-out user from continuing to look at, e.g.,
+  // workspaces or tables they may have been viewing at the time of logout.
+  window.location.href = 'https://multinet.app';
+}
+
+function login(): void {
+  oauthClient.redirectToLogin();
+}
+
+// Get user info on created
+store.dispatch.fetchUserInfo();
 </script>
 
 <style scoped>

--- a/src/components/LoginMenu.vue
+++ b/src/components/LoginMenu.vue
@@ -65,7 +65,7 @@ import store from '@/store';
 import oauthClient from '@/oauth';
 import {
   computed, defineComponent, ref, watchEffect,
-} from '@vue/composition-api';
+} from 'vue';
 
 export default defineComponent({
   setup() {

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -17,7 +17,7 @@ import ContextMenu from '@/components/ContextMenu.vue';
 import { applyForceToSimulation } from '@/lib/d3ForceUtils';
 import {
   computed, defineComponent, getCurrentInstance, onMounted, ref, Ref, watch,
-} from '@vue/composition-api';
+} from 'vue';
 import { axisBottom, axisLeft } from 'd3-axis';
 import { isInternalField } from '@/lib/typeUtils';
 import { ColumnType } from 'multinet';

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script setup lang="ts">
 import {
   scaleBand,
   scaleLinear, ScaleLinear,
@@ -16,332 +16,326 @@ import {
 import ContextMenu from '@/components/ContextMenu.vue';
 import { applyForceToSimulation } from '@/lib/d3ForceUtils';
 import {
-  computed, defineComponent, getCurrentInstance, onMounted, ref, Ref, watch,
+  computed, getCurrentInstance, onMounted, ref, Ref, watch,
 } from 'vue';
 import { axisBottom, axisLeft } from 'd3-axis';
 import { isInternalField } from '@/lib/typeUtils';
 import { ColumnType } from 'multinet';
 
-export default defineComponent({
-  components: {
-    ContextMenu,
-  },
+// Commonly used variables
+const currentInstance = getCurrentInstance();
+const network = computed(() => store.state.network);
+const svg: Ref<Element | null> = ref(null);
+const selectedNodes = computed(() => store.state.selectedNodes);
+const nodeBarColorScale = computed(() => store.state.nodeBarColorScale);
+const nodeTextStyle = computed(() => `font-size: ${store.state.fontSize || 0}pt;`);
+const nestedVariables = computed(() => store.state.nestedVariables);
+const markerSize = computed(() => store.state.markerSize || 0);
+const nestedPadding = ref(5);
+const nestedBarWidth = computed(() => {
+  const hasGlyphs = nestedVariables.value.glyph.length !== 0;
+  const totalColumns = nestedVariables.value.bar.length + (hasGlyphs ? 1 : 0);
 
-  setup() {
-    // Commonly used variables
-    const currentInstance = getCurrentInstance();
-    const network = computed(() => store.state.network);
-    const svg: Ref<Element | null> = ref(null);
-    const selectedNodes = computed(() => store.state.selectedNodes);
-    const nodeBarColorScale = computed(() => store.state.nodeBarColorScale);
-    const nodeTextStyle = computed(() => `font-size: ${store.state.fontSize || 0}pt;`);
-    const nestedVariables = computed(() => store.state.nestedVariables);
-    const markerSize = computed(() => store.state.markerSize || 0);
-    const nestedPadding = ref(5);
-    const nestedBarWidth = computed(() => {
-      const hasGlyphs = nestedVariables.value.glyph.length !== 0;
-      const totalColumns = nestedVariables.value.bar.length + (hasGlyphs ? 1 : 0);
+  // Left padding + padding on right for each column
+  const totalPadding = nestedPadding.value + totalColumns * nestedPadding.value;
 
-      // Left padding + padding on right for each column
-      const totalPadding = nestedPadding.value + totalColumns * nestedPadding.value;
+  return (markerSize.value - totalPadding) / (totalColumns);
+});
+const nestedBarHeight = computed(() => markerSize.value - 24);
+const displayCharts = computed(() => store.state.displayCharts);
+const labelVariable = computed(() => store.state.labelVariable);
+const selectNeighbors = computed(() => store.state.selectNeighbors);
+const attributeRanges = computed(() => store.state.attributeRanges);
+const columnTypes = computed(() => store.state.columnTypes);
+const attributeScales = computed(() => {
+  const scales: {[key: string]: ScaleLinear<number, number>} = {};
 
-      return (markerSize.value - totalPadding) / (totalColumns);
+  if (Object.values(attributeRanges.value) !== undefined) {
+    Object.values(attributeRanges.value).forEach((attr) => {
+      scales[attr.attr] = scaleLinear()
+        .domain([attr.min, attr.max])
+        .range([0, nestedBarHeight.value]);
     });
-    const nestedBarHeight = computed(() => markerSize.value - 24);
-    const displayCharts = computed(() => store.state.displayCharts);
-    const labelVariable = computed(() => store.state.labelVariable);
-    const selectNeighbors = computed(() => store.state.selectNeighbors);
-    const attributeRanges = computed(() => store.state.attributeRanges);
-    const columnTypes = computed(() => store.state.columnTypes);
-    const attributeScales = computed(() => {
-      const scales: {[key: string]: ScaleLinear<number, number>} = {};
+  }
+  return scales;
+});
+const controlsWidth = computed(() => store.state.controlsWidth);
+const directionalEdges = computed(() => store.state.directionalEdges);
+const edgeColorScale = computed(() => store.getters.edgeColorScale);
+const clipRegionSize = 100;
+const layoutVars = computed(() => store.state.layoutVars);
 
-      if (Object.values(attributeRanges.value) !== undefined) {
-        Object.values(attributeRanges.value).forEach((attr) => {
-          scales[attr.attr] = scaleLinear()
-            .domain([attr.min, attr.max])
-            .range([0, nestedBarHeight.value]);
-        });
-      }
-      return scales;
-    });
-    const controlsWidth = computed(() => store.state.controlsWidth);
-    const directionalEdges = computed(() => store.state.directionalEdges);
-    const edgeColorScale = computed(() => store.getters.edgeColorScale);
-    const clipRegionSize = 100;
-    const layoutVars = computed(() => store.state.layoutVars);
+// Update height and width as the window size changes
+// Also update center attraction forces as the size changes
+const svgDimensions = computed(() => {
+  const height = currentInstance !== null ? currentInstance.proxy.$vuetify.breakpoint.height : 0;
+  const width = currentInstance !== null ? currentInstance.proxy.$vuetify.breakpoint.width - controlsWidth.value : 0;
 
-    // Update height and width as the window size changes
-    // Also update center attraction forces as the size changes
-    const svgDimensions = computed(() => {
-      const height = currentInstance !== null ? currentInstance.proxy.$vuetify.breakpoint.height : 0;
-      const width = currentInstance !== null ? currentInstance.proxy.$vuetify.breakpoint.width - controlsWidth.value : 0;
+  applyForceToSimulation(
+    store.state.simulation,
+    'x',
+    forceX<Node>(width / 2),
+  );
+  applyForceToSimulation(
+    store.state.simulation,
+    'y',
+    forceY<Node>(height / 2),
+  );
 
-      applyForceToSimulation(
-        store.state.simulation,
-        'x',
-        forceX<Node>(width / 2),
-      );
-      applyForceToSimulation(
-        store.state.simulation,
-        'y',
-        forceY<Node>(height / 2),
-      );
+  const dimensions = {
+    height,
+    width,
+  };
+  store.commit.setSvgDimensions(dimensions);
 
-      const dimensions = {
-        height,
-        width,
-      };
-      store.commit.setSvgDimensions(dimensions);
+  return dimensions;
+});
+watch([svgDimensions], () => {
+  // If we're in a static layout, then redraw the layout
+  const xLayout = store.state.layoutVars.x !== null;
+  const yLayout = store.state.layoutVars.y !== null;
+  if (xLayout) {
+    store.dispatch.applyVariableLayout({ varName: store.state.layoutVars.x || '', axis: 'x' });
+  }
 
-      return dimensions;
-    });
-    watch([svgDimensions], () => {
-      // If we're in a static layout, then redraw the layout
-      const xLayout = store.state.layoutVars.x !== null;
-      const yLayout = store.state.layoutVars.y !== null;
-      if (xLayout) {
-        store.dispatch.applyVariableLayout({ varName: store.state.layoutVars.x || '', axis: 'x' });
-      }
+  if (yLayout) {
+    store.dispatch.applyVariableLayout({ varName: store.state.layoutVars.y || '', axis: 'y' });
+  }
 
-      if (yLayout) {
-        store.dispatch.applyVariableLayout({ varName: store.state.layoutVars.y || '', axis: 'y' });
-      }
+  if (!xLayout && !yLayout) {
+    store.commit.startSimulation();
+  }
+});
 
-      if (!xLayout && !yLayout) {
-        store.commit.startSimulation();
-      }
-    });
+function selectNode(node: Node) {
+  if (selectedNodes.value.has(node._id)) {
+    store.commit.removeSelectedNode(node._id);
+  } else {
+    store.commit.addSelectedNode([node._id]);
+  }
+}
 
-    function selectNode(node: Node) {
-      if (selectedNodes.value.has(node._id)) {
-        store.commit.removeSelectedNode(node._id);
-      } else {
-        store.commit.addSelectedNode([node._id]);
-      }
+const nodeSizeVariable = computed(() => store.state.nodeSizeVariable);
+const nodeSizeScale = computed(() => store.getters.nodeSizeScale);
+function calculateNodeSize(node: Node) {
+  // Don't render dynamic node size if the size variable is empty or
+  // we want to display charts
+  if (nodeSizeVariable.value === '' || displayCharts.value || nodeSizeScale.value === null) {
+    return markerSize.value;
+  }
+
+  const calculatedValue = nodeSizeScale.value(node[nodeSizeVariable.value]);
+
+  return calculatedValue > 40 || calculatedValue < 10 ? 0 : calculatedValue;
+}
+
+function dragNode(node: Node, event: MouseEvent) {
+  // Only drag on left clicks
+  if (event.button !== 0) {
+    return;
+  }
+
+  if (!(svg.value instanceof Element)) {
+    throw new Error('SVG is not of type Element');
+  }
+
+  event.stopPropagation();
+
+  const initialX = event.x - controlsWidth.value - (calculateNodeSize(node) / 2);
+  const initialY = event.y - (calculateNodeSize(node) / 2);
+
+  const moveFn = (evt: Event) => {
+    // Check we have a mouse event
+    if (!(evt instanceof MouseEvent)) {
+      throw new Error('event is not MouseEvent');
     }
 
-    const nodeSizeVariable = computed(() => store.state.nodeSizeVariable);
-    const nodeSizeScale = computed(() => store.getters.nodeSizeScale);
-    function calculateNodeSize(node: Node) {
-      // Don't render dynamic node size if the size variable is empty or
-      // we want to display charts
-      if (nodeSizeVariable.value === '' || displayCharts.value || nodeSizeScale.value === null) {
-        return markerSize.value;
-      }
+    const eventX = evt.x - controlsWidth.value - (calculateNodeSize(node) / 2);
+    const eventY = evt.y - (calculateNodeSize(node) / 2);
 
-      const calculatedValue = nodeSizeScale.value(node[nodeSizeVariable.value]);
+    if (selectedNodes.value.has(node._id)) {
+      const nodeX = Math.floor(node.x || 0);
+      const nodeY = Math.floor(node.y || 0);
+      const dx = eventX - nodeX;
+      const dy = eventY - nodeY;
 
-      return calculatedValue > 40 || calculatedValue < 10 ? 0 : calculatedValue;
-    }
-
-    function dragNode(node: Node, event: MouseEvent) {
-      // Only drag on left clicks
-      if (event.button !== 0) {
-        return;
-      }
-
-      if (!(svg.value instanceof Element)) {
-        throw new Error('SVG is not of type Element');
-      }
-
-      event.stopPropagation();
-
-      const initialX = event.x - controlsWidth.value - (calculateNodeSize(node) / 2);
-      const initialY = event.y - (calculateNodeSize(node) / 2);
-
-      const moveFn = (evt: Event) => {
-        // Check we have a mouse event
-        if (!(evt instanceof MouseEvent)) {
-          throw new Error('event is not MouseEvent');
-        }
-
-        const eventX = evt.x - controlsWidth.value - (calculateNodeSize(node) / 2);
-        const eventY = evt.y - (calculateNodeSize(node) / 2);
-
-        if (selectedNodes.value.has(node._id)) {
-          const nodeX = Math.floor(node.x || 0);
-          const nodeY = Math.floor(node.y || 0);
-          const dx = eventX - nodeX;
-          const dy = eventY - nodeY;
-
-          if (network.value !== null) {
-            network.value.nodes
-              .filter((innerNode) => selectedNodes.value.has(innerNode._id) && innerNode._id !== node._id)
-              .forEach((innerNode) => {
-                // eslint-disable-next-line no-param-reassign
-                innerNode.x = (innerNode.x || 0) + dx;
-                // eslint-disable-next-line no-param-reassign
-                innerNode.y = (innerNode.y || 0) + dy;
-                // eslint-disable-next-line no-param-reassign
-                innerNode.fx = (innerNode.fx || innerNode.x || 0) + dx;
-                // eslint-disable-next-line no-param-reassign
-                innerNode.fy = (innerNode.fy || innerNode.y || 0) + dy;
-              });
-          }
-        }
-
-        // eslint-disable-next-line no-param-reassign
-        node.x = eventX;
-        // eslint-disable-next-line no-param-reassign
-        node.y = eventY;
-        // eslint-disable-next-line no-param-reassign
-        node.fx = eventX;
-        // eslint-disable-next-line no-param-reassign
-        node.fy = eventY;
-
-        if (currentInstance !== null) {
-          currentInstance.proxy.$forceUpdate();
-        }
-      };
-
-      const stopFn = (evt: Event) => {
-        if (!(svg.value instanceof Element)) {
-          throw new Error('SVG is not of type Element');
-        }
-        svg.value.removeEventListener('mousemove', moveFn);
-        svg.value.removeEventListener('mouseup', stopFn);
-
-        // Check we have a mouse event
-        if (!(evt instanceof MouseEvent)) {
-          throw new Error('event is not MouseEvent');
-        }
-
-        const finalX = evt.x - controlsWidth.value - (calculateNodeSize(node) / 2);
-        const finalY = evt.y - (calculateNodeSize(node) / 2);
-        const totalXMovement = Math.abs(initialX - finalX);
-        const totalYMovement = Math.abs(initialY - finalY);
-
-        if (totalXMovement < 25 && totalYMovement < 25) {
-          selectNode(node);
-        }
-      };
-
-      svg.value.addEventListener('mousemove', moveFn);
-      svg.value.addEventListener('mouseup', stopFn);
-    }
-
-    const tooltipMessage = ref('');
-    const toggleTooltip = ref(false);
-    const tooltipPosition = ref({ x: 0, y: 0 });
-    const tooltipStyle = computed(() => `left: ${tooltipPosition.value.x}px; top: ${tooltipPosition.value.y}px; white-space: pre-line;`);
-    function showTooltip(element: Node | Edge, event: MouseEvent) {
-      tooltipPosition.value = {
-        x: event.clientX - controlsWidth.value,
-        y: event.clientY,
-      };
-
-      tooltipMessage.value = Object.entries(element)
-        .filter(([key]) => !isInternalField(key))
-        .map(([key, value]) => `${key}: ${value}`).reduce((a, b) => `${a}\n${b}`);
-      toggleTooltip.value = true;
-    }
-
-    function hideTooltip() {
-      tooltipMessage.value = '';
-      toggleTooltip.value = false;
-    }
-
-    function nodeTranslate(node: Node): string {
-      let forcedX = node.x || 0;
-      let forcedY = node.y || 0;
-
-      const svgEdgePadding = 5;
-
-      const minimumX = svgEdgePadding;
-      const minimumY = svgEdgePadding;
-      const maximumX = svgDimensions.value.width - calculateNodeSize(node) - svgEdgePadding;
-      const maximumY = svgDimensions.value.height - calculateNodeSize(node) - svgEdgePadding;
-
-      // Ideally we would update node.x and node.y, but those variables are being changed
-      // by the simulation. My solution was to use these forcedX and forcedY variables.
-      if (forcedX < minimumX) { forcedX = minimumX; }
-      if (forcedX > maximumX) { forcedX = maximumX; }
-      if (forcedY < minimumY) { forcedY = minimumY; }
-      if (forcedY > maximumY) { forcedY = maximumY; }
-
-      // Update the node position with this forced position
-      // eslint-disable-next-line no-param-reassign
-      node.x = forcedX;
-      // eslint-disable-next-line no-param-reassign
-      node.y = forcedY;
-
-      // Use the forced position, because the node.x is updated by simulation
-      return `translate(${forcedX}, ${forcedY})`;
-    }
-
-    function arcPath(edge: Edge): string {
       if (network.value !== null) {
-        const fromNode = network.value.nodes.find((node) => node._id === edge._from);
-        const toNode = network.value.nodes.find((node) => node._id === edge._to);
-
-        if (fromNode === undefined || toNode === undefined) {
-          throw new Error('Couldn\'t find the source or target for a edge, didn\'t draw arc.');
-        }
-
-        if (fromNode.x === undefined || fromNode.y === undefined || toNode.x === undefined || toNode.y === undefined) {
-          throw new Error('_from or _to node didn\'t have an x or a y position.');
-        }
-
-        const x1 = fromNode.x + calculateNodeSize(fromNode) / 2;
-        const y1 = fromNode.y + calculateNodeSize(fromNode) / 2;
-        const x2 = toNode.x + calculateNodeSize(toNode) / 2;
-        const y2 = toNode.y + calculateNodeSize(toNode) / 2;
-
-        const dx = x2 - x1;
-        const dy = y2 - y1;
-        const dr = Math.sqrt(dx * dx + dy * dy);
-        const sweep = 1;
-        const xRotation = 0;
-        const largeArc = 0;
-
-        return (`M ${x1}, ${y1} A ${dr}, ${dr} ${xRotation}, ${largeArc}, ${sweep} ${x2},${y2}`);
+        network.value.nodes
+          .filter((innerNode) => selectedNodes.value.has(innerNode._id) && innerNode._id !== node._id)
+          .forEach((innerNode) => {
+            // eslint-disable-next-line no-param-reassign
+            innerNode.x = (innerNode.x || 0) + dx;
+            // eslint-disable-next-line no-param-reassign
+            innerNode.y = (innerNode.y || 0) + dy;
+            // eslint-disable-next-line no-param-reassign
+            innerNode.fx = (innerNode.fx || innerNode.x || 0) + dx;
+            // eslint-disable-next-line no-param-reassign
+            innerNode.fy = (innerNode.fy || innerNode.y || 0) + dy;
+          });
       }
-      return '';
     }
 
-    function isSelected(nodeID: string): boolean {
-      return selectedNodes.value.has(nodeID);
+    // eslint-disable-next-line no-param-reassign
+    node.x = eventX;
+    // eslint-disable-next-line no-param-reassign
+    node.y = eventY;
+    // eslint-disable-next-line no-param-reassign
+    node.fx = eventX;
+    // eslint-disable-next-line no-param-reassign
+    node.fy = eventY;
+
+    if (currentInstance !== null) {
+      currentInstance.proxy.$forceUpdate();
+    }
+  };
+
+  const stopFn = (evt: Event) => {
+    if (!(svg.value instanceof Element)) {
+      throw new Error('SVG is not of type Element');
+    }
+    svg.value.removeEventListener('mousemove', moveFn);
+    svg.value.removeEventListener('mouseup', stopFn);
+
+    // Check we have a mouse event
+    if (!(evt instanceof MouseEvent)) {
+      throw new Error('event is not MouseEvent');
     }
 
-    const oneHop = computed(() => {
-      if (network.value !== null) {
-        const inNodes = network.value.edges.map((edge) => (selectedNodes.value.has(edge._to) ? edge._from : null));
-        const outNodes = network.value.edges.map((edge) => (selectedNodes.value.has(edge._from) ? edge._to : null));
+    const finalX = evt.x - controlsWidth.value - (calculateNodeSize(node) / 2);
+    const finalY = evt.y - (calculateNodeSize(node) / 2);
+    const totalXMovement = Math.abs(initialX - finalX);
+    const totalYMovement = Math.abs(initialY - finalY);
 
-        const oneHopNodeIDs: Set<string | null> = new Set([...outNodes, ...inNodes]);
+    if (totalXMovement < 25 && totalYMovement < 25) {
+      selectNode(node);
+    }
+  };
 
-        // Remove null if it exists
-        if (oneHopNodeIDs.has(null)) {
-          oneHopNodeIDs.delete(null);
-        }
+  svg.value.addEventListener('mousemove', moveFn);
+  svg.value.addEventListener('mouseup', stopFn);
+}
 
-        return oneHopNodeIDs;
-      }
-      return new Set();
-    });
-    function nodeGroupClass(node: Node): string {
-      if (selectedNodes.value.size > 0) {
-        const selected = isSelected(node._id);
-        const inOneHop = selectNeighbors.value ? oneHop.value.has(node._id) : false;
-        const selectedClass = selected || inOneHop || !selectNeighbors.value ? '' : 'muted';
-        return `nodeGroup ${selectedClass}`;
-      }
-      return 'nodeGroup';
+const tooltipMessage = ref('');
+const toggleTooltip = ref(false);
+const tooltipPosition = ref({ x: 0, y: 0 });
+const tooltipStyle = computed(() => `left: ${tooltipPosition.value.x}px; top: ${tooltipPosition.value.y}px; white-space: pre-line;`);
+function showTooltip(element: Node | Edge, event: MouseEvent) {
+  tooltipPosition.value = {
+    x: event.clientX - controlsWidth.value,
+    y: event.clientY,
+  };
+
+  tooltipMessage.value = Object.entries(element)
+    .filter(([key]) => !isInternalField(key))
+    .map(([key, value]) => `${key}: ${value}`).reduce((a, b) => `${a}\n${b}`);
+  toggleTooltip.value = true;
+}
+
+function hideTooltip() {
+  tooltipMessage.value = '';
+  toggleTooltip.value = false;
+}
+
+function nodeTranslate(node: Node): string {
+  let forcedX = node.x || 0;
+  let forcedY = node.y || 0;
+
+  const svgEdgePadding = 5;
+
+  const minimumX = svgEdgePadding;
+  const minimumY = svgEdgePadding;
+  const maximumX = svgDimensions.value.width - calculateNodeSize(node) - svgEdgePadding;
+  const maximumY = svgDimensions.value.height - calculateNodeSize(node) - svgEdgePadding;
+
+  // Ideally we would update node.x and node.y, but those variables are being changed
+  // by the simulation. My solution was to use these forcedX and forcedY variables.
+  if (forcedX < minimumX) { forcedX = minimumX; }
+  if (forcedX > maximumX) { forcedX = maximumX; }
+  if (forcedY < minimumY) { forcedY = minimumY; }
+  if (forcedY > maximumY) { forcedY = maximumY; }
+
+  // Update the node position with this forced position
+  // eslint-disable-next-line no-param-reassign
+  node.x = forcedX;
+  // eslint-disable-next-line no-param-reassign
+  node.y = forcedY;
+
+  // Use the forced position, because the node.x is updated by simulation
+  return `translate(${forcedX}, ${forcedY})`;
+}
+
+function arcPath(edge: Edge): string {
+  if (network.value !== null) {
+    const fromNode = network.value.nodes.find((node) => node._id === edge._from);
+    const toNode = network.value.nodes.find((node) => node._id === edge._to);
+
+    if (fromNode === undefined || toNode === undefined) {
+      throw new Error('Couldn\'t find the source or target for a edge, didn\'t draw arc.');
     }
 
-    function nodeClass(node: Node): string {
-      const selected = isSelected(node._id);
-      const selectedClass = selected ? 'selected' : '';
-
-      return `node nodeBox ${selectedClass}`;
+    if (fromNode.x === undefined || fromNode.y === undefined || toNode.x === undefined || toNode.y === undefined) {
+      throw new Error('_from or _to node didn\'t have an x or a y position.');
     }
 
-    const nodeColorVariable = computed(() => store.state.nodeColorVariable);
-    const nodeColorScale = computed(() => store.getters.nodeColorScale);
-    function nodeFill(node: Node) {
-      const calculatedValue = node[nodeColorVariable.value];
-      const useCalculatedValue = !displayCharts.value && columnTypes.value !== null
+    const x1 = fromNode.x + calculateNodeSize(fromNode) / 2;
+    const y1 = fromNode.y + calculateNodeSize(fromNode) / 2;
+    const x2 = toNode.x + calculateNodeSize(toNode) / 2;
+    const y2 = toNode.y + calculateNodeSize(toNode) / 2;
+
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    const dr = Math.sqrt(dx * dx + dy * dy);
+    const sweep = 1;
+    const xRotation = 0;
+    const largeArc = 0;
+
+    return (`M ${x1}, ${y1} A ${dr}, ${dr} ${xRotation}, ${largeArc}, ${sweep} ${x2},${y2}`);
+  }
+  return '';
+}
+
+function isSelected(nodeID: string): boolean {
+  return selectedNodes.value.has(nodeID);
+}
+
+const oneHop = computed(() => {
+  if (network.value !== null) {
+    const inNodes = network.value.edges.map((edge) => (selectedNodes.value.has(edge._to) ? edge._from : null));
+    const outNodes = network.value.edges.map((edge) => (selectedNodes.value.has(edge._from) ? edge._to : null));
+
+    const oneHopNodeIDs: Set<string | null> = new Set([...outNodes, ...inNodes]);
+
+    // Remove null if it exists
+    if (oneHopNodeIDs.has(null)) {
+      oneHopNodeIDs.delete(null);
+    }
+
+    return oneHopNodeIDs;
+  }
+  return new Set();
+});
+function nodeGroupClass(node: Node): string {
+  if (selectedNodes.value.size > 0) {
+    const selected = isSelected(node._id);
+    const inOneHop = selectNeighbors.value ? oneHop.value.has(node._id) : false;
+    const selectedClass = selected || inOneHop || !selectNeighbors.value ? '' : 'muted';
+    return `nodeGroup ${selectedClass}`;
+  }
+  return 'nodeGroup';
+}
+
+function nodeClass(node: Node): string {
+  const selected = isSelected(node._id);
+  const selectedClass = selected ? 'selected' : '';
+
+  return `node nodeBox ${selectedClass}`;
+}
+
+const nodeColorVariable = computed(() => store.state.nodeColorVariable);
+const nodeColorScale = computed(() => store.getters.nodeColorScale);
+function nodeFill(node: Node) {
+  const calculatedValue = node[nodeColorVariable.value];
+  const useCalculatedValue = !displayCharts.value && columnTypes.value !== null
       && (
         // Numeric check
         (
@@ -358,25 +352,25 @@ export default defineComponent({
         )
       );
 
-      return useCalculatedValue ? nodeColorScale.value(calculatedValue) : '#EEEEEE';
-    }
+  return useCalculatedValue ? nodeColorScale.value(calculatedValue) : '#EEEEEE';
+}
 
-    function edgeGroupClass(edge: Edge): string {
-      if (selectedNodes.value.size > 0) {
-        const selected = isSelected(edge._from) || isSelected(edge._to);
-        const selectedClass = selected || !selectNeighbors.value ? '' : 'muted';
-        return `edgeGroup ${selectedClass}`;
-      }
-      return 'edgeGroup';
-    }
+function edgeGroupClass(edge: Edge): string {
+  if (selectedNodes.value.size > 0) {
+    const selected = isSelected(edge._from) || isSelected(edge._to);
+    const selectedClass = selected || !selectNeighbors.value ? '' : 'muted';
+    return `edgeGroup ${selectedClass}`;
+  }
+  return 'edgeGroup';
+}
 
-    const edgeWidthScale = computed(() => store.getters.edgeWidthScale);
-    const edgeVariables = computed(() => store.state.edgeVariables);
-    function edgeStyle(edge: Edge): string {
-      const edgeWidth = edgeVariables.value.width === '' ? 1 : edgeWidthScale.value(edge[edgeVariables.value.width]);
+const edgeWidthScale = computed(() => store.getters.edgeWidthScale);
+const edgeVariables = computed(() => store.state.edgeVariables);
+function edgeStyle(edge: Edge): string {
+  const edgeWidth = edgeVariables.value.width === '' ? 1 : edgeWidthScale.value(edge[edgeVariables.value.width]);
 
-      const calculatedColorValue = edge[edgeVariables.value.color];
-      const useCalculatedColorValue = edgeVariables.value.color !== '' && columnTypes.value !== null
+  const calculatedColorValue = edge[edgeVariables.value.color];
+  const useCalculatedColorValue = edgeVariables.value.color !== '' && columnTypes.value !== null
       && (
         // Numeric check
         (
@@ -392,511 +386,472 @@ export default defineComponent({
         )
       );
 
-      return `
+  return `
         stroke: ${useCalculatedColorValue ? edgeColorScale.value(calculatedColorValue) : '#888888'};
         stroke-width: ${(edgeWidth > 20 || edgeWidth < 1) ? 0 : edgeWidth}px;
         opacity: 0.7;
       `;
+}
+
+const nodeGlyphColorScale = computed(() => store.state.nodeGlyphColorScale);
+function glyphFill(node: Node, glyphVar: string) {
+  // Figure out what values should be mapped to colors
+  const possibleValues = [
+    ...(attributeRanges.value[nestedVariables.value.glyph[0]].currentBinLabels || attributeRanges.value[nestedVariables.value.glyph[0]].binLabels),
+  ];
+  if (nestedVariables.value.glyph[1]) {
+    possibleValues.push(...(attributeRanges.value[nestedVariables.value.glyph[1]].currentBinLabels || attributeRanges.value[nestedVariables.value.glyph[1]].binLabels));
+  }
+  const scaleContainsValue = possibleValues.find((domainElement) => domainElement === node[glyphVar]);
+
+  // If outside the doamin, return black
+  return scaleContainsValue ? nodeGlyphColorScale.value(node[glyphVar]) : '#000000';
+}
+
+const rectSelect = ref({
+  x: 0,
+  y: 0,
+  width: 0,
+  height: 0,
+  transformX: 0,
+  transformY: 0,
+});
+function rectSelectDrag(event: MouseEvent) {
+  // Only drag on left clicks
+  if (event.button !== 0) {
+    return;
+  }
+
+  // Set initial location for box (pins one corner)
+  rectSelect.value = {
+    x: event.x - controlsWidth.value,
+    y: event.y,
+    width: 0,
+    height: 0,
+    transformX: 0,
+    transformY: 0,
+  };
+
+  const moveFn = (evt: Event) => {
+    // Check we have a mouse event
+    if (!(evt instanceof MouseEvent)) {
+      throw new Error('event is not MouseEvent');
     }
 
-    const nodeGlyphColorScale = computed(() => store.state.nodeGlyphColorScale);
-    function glyphFill(node: Node, glyphVar: string) {
-      // Figure out what values should be mapped to colors
-      const possibleValues = [
-        ...(attributeRanges.value[nestedVariables.value.glyph[0]].currentBinLabels || attributeRanges.value[nestedVariables.value.glyph[0]].binLabels),
-      ];
-      if (nestedVariables.value.glyph[1]) {
-        possibleValues.push(...(attributeRanges.value[nestedVariables.value.glyph[1]].currentBinLabels || attributeRanges.value[nestedVariables.value.glyph[1]].binLabels));
-      }
-      const scaleContainsValue = possibleValues.find((domainElement) => domainElement === node[glyphVar]);
+    // Get event location
+    const mouseX = evt.x - controlsWidth.value;
+    const mouseY = evt.y;
 
-      // If outside the doamin, return black
-      return scaleContainsValue ? nodeGlyphColorScale.value(node[glyphVar]) : '#000000';
+    // Check if we need to translate (case when mouse is left/above initial click)
+    const translateX = mouseX < rectSelect.value.x;
+    const translateY = mouseY < rectSelect.value.y;
+
+    // Set the parameters
+    rectSelect.value = {
+      x: rectSelect.value.x,
+      y: rectSelect.value.y,
+      width: Math.abs(rectSelect.value.x - mouseX),
+      height: Math.abs(rectSelect.value.y - mouseY),
+      transformX: translateX ? -Math.abs(rectSelect.value.x - mouseX) : 0,
+      transformY: translateY ? -Math.abs(rectSelect.value.y - mouseY) : 0,
+    };
+  };
+
+  const stopFn = () => {
+    const boxX1 = Math.min(rectSelect.value.x + rectSelect.value.transformX, rectSelect.value.x);
+    const boxX2 = boxX1 + rectSelect.value.width;
+    const boxY1 = Math.min(rectSelect.value.y + rectSelect.value.transformY, rectSelect.value.y);
+    const boxY2 = boxY1 + rectSelect.value.height;
+
+    // If x1 == x2 && y1 == y2, it was a click so deselect
+    if (boxX1 === boxX2 && boxY1 === boxY2) {
+      store.commit.setSelected(new Set());
     }
 
-    const rectSelect = ref({
+    // Find which nodes are in the box
+    let nodesInRect: Node[] = [];
+    if (network.value !== null) {
+      nodesInRect = network.value.nodes.filter((node) => {
+        const nodeSize = calculateNodeSize(node) / 2;
+        return (node.x || 0) + nodeSize > boxX1
+              && (node.x || 0) + nodeSize < boxX2
+              && (node.y || 0) + nodeSize > boxY1
+              && (node.y || 0) + nodeSize < boxY2;
+      });
+    }
+
+    // Select the nodes inside the box if there are any
+    store.commit.addSelectedNode(nodesInRect.map((node) => node._id));
+
+    // Remove the listeners so that the box stops updating location
+    if (!(svg.value instanceof Element)) {
+      throw new Error('SVG is not of type Element');
+    }
+    svg.value.removeEventListener('mousemove', moveFn);
+    svg.value.removeEventListener('mouseup', stopFn);
+
+    // Remove the selection box
+    rectSelect.value = {
       x: 0,
       y: 0,
       width: 0,
       height: 0,
       transformX: 0,
       transformY: 0,
+    };
+  };
+
+  if (!(svg.value instanceof Element)) {
+    throw new Error('SVG is not of type Element');
+  }
+  svg.value.addEventListener('mousemove', moveFn);
+  svg.value.addEventListener('mouseup', stopFn);
+}
+
+function showContextMenu(event: MouseEvent) {
+  store.commit.updateRightClickMenu({
+    show: true,
+    top: event.y,
+    left: event.x,
+  });
+
+  event.preventDefault();
+}
+
+function generateNodePositions(nodes: Node[]) {
+  nodes.forEach((node) => {
+    // If the position is not defined for x or y, generate it
+    if (node.x === undefined || node.y === undefined) {
+      // eslint-disable-next-line no-param-reassign
+      node.x = Math.random() * svgDimensions.value.width;
+      // eslint-disable-next-line no-param-reassign
+      node.y = Math.random() * svgDimensions.value.height;
+    }
+  });
+}
+if (network.value !== null) {
+  generateNodePositions(network.value.nodes);
+}
+
+const simulationEdges = computed(() => {
+  if (network.value !== null) {
+    return network.value.edges.map((edge: Edge) => {
+      const newEdge: SimulationEdge = {
+        ...structuredClone(edge),
+        source: edge._from,
+        target: edge._to,
+      };
+      return newEdge;
     });
-    function rectSelectDrag(event: MouseEvent) {
-      // Only drag on left clicks
-      if (event.button !== 0) {
-        return;
+  }
+  return null;
+});
+watch(attributeRanges, () => {
+  if (simulationEdges.value !== null && layoutVars.value.x === null && layoutVars.value.y === null) {
+    const simEdges = simulationEdges.value.filter((edge: Edge) => {
+      if (edgeVariables.value.width !== '') {
+        const widthValue = edgeWidthScale.value(edge[edgeVariables.value.width]);
+        return widthValue < 20 && widthValue > 1;
       }
-
-      // Set initial location for box (pins one corner)
-      rectSelect.value = {
-        x: event.x - controlsWidth.value,
-        y: event.y,
-        width: 0,
-        height: 0,
-        transformX: 0,
-        transformY: 0,
-      };
-
-      const moveFn = (evt: Event) => {
-        // Check we have a mouse event
-        if (!(evt instanceof MouseEvent)) {
-          throw new Error('event is not MouseEvent');
-        }
-
-        // Get event location
-        const mouseX = evt.x - controlsWidth.value;
-        const mouseY = evt.y;
-
-        // Check if we need to translate (case when mouse is left/above initial click)
-        const translateX = mouseX < rectSelect.value.x;
-        const translateY = mouseY < rectSelect.value.y;
-
-        // Set the parameters
-        rectSelect.value = {
-          x: rectSelect.value.x,
-          y: rectSelect.value.y,
-          width: Math.abs(rectSelect.value.x - mouseX),
-          height: Math.abs(rectSelect.value.y - mouseY),
-          transformX: translateX ? -Math.abs(rectSelect.value.x - mouseX) : 0,
-          transformY: translateY ? -Math.abs(rectSelect.value.y - mouseY) : 0,
-        };
-      };
-
-      const stopFn = () => {
-        const boxX1 = Math.min(rectSelect.value.x + rectSelect.value.transformX, rectSelect.value.x);
-        const boxX2 = boxX1 + rectSelect.value.width;
-        const boxY1 = Math.min(rectSelect.value.y + rectSelect.value.transformY, rectSelect.value.y);
-        const boxY2 = boxY1 + rectSelect.value.height;
-
-        // If x1 == x2 && y1 == y2, it was a click so deselect
-        if (boxX1 === boxX2 && boxY1 === boxY2) {
-          store.commit.setSelected(new Set());
-        }
-
-        // Find which nodes are in the box
-        let nodesInRect: Node[] = [];
-        if (network.value !== null) {
-          nodesInRect = network.value.nodes.filter((node) => {
-            const nodeSize = calculateNodeSize(node) / 2;
-            return (node.x || 0) + nodeSize > boxX1
-              && (node.x || 0) + nodeSize < boxX2
-              && (node.y || 0) + nodeSize > boxY1
-              && (node.y || 0) + nodeSize < boxY2;
-          });
-        }
-
-        // Select the nodes inside the box if there are any
-        store.commit.addSelectedNode(nodesInRect.map((node) => node._id));
-
-        // Remove the listeners so that the box stops updating location
-        if (!(svg.value instanceof Element)) {
-          throw new Error('SVG is not of type Element');
-        }
-        svg.value.removeEventListener('mousemove', moveFn);
-        svg.value.removeEventListener('mouseup', stopFn);
-
-        // Remove the selection box
-        rectSelect.value = {
-          x: 0,
-          y: 0,
-          width: 0,
-          height: 0,
-          transformX: 0,
-          transformY: 0,
-        };
-      };
-
-      if (!(svg.value instanceof Element)) {
-        throw new Error('SVG is not of type Element');
-      }
-      svg.value.addEventListener('mousemove', moveFn);
-      svg.value.addEventListener('mouseup', stopFn);
-    }
-
-    function showContextMenu(event: MouseEvent) {
-      store.commit.updateRightClickMenu({
-        show: true,
-        top: event.y,
-        left: event.x,
-      });
-
-      event.preventDefault();
-    }
-
-    function generateNodePositions(nodes: Node[]) {
-      nodes.forEach((node) => {
-        // If the position is not defined for x or y, generate it
-        if (node.x === undefined || node.y === undefined) {
-          // eslint-disable-next-line no-param-reassign
-          node.x = Math.random() * svgDimensions.value.width;
-          // eslint-disable-next-line no-param-reassign
-          node.y = Math.random() * svgDimensions.value.height;
-        }
-      });
-    }
-    if (network.value !== null) {
-      generateNodePositions(network.value.nodes);
-    }
-
-    const simulationEdges = computed(() => {
-      if (network.value !== null) {
-        return network.value.edges.map((edge: Edge) => {
-          const newEdge: SimulationEdge = {
-            ...structuredClone(edge),
-            source: edge._from,
-            target: edge._to,
-          };
-          return newEdge;
-        });
-      }
-      return null;
+      return true;
     });
-    watch(attributeRanges, () => {
-      if (simulationEdges.value !== null && layoutVars.value.x === null && layoutVars.value.y === null) {
-        const simEdges = simulationEdges.value.filter((edge: Edge) => {
-          if (edgeVariables.value.width !== '') {
-            const widthValue = edgeWidthScale.value(edge[edgeVariables.value.width]);
-            return widthValue < 20 && widthValue > 1;
+
+    applyForceToSimulation(
+      store.state.simulation,
+      'edge',
+      forceLink<Node, SimulationEdge>(simEdges).id((d) => { const datum = (d as Edge); return datum._id; }).strength(0.5),
+    );
+  }
+});
+
+function resetSimulationForces() {
+  // Reset forces before applying (if there are layout vars)
+  if (simulationEdges.value !== null) {
+    // Double force to the middle of each axis if there's a layout var. Causes the nodes to be pulled to the middle.
+    const forceStrength = layoutVars.value.x === null && layoutVars.value.y === null ? 1 : 2;
+    applyForceToSimulation(
+      store.state.simulation,
+      'x',
+      forceX<Node>(svgDimensions.value.width / 2).strength(forceStrength),
+    );
+    applyForceToSimulation(
+      store.state.simulation,
+      'y',
+      forceY<Node>(svgDimensions.value.height / 2).strength(forceStrength),
+    );
+    applyForceToSimulation(
+      store.state.simulation,
+      'edge',
+      forceLink<Node, SimulationEdge>(simulationEdges.value).id((d) => { const datum = (d as Edge); return datum._id; }).strength(1),
+    );
+    applyForceToSimulation(
+      store.state.simulation,
+      'charge',
+      forceManyBody<Node>().strength(-500),
+    );
+    applyForceToSimulation(
+      store.state.simulation,
+      'collision',
+      forceCollide((markerSize.value / 2) * 1.5),
+    );
+  }
+}
+
+const xAxisPadding = 60;
+const yAxisPadding = 80;
+function makePositionScale(axis: 'x' | 'y', type: ColumnType, range: AttributeRange) {
+  const varName = layoutVars.value[axis];
+  let clipLow = false;
+  let clipHigh = false;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let positionScale: any;
+
+  if (type === 'number') {
+    let minValue = range.min;
+    let maxValue = range.max - 1; // subtract 1, because of the + 1 on the legend chart scale
+
+    // Check IQR for outliers
+    if (network.value !== null && varName !== null) {
+      const values = network.value.nodes.map((node) => node[varName]).sort((a, b) => a - b);
+
+      let q1;
+      let q3;
+      if ((values.length / 4) % 1 === 0) {
+        q1 = 0.5 * (values[(values.length / 4)] + values[(values.length / 4) + 1]);
+        q3 = 0.5 * (values[(values.length * (3 / 4))] + values[(values.length * (3 / 4)) + 1]);
+      } else {
+        q1 = values[Math.floor(values.length / 4 + 1)];
+        q3 = values[Math.ceil(values.length * (3 / 4) + 1)];
+      }
+
+      const iqr = q3 - q1;
+      const maxCandidate = q3 + iqr * 1.5;
+      const minCandidate = q1 - iqr * 1.5;
+
+      if (maxCandidate < maxValue) {
+        maxValue = maxCandidate;
+        clipHigh = true;
+        select(`#${axis}-high-clip`).style('visibility', 'visible');
+        select(`#${axis}-high-clip > text`).text(`> ${maxCandidate}`);
+      }
+
+      if (minCandidate > minValue) {
+        minValue = minCandidate;
+        clipLow = true;
+        select(`#${axis}-low-clip`).style('visibility', 'visible');
+        select(`#${axis}-low-clip > text`).text(`< ${minCandidate}`);
+      }
+    }
+
+    positionScale = scaleLinear()
+      .domain([minValue, maxValue]);
+  } else {
+    positionScale = scaleBand()
+      .domain(range.binLabels);
+  }
+
+  if (axis === 'x') {
+    const minMax = [clipLow ? yAxisPadding + clipRegionSize : yAxisPadding, clipHigh ? store.state.svgDimensions.width - clipRegionSize : store.state.svgDimensions.width];
+    positionScale = positionScale
+      .range(minMax);
+  } else {
+    const minMax = [clipLow ? store.state.svgDimensions.height - xAxisPadding - clipRegionSize : store.state.svgDimensions.height - xAxisPadding, clipHigh ? clipRegionSize : 0];
+    positionScale = positionScale
+      .range(minMax);
+  }
+
+  const otherAxis = axis === 'x' ? 'y' : 'x';
+
+  if (varName !== null) {
+    // Set node size smaller
+    store.commit.setMarkerSize({ markerSize: 10, updateProv: true });
+
+    // Clear the label variable
+    store.commit.setLabelVariable(undefined);
+
+    if (store.state.network !== null && store.state.columnTypes !== null) {
+      const otherAxisPadding = axis === 'x' ? 80 : 60;
+
+      if (type === 'number') {
+        const scaleDomain = positionScale.domain();
+        const scaleRange = positionScale.range();
+        store.state.network.nodes.forEach((node) => {
+          const nodeVal = node[varName];
+          let position = positionScale(nodeVal);
+
+          if (axis === 'x') {
+            position = nodeVal > scaleDomain[1] ? scaleRange[1] + ((clipRegionSize - 10) * ((nodeVal - scaleDomain[1]) / (range.max - 1 - scaleDomain[1]))) : position;
+            position = nodeVal < scaleDomain[0] ? scaleRange[0] - ((clipRegionSize - 10) * ((scaleDomain[0] - nodeVal) / (scaleDomain[0] - range.min))) : position;
+          } else {
+            position = nodeVal > scaleDomain[1] ? scaleRange[1] - ((clipRegionSize - 10) * ((nodeVal - scaleDomain[1]) / (range.max - 1 - scaleDomain[1]))) : position;
+            position = nodeVal < scaleDomain[0] ? scaleRange[0] + ((clipRegionSize - 10) * ((scaleDomain[0] - nodeVal) / (scaleDomain[0] - range.min))) : position;
           }
-          return true;
+          position -= (markerSize.value / 2);
+
+          // eslint-disable-next-line no-param-reassign
+          node[axis] = position;
+          // eslint-disable-next-line no-param-reassign
+          node[`f${axis}`] = position;
+
+          if (store.state.layoutVars[otherAxis] === null) {
+            const otherSvgDimension = axis === 'x' ? store.state.svgDimensions.height : store.state.svgDimensions.width;
+            // eslint-disable-next-line no-param-reassign
+            node[otherAxis] = otherSvgDimension / 2;
+            // eslint-disable-next-line no-param-reassign
+            node[`f${otherAxis}`] = otherSvgDimension / 2;
+          }
         });
+      } else {
+        let positionOffset: number;
 
-        applyForceToSimulation(
-          store.state.simulation,
-          'edge',
-          forceLink<Node, SimulationEdge>(simEdges).id((d) => { const datum = (d as Edge); return datum._id; }).strength(0.5),
-        );
-      }
-    });
+        if (axis === 'x') {
+          positionOffset = (store.state.svgDimensions.width - otherAxisPadding) / ((range.binLabels.length) * 2);
+        } else {
+          positionOffset = ((store.state.svgDimensions.height - xAxisPadding) / ((range.binLabels.length) * 2)) - 10;
+        }
 
-    function resetSimulationForces() {
-      // Reset forces before applying (if there are layout vars)
-      if (simulationEdges.value !== null) {
-        // Double force to the middle of each axis if there's a layout var. Causes the nodes to be pulled to the middle.
-        const forceStrength = layoutVars.value.x === null && layoutVars.value.y === null ? 1 : 2;
+        const force = axis === 'x' ? forceX<Node>((d) => positionScale(d[varName]) + positionOffset).strength(2) : forceY<Node>((d) => positionScale(d[varName]) + positionOffset).strength(2);
         applyForceToSimulation(
           store.state.simulation,
-          'x',
-          forceX<Node>(svgDimensions.value.width / 2).strength(forceStrength),
-        );
-        applyForceToSimulation(
-          store.state.simulation,
-          'y',
-          forceY<Node>(svgDimensions.value.height / 2).strength(forceStrength),
+          axis,
+          force,
         );
         applyForceToSimulation(
           store.state.simulation,
           'edge',
-          forceLink<Node, SimulationEdge>(simulationEdges.value).id((d) => { const datum = (d as Edge); return datum._id; }).strength(1),
+          forceLink<Node, SimulationEdge>(),
         );
         applyForceToSimulation(
           store.state.simulation,
           'charge',
-          forceManyBody<Node>().strength(-500),
+          forceManyBody<Node>(),
         );
-        applyForceToSimulation(
-          store.state.simulation,
-          'collision',
-          forceCollide((markerSize.value / 2) * 1.5),
-        );
-      }
-    }
-
-    const xAxisPadding = 60;
-    const yAxisPadding = 80;
-    function makePositionScale(axis: 'x' | 'y', type: ColumnType, range: AttributeRange) {
-      const varName = layoutVars.value[axis];
-      let clipLow = false;
-      let clipHigh = false;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let positionScale: any;
-
-      if (type === 'number') {
-        let minValue = range.min;
-        let maxValue = range.max - 1; // subtract 1, because of the + 1 on the legend chart scale
-
-        // Check IQR for outliers
-        if (network.value !== null && varName !== null) {
-          const values = network.value.nodes.map((node) => node[varName]).sort((a, b) => a - b);
-
-          let q1;
-          let q3;
-          if ((values.length / 4) % 1 === 0) {
-            q1 = 0.5 * (values[(values.length / 4)] + values[(values.length / 4) + 1]);
-            q3 = 0.5 * (values[(values.length * (3 / 4))] + values[(values.length * (3 / 4)) + 1]);
-          } else {
-            q1 = values[Math.floor(values.length / 4 + 1)];
-            q3 = values[Math.ceil(values.length * (3 / 4) + 1)];
-          }
-
-          const iqr = q3 - q1;
-          const maxCandidate = q3 + iqr * 1.5;
-          const minCandidate = q1 - iqr * 1.5;
-
-          if (maxCandidate < maxValue) {
-            maxValue = maxCandidate;
-            clipHigh = true;
-            select(`#${axis}-high-clip`).style('visibility', 'visible');
-            select(`#${axis}-high-clip > text`).text(`> ${maxCandidate}`);
-          }
-
-          if (minCandidate > minValue) {
-            minValue = minCandidate;
-            clipLow = true;
-            select(`#${axis}-low-clip`).style('visibility', 'visible');
-            select(`#${axis}-low-clip > text`).text(`< ${minCandidate}`);
-          }
-        }
-
-        positionScale = scaleLinear()
-          .domain([minValue, maxValue]);
-      } else {
-        positionScale = scaleBand()
-          .domain(range.binLabels);
-      }
-
-      if (axis === 'x') {
-        const minMax = [clipLow ? yAxisPadding + clipRegionSize : yAxisPadding, clipHigh ? store.state.svgDimensions.width - clipRegionSize : store.state.svgDimensions.width];
-        positionScale = positionScale
-          .range(minMax);
-      } else {
-        const minMax = [clipLow ? store.state.svgDimensions.height - xAxisPadding - clipRegionSize : store.state.svgDimensions.height - xAxisPadding, clipHigh ? clipRegionSize : 0];
-        positionScale = positionScale
-          .range(minMax);
-      }
-
-      const otherAxis = axis === 'x' ? 'y' : 'x';
-
-      if (varName !== null) {
-      // Set node size smaller
-        store.commit.setMarkerSize({ markerSize: 10, updateProv: true });
-
-        // Clear the label variable
-        store.commit.setLabelVariable(undefined);
-
-        if (store.state.network !== null && store.state.columnTypes !== null) {
-          const otherAxisPadding = axis === 'x' ? 80 : 60;
-
-          if (type === 'number') {
-            const scaleDomain = positionScale.domain();
-            const scaleRange = positionScale.range();
-            store.state.network.nodes.forEach((node) => {
-              const nodeVal = node[varName];
-              let position = positionScale(nodeVal);
-
-              if (axis === 'x') {
-                position = nodeVal > scaleDomain[1] ? scaleRange[1] + ((clipRegionSize - 10) * ((nodeVal - scaleDomain[1]) / (range.max - 1 - scaleDomain[1]))) : position;
-                position = nodeVal < scaleDomain[0] ? scaleRange[0] - ((clipRegionSize - 10) * ((scaleDomain[0] - nodeVal) / (scaleDomain[0] - range.min))) : position;
-              } else {
-                position = nodeVal > scaleDomain[1] ? scaleRange[1] - ((clipRegionSize - 10) * ((nodeVal - scaleDomain[1]) / (range.max - 1 - scaleDomain[1]))) : position;
-                position = nodeVal < scaleDomain[0] ? scaleRange[0] + ((clipRegionSize - 10) * ((scaleDomain[0] - nodeVal) / (scaleDomain[0] - range.min))) : position;
-              }
-              position -= (markerSize.value / 2);
-
-              // eslint-disable-next-line no-param-reassign
-              node[axis] = position;
-              // eslint-disable-next-line no-param-reassign
-              node[`f${axis}`] = position;
-
-              if (store.state.layoutVars[otherAxis] === null) {
-                const otherSvgDimension = axis === 'x' ? store.state.svgDimensions.height : store.state.svgDimensions.width;
-                // eslint-disable-next-line no-param-reassign
-                node[otherAxis] = otherSvgDimension / 2;
-                // eslint-disable-next-line no-param-reassign
-                node[`f${otherAxis}`] = otherSvgDimension / 2;
-              }
-            });
-          } else {
-            let positionOffset: number;
-
-            if (axis === 'x') {
-              positionOffset = (store.state.svgDimensions.width - otherAxisPadding) / ((range.binLabels.length) * 2);
-            } else {
-              positionOffset = ((store.state.svgDimensions.height - xAxisPadding) / ((range.binLabels.length) * 2)) - 10;
-            }
-
-            const force = axis === 'x' ? forceX<Node>((d) => positionScale(d[varName]) + positionOffset).strength(2) : forceY<Node>((d) => positionScale(d[varName]) + positionOffset).strength(2);
-            applyForceToSimulation(
-              store.state.simulation,
-              axis,
-              force,
-            );
-            applyForceToSimulation(
-              store.state.simulation,
-              'edge',
-              forceLink<Node, SimulationEdge>(),
-            );
-            applyForceToSimulation(
-              store.state.simulation,
-              'charge',
-              forceManyBody<Node>(),
-            );
-            store.commit.startSimulation();
-          }
-        }
-      } else if (store.state.layoutVars[otherAxis] === null) {
-        store.dispatch.releaseNodes();
-      }
-
-      return positionScale;
-    }
-
-    function resetAxesClipRegions() {
-      select('#axes').selectAll('g').remove();
-
-      select('#x-low-clip').style('visibility', 'hidden');
-      select('#x-high-clip').style('visibility', 'hidden');
-      select('#y-low-clip').style('visibility', 'hidden');
-      select('#y-high-clip').style('visibility', 'hidden');
-    }
-
-    watch(layoutVars, () => {
-      resetAxesClipRegions();
-      resetSimulationForces();
-
-      // Add x layout
-      if (store.state.columnTypes !== null && layoutVars.value.x !== null) {
-        const type = store.state.columnTypes[layoutVars.value.x];
-        const range = store.state.attributeRanges[layoutVars.value.x];
-
-        const positionScale = makePositionScale('x', type, range);
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const xAxis = axisBottom(positionScale as any);
-        const axisGroup = select('#axes')
-          .append('g');
-
-        // Add the axis
-        axisGroup
-          .attr('transform', `translate(0, ${svgDimensions.value.height - xAxisPadding})`)
-          .call(xAxis);
-
-        // Add the axis label
-        const labelGroup = axisGroup
-          .append('g');
-
-        const label = labelGroup
-          .append('text')
-          .text(layoutVars.value.x)
-          .attr('fill', 'currentColor')
-          .attr('font-size', '14px')
-          .attr('font-weight', 'bold')
-          .attr('x', ((store.state.svgDimensions.width - yAxisPadding) / 2) + yAxisPadding)
-          .attr('y', xAxisPadding - 20);
-
-        const labelRectPos = (label.node() as SVGTextElement).getBBox();
-        labelGroup
-          .insert('rect', 'text')
-          .attr('x', labelRectPos.x)
-          .attr('y', labelRectPos.y)
-          .attr('width', labelRectPos.width)
-          .attr('height', labelRectPos.height)
-          .attr('fill', 'white');
-      }
-
-      // Add y layout
-      if (store.state.columnTypes !== null && layoutVars.value.y !== null) {
-        const type = store.state.columnTypes[layoutVars.value.y];
-        const range = store.state.attributeRanges[layoutVars.value.y];
-
-        const positionScale = makePositionScale('y', type, range);
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const yAxis = axisLeft(positionScale as any);
-        const axisGroup = select('#axes')
-          .append('g');
-
-        // Add the axis
-        axisGroup
-          .attr('transform', `translate(${yAxisPadding}, 0)`)
-          .call(yAxis);
-
-        // Add the axis label
-        const labelGroup = axisGroup
-          .append('g')
-          .attr('transform', 'rotate(90)');
-
-        const label = labelGroup
-          .append('text')
-          .text(layoutVars.value.y)
-          .attr('fill', 'currentColor')
-          .attr('font-size', '14px')
-          .attr('font-weight', 'bold')
-          .attr('text-anchor', 'middle')
-          .attr('x', ((store.state.svgDimensions.height - xAxisPadding - 10) / 2) + 10)
-          .attr('y', yAxisPadding - 20);
-
-        const labelRectPos = (label.node() as SVGTextElement).getBBox();
-        labelGroup
-          .insert('rect', 'text')
-          .attr('x', labelRectPos.x)
-          .attr('y', labelRectPos.y)
-          .attr('width', labelRectPos.width)
-          .attr('height', labelRectPos.height)
-          .attr('fill', 'white');
-      }
-    });
-
-    onMounted(() => {
-      if (network.value !== null && simulationEdges.value !== null) {
-        // Make the simulation
-        const simulation = forceSimulation<Node, SimulationEdge>(network.value.nodes)
-          .on('tick', () => {
-            if (currentInstance !== null) {
-              currentInstance.proxy.$forceUpdate();
-            }
-          })
-        // The next line handles the start stop button change in the controls.
-        // It's not explicitly necessary for the simulation to work
-          .on('end', () => {
-            store.commit.stopSimulation();
-          });
-
-        store.commit.setSimulation(simulation);
-        resetSimulationForces(); // Initialize simulation forces
         store.commit.startSimulation();
-        resetAxesClipRegions();
       }
-    });
+    }
+  } else if (store.state.layoutVars[otherAxis] === null) {
+    store.dispatch.releaseNodes();
+  }
 
-    return {
-      svg,
-      svgDimensions,
-      rectSelect,
-      network,
-      edgeGroupClass,
-      edgeStyle,
-      arcPath,
-      directionalEdges,
-      nodeGroupClass,
-      nodeTranslate,
-      nodeClass,
-      rectSelectDrag,
-      showContextMenu,
-      calculateNodeSize,
-      nodeFill,
-      toggleTooltip,
-      displayCharts,
-      showTooltip,
-      hideTooltip,
-      nodeTextStyle,
-      labelVariable,
-      tooltipStyle,
-      tooltipMessage,
-      dragNode,
-      nestedVariables,
-      attributeScales,
-      nestedBarWidth,
-      nestedBarHeight,
-      nestedPadding,
-      nodeBarColorScale,
-      glyphFill,
-      clipRegionSize,
-      xAxisPadding,
-      yAxisPadding,
-    };
-  },
+  return positionScale;
+}
+
+function resetAxesClipRegions() {
+  select('#axes').selectAll('g').remove();
+
+  select('#x-low-clip').style('visibility', 'hidden');
+  select('#x-high-clip').style('visibility', 'hidden');
+  select('#y-low-clip').style('visibility', 'hidden');
+  select('#y-high-clip').style('visibility', 'hidden');
+}
+
+watch(layoutVars, () => {
+  resetAxesClipRegions();
+  resetSimulationForces();
+
+  // Add x layout
+  if (store.state.columnTypes !== null && layoutVars.value.x !== null) {
+    const type = store.state.columnTypes[layoutVars.value.x];
+    const range = store.state.attributeRanges[layoutVars.value.x];
+
+    const positionScale = makePositionScale('x', type, range);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const xAxis = axisBottom(positionScale as any);
+    const axisGroup = select('#axes')
+      .append('g');
+
+    // Add the axis
+    axisGroup
+      .attr('transform', `translate(0, ${svgDimensions.value.height - xAxisPadding})`)
+      .call(xAxis);
+
+    // Add the axis label
+    const labelGroup = axisGroup
+      .append('g');
+
+    const label = labelGroup
+      .append('text')
+      .text(layoutVars.value.x)
+      .attr('fill', 'currentColor')
+      .attr('font-size', '14px')
+      .attr('font-weight', 'bold')
+      .attr('x', ((store.state.svgDimensions.width - yAxisPadding) / 2) + yAxisPadding)
+      .attr('y', xAxisPadding - 20);
+
+    const labelRectPos = (label.node() as SVGTextElement).getBBox();
+    labelGroup
+      .insert('rect', 'text')
+      .attr('x', labelRectPos.x)
+      .attr('y', labelRectPos.y)
+      .attr('width', labelRectPos.width)
+      .attr('height', labelRectPos.height)
+      .attr('fill', 'white');
+  }
+
+  // Add y layout
+  if (store.state.columnTypes !== null && layoutVars.value.y !== null) {
+    const type = store.state.columnTypes[layoutVars.value.y];
+    const range = store.state.attributeRanges[layoutVars.value.y];
+
+    const positionScale = makePositionScale('y', type, range);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const yAxis = axisLeft(positionScale as any);
+    const axisGroup = select('#axes')
+      .append('g');
+
+    // Add the axis
+    axisGroup
+      .attr('transform', `translate(${yAxisPadding}, 0)`)
+      .call(yAxis);
+
+    // Add the axis label
+    const labelGroup = axisGroup
+      .append('g')
+      .attr('transform', 'rotate(90)');
+
+    const label = labelGroup
+      .append('text')
+      .text(layoutVars.value.y)
+      .attr('fill', 'currentColor')
+      .attr('font-size', '14px')
+      .attr('font-weight', 'bold')
+      .attr('text-anchor', 'middle')
+      .attr('x', ((store.state.svgDimensions.height - xAxisPadding - 10) / 2) + 10)
+      .attr('y', yAxisPadding - 20);
+
+    const labelRectPos = (label.node() as SVGTextElement).getBBox();
+    labelGroup
+      .insert('rect', 'text')
+      .attr('x', labelRectPos.x)
+      .attr('y', labelRectPos.y)
+      .attr('width', labelRectPos.width)
+      .attr('height', labelRectPos.height)
+      .attr('fill', 'white');
+  }
+});
+
+onMounted(() => {
+  if (network.value !== null && simulationEdges.value !== null) {
+    // Make the simulation
+    const simulation = forceSimulation<Node, SimulationEdge>(network.value.nodes)
+      .on('tick', () => {
+        if (currentInstance !== null) {
+          currentInstance.proxy.$forceUpdate();
+        }
+      })
+    // The next line handles the start stop button change in the controls.
+    // It's not explicitly necessary for the simulation to work
+      .on('end', () => {
+        store.commit.stopSimulation();
+      });
+
+    store.commit.setSimulation(simulation);
+    resetSimulationForces(); // Initialize simulation forces
+    store.commit.startSimulation();
+    resetAxesClipRegions();
+  }
 });
 </script>
 

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -25,7 +25,7 @@ import { ColumnType } from 'multinet';
 // Commonly used variables
 const currentInstance = getCurrentInstance();
 const network = computed(() => store.state.network);
-const svg: Ref<Element | null> = ref(null);
+const multiLinkSvg: Ref<Element | null> = ref(null);
 const selectedNodes = computed(() => store.state.selectedNodes);
 const nodeBarColorScale = computed(() => store.state.nodeBarColorScale);
 const nodeTextStyle = computed(() => `font-size: ${store.state.fontSize || 0}pt;`);
@@ -135,8 +135,8 @@ function dragNode(node: Node, event: MouseEvent) {
     return;
   }
 
-  if (!(svg.value instanceof Element)) {
-    throw new Error('SVG is not of type Element');
+  if (!(multiLinkSvg.value instanceof Element)) {
+    throw new Error('multiLinkSvg is not of type Element');
   }
 
   event.stopPropagation();
@@ -190,11 +190,11 @@ function dragNode(node: Node, event: MouseEvent) {
   };
 
   const stopFn = (evt: Event) => {
-    if (!(svg.value instanceof Element)) {
-      throw new Error('SVG is not of type Element');
+    if (!(multiLinkSvg.value instanceof Element)) {
+      throw new Error('multiLinkSvg is not of type Element');
     }
-    svg.value.removeEventListener('mousemove', moveFn);
-    svg.value.removeEventListener('mouseup', stopFn);
+    multiLinkSvg.value.removeEventListener('mousemove', moveFn);
+    multiLinkSvg.value.removeEventListener('mouseup', stopFn);
 
     // Check we have a mouse event
     if (!(evt instanceof MouseEvent)) {
@@ -211,8 +211,8 @@ function dragNode(node: Node, event: MouseEvent) {
     }
   };
 
-  svg.value.addEventListener('mousemove', moveFn);
-  svg.value.addEventListener('mouseup', stopFn);
+  multiLinkSvg.value.addEventListener('mousemove', moveFn);
+  multiLinkSvg.value.addEventListener('mouseup', stopFn);
 }
 
 const tooltipMessage = ref('');
@@ -484,11 +484,11 @@ function rectSelectDrag(event: MouseEvent) {
     store.commit.addSelectedNode(nodesInRect.map((node) => node._id));
 
     // Remove the listeners so that the box stops updating location
-    if (!(svg.value instanceof Element)) {
-      throw new Error('SVG is not of type Element');
+    if (!(multiLinkSvg.value instanceof Element)) {
+      throw new Error('multiLinkSvg is not of type Element');
     }
-    svg.value.removeEventListener('mousemove', moveFn);
-    svg.value.removeEventListener('mouseup', stopFn);
+    multiLinkSvg.value.removeEventListener('mousemove', moveFn);
+    multiLinkSvg.value.removeEventListener('mouseup', stopFn);
 
     // Remove the selection box
     rectSelect.value = {
@@ -501,11 +501,11 @@ function rectSelectDrag(event: MouseEvent) {
     };
   };
 
-  if (!(svg.value instanceof Element)) {
-    throw new Error('SVG is not of type Element');
+  if (!(multiLinkSvg.value instanceof Element)) {
+    throw new Error('multiLinkSvg is not of type Element');
   }
-  svg.value.addEventListener('mousemove', moveFn);
-  svg.value.addEventListener('mouseup', stopFn);
+  multiLinkSvg.value.addEventListener('mousemove', moveFn);
+  multiLinkSvg.value.addEventListener('mouseup', stopFn);
 }
 
 function showContextMenu(event: MouseEvent) {
@@ -858,7 +858,7 @@ onMounted(() => {
 <template>
   <div>
     <svg
-      ref="svg"
+      ref="multiLinkSvg"
       :width="svgDimensions.width"
       :height="svgDimensions.height"
       @mousedown="rectSelectDrag"

--- a/src/components/ProvVis.vue
+++ b/src/components/ProvVis.vue
@@ -3,7 +3,7 @@ import { ProvVisCreator } from '@visdesignlab/trrack-vis';
 import { ProvenanceEventTypes, State } from '@/types';
 import {
   computed, ComputedRef, defineComponent, onMounted,
-} from '@vue/composition-api';
+} from 'vue';
 import store from '@/store';
 import { Provenance } from '@visdesignlab/trrack';
 

--- a/src/components/ProvVis.vue
+++ b/src/components/ProvVis.vue
@@ -1,38 +1,22 @@
-<script lang="ts">
+<script setup lang="ts">
 import { ProvVisCreator } from '@visdesignlab/trrack-vis';
-import { ProvenanceEventTypes, State } from '@/types';
-import {
-  computed, ComputedRef, defineComponent, onMounted,
-} from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import store from '@/store';
-import { Provenance } from '@visdesignlab/trrack';
 
-export default defineComponent({
-  setup() {
-    const provenance: ComputedRef<Provenance<State, ProvenanceEventTypes, unknown> | null> = computed(
-      () => store.state.provenance,
+const provenance = computed(() => store.state.provenance);
+const provDiv = ref();
+
+onMounted(() => {
+  if (provenance.value !== null && provDiv.value != null) {
+    ProvVisCreator(
+      provDiv.value,
+      provenance.value,
+      (newNode: string) => store.commit.goToProvenanceNode(newNode),
+      true,
+      true,
+      provenance.value.root.id,
     );
-
-    onMounted(() => {
-      const provDiv = document.getElementById('provDiv');
-      if (provenance.value !== null && provDiv != null) {
-        ProvVisCreator(
-          provDiv,
-          provenance.value,
-          (newNode: string) => store.commit.goToProvenanceNode(newNode),
-          true,
-          true,
-          provenance.value.root.id,
-        );
-      }
-    });
-
-    function toggleProvVis() {
-      store.commit.toggleShowProvenanceVis();
-    }
-
-    return { toggleProvVis };
-  },
+  }
 });
 </script>
 
@@ -46,17 +30,20 @@ export default defineComponent({
     <v-btn
       icon
       class="ma-2"
-      @click="toggleProvVis"
+      @click="store.commit.toggleShowProvenanceVis"
     >
       <v-icon>mdi-close</v-icon>
     </v-btn>
 
-    <div id="provDiv" />
+    <div
+      id="provDiv"
+      ref="provDiv"
+    />
   </v-navigation-drawer>
 </template>
 
 <style scoped>
-#provDiv >>> .secondary {
+#provDiv :deep(.secondary) {
   /* Unset vuetify colors for secondary */
   background-color: unset !important;
   border-color: white !important;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,10 @@
 import Vue from 'vue';
 import App from '@/App.vue';
-import VueCompositionApi from '@vue/composition-api';
 import vuetify from '@/plugins/vuetify';
 import api from '@/api';
 import oauthClient from '@/oauth';
 
 Vue.config.productionTip = false;
-Vue.use(VueCompositionApi);
 
 oauthClient.maybeRestoreLogin().then(() => {
   Object.assign(api.axios.defaults.headers.common, oauthClient.authHeaders);

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+  import Vue from 'vue';
+
+  export default Vue;
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -351,7 +351,8 @@ const {
       // Get all table names
       try {
         network = await api.network(workspaceName, networkName);
-      } catch (error) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (error: any) {
         if (error.status === 404) {
           if (workspaceName === undefined || networkName === undefined) {
             commit.setLoadError({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
     "sourceMap": true,
     "baseUrl": ".",
     "types": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "skipLibCheck": true,
     "sourceMap": true,
     "baseUrl": ".",
     "types": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -16158,10 +16158,10 @@ typedoc@^0.19.2:
     shelljs "^0.8.4"
     typedoc-default-themes "^0.11.4"
 
-typescript@^3.6.3:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.0.0:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 typestyle@^2.0.4:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,15 @@
 # yarn lockfile v1
 
 
+"@achrinza/node-ipc@9.2.2":
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/@achrinza/node-ipc/-/node-ipc-9.2.2.tgz#ae1b5d3d6a9362034eea60c8d946b93893c2e4ec"
+  integrity sha512-b90U39dx0cU6emsOvy5hxU4ApNXnE3+Tuo8XQZfiKTGelDwpMwBVgBP7QX6dGTcJgu/miyJuNJ/2naFBliNWEw==
+  dependencies:
+    "@node-ipc/js-queue" "2.0.3"
+    event-pubsub "4.3.0"
+    js-message "1.0.7"
+
 "@achrinza/node-ipc@^9.2.5":
   version "9.2.5"
   resolved "https://registry.yarnpkg.com/@achrinza/node-ipc/-/node-ipc-9.2.5.tgz#29788e608ff41121f0543491da723b243266ac28"
@@ -517,6 +526,11 @@
   version "7.14.1"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.1.tgz#1bd644b5db3f5797c4479d89ec1817fe02b84c47"
   integrity sha512-muUGEKu8E/ftMTPlNp+mc6zL3E9zKWmF5sDHZ5MSsoTP9Wyz64AhEf9kD08xYJ7w6Hdcu8H550ircnPyWSIF0Q==
+
+"@babel/parser@^7.18.4":
+  version "7.18.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.8.tgz#822146080ac9c62dac0823bb3489622e0bc1cbdf"
+  integrity sha512-RSKRfYX20dyH+elbJK2uqAkVyucL+xXzhqlMD5/ZXx+dAAwpyB7HsvnHe/ZUGOF+xLr5Wx9/JoXVTj6BQE2/oA==
 
 "@babel/parser@^7.18.6", "@babel/parser@^7.7.0":
   version "7.18.6"
@@ -3630,13 +3644,6 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz#c893b73721db73699943bfc3653b1deb7faa4a3a"
   integrity sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==
 
-"@types/mini-css-extract-plugin@^0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@types/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.1.tgz#d4bdde5197326fca039d418f4bdda03dc74dc451"
-  integrity sha512-+mN04Oszdz9tGjUP/c1ReVwJXxSniLd7lF++sv+8dkABxVNthg6uccei+4ssKxRHGoMmPxdn7uBdJWONSJGTGQ==
-  dependencies:
-    "@types/webpack" "*"
-
 "@types/minimatch@*":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"
@@ -4067,10 +4074,10 @@
     "@vue/babel-plugin-transform-vue-jsx" "^1.1.2"
     camelcase "^5.0.0"
 
-"@vue/cli-overlay@^4.5.3":
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/@vue/cli-overlay/-/cli-overlay-4.5.3.tgz#5937a232c613e5019868ce090b7c3e5d9e5ae473"
-  integrity sha512-CHIiZEZlcb2HlZNIU6ZgNfTysNZWokQGzStfrCrQMXUXG0ffBRoi8K/kXNox2HxSfrT1Swi4NqREdPXefZJgNQ==
+"@vue/cli-overlay@^4.5.19":
+  version "4.5.19"
+  resolved "https://registry.yarnpkg.com/@vue/cli-overlay/-/cli-overlay-4.5.19.tgz#d1206f7802bcba1d9c307695b54091df996db804"
+  integrity sha512-GdxvNSmOw7NHIazCO8gTK+xZbaOmScTtxj6eHVeMbYpDYVPJ+th3VMLWNpw/b6uOjwzzcyKlA5dRQ1DAb+gF/g==
 
 "@vue/cli-plugin-babel@^4.1.0":
   version "4.5.3"
@@ -4096,12 +4103,12 @@
     webpack "^5.54.0"
     yorkie "^2.0.0"
 
-"@vue/cli-plugin-router@^4.5.3":
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/@vue/cli-plugin-router/-/cli-plugin-router-4.5.3.tgz#32c73d6b68b1d2b0d945dcc9be3ceb15e1d7fd52"
-  integrity sha512-e0EqfwY4AGar1SX3rqD58QMoMYIxRD0AUauNiwSmuGjyA0Fr4Lfl1gBEPDCMZ5jIsO/4QNBateQGUy1S/GlxAw==
+"@vue/cli-plugin-router@^4.5.19":
+  version "4.5.19"
+  resolved "https://registry.yarnpkg.com/@vue/cli-plugin-router/-/cli-plugin-router-4.5.19.tgz#a7feea7024b83a0af77fc940d1637d3ce2f92e1f"
+  integrity sha512-3icGzH1IbVYmMMsOwYa0lal/gtvZLebFXdE5hcQJo2mnTwngXGMTyYAzL56EgHBPjbMmRpyj6Iw9k4aVInVX6A==
   dependencies:
-    "@vue/cli-shared-utils" "^4.5.3"
+    "@vue/cli-shared-utils" "^4.5.19"
 
 "@vue/cli-plugin-typescript@^3.11.0":
   version "3.12.1"
@@ -4138,15 +4145,15 @@
     ts-jest "^24.2.0"
     vue-jest "^3.0.5"
 
-"@vue/cli-plugin-vuex@^4.5.3":
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/@vue/cli-plugin-vuex/-/cli-plugin-vuex-4.5.3.tgz#c0a566b0156e5bbbcc41e8cec195bc683aca7f5c"
-  integrity sha512-23AAuaVbng6OUc5l7VHEGqCNiL1g1BsZL99X1rvKRttjDpdIYHtQAFsXjcTFitGpHRWoA9dgeujj/MkBPa1TcA==
+"@vue/cli-plugin-vuex@^4.5.19":
+  version "4.5.19"
+  resolved "https://registry.yarnpkg.com/@vue/cli-plugin-vuex/-/cli-plugin-vuex-4.5.19.tgz#2452de58eb66ed873852bea45e6e06b57d842b47"
+  integrity sha512-DUmfdkG3pCdkP7Iznd87RfE9Qm42mgp2hcrNcYQYSru1W1gX2dG/JcW8bxmeGSa06lsxi9LEIc/QD1yPajSCZw==
 
-"@vue/cli-service@^4.1.0":
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/@vue/cli-service/-/cli-service-4.5.3.tgz#4cf269a86d3d78c0568ed77908c18e9b970ad2ff"
-  integrity sha512-AufXUW+n8Wh9pqJu1v9Uh+6Sx6HdDrRopHMhUB/FrXhLFFPXRDo+s9zFC5QuJSt+roR0oBwmAp/x6KvBFQosIQ==
+"@vue/cli-service@^4.5.18":
+  version "4.5.19"
+  resolved "https://registry.yarnpkg.com/@vue/cli-service/-/cli-service-4.5.19.tgz#5f6513128f426be0ee9a7d03155c23a6f23f8d42"
+  integrity sha512-+Wpvj8fMTCt9ZPOLu5YaLkFCQmB4MrZ26aRmhhKiCQ/4PMoL6mLezfqdt6c+m2htM+1WV5RunRo+0WHl2DfwZA==
   dependencies:
     "@intervolga/optimize-cssnano-plugin" "^1.0.5"
     "@soda/friendly-errors-webpack-plugin" "^1.7.1"
@@ -4154,10 +4161,10 @@
     "@types/minimist" "^1.2.0"
     "@types/webpack" "^4.0.0"
     "@types/webpack-dev-server" "^3.11.0"
-    "@vue/cli-overlay" "^4.5.3"
-    "@vue/cli-plugin-router" "^4.5.3"
-    "@vue/cli-plugin-vuex" "^4.5.3"
-    "@vue/cli-shared-utils" "^4.5.3"
+    "@vue/cli-overlay" "^4.5.19"
+    "@vue/cli-plugin-router" "^4.5.19"
+    "@vue/cli-plugin-vuex" "^4.5.19"
+    "@vue/cli-shared-utils" "^4.5.19"
     "@vue/component-compiler-utils" "^3.1.2"
     "@vue/preload-webpack-plugin" "^1.1.0"
     "@vue/web-component-wrapper" "^1.2.0"
@@ -4192,8 +4199,8 @@
     pnp-webpack-plugin "^1.6.4"
     portfinder "^1.0.26"
     postcss-loader "^3.0.0"
-    ssri "^7.1.0"
-    terser-webpack-plugin "^2.3.6"
+    ssri "^8.0.1"
+    terser-webpack-plugin "^1.4.4"
     thread-loader "^2.1.3"
     url-loader "^2.2.0"
     vue-loader "^15.9.2"
@@ -4204,7 +4211,7 @@
     webpack-dev-server "^3.11.0"
     webpack-merge "^4.2.2"
   optionalDependencies:
-    vue-loader-v16 "npm:vue-loader@^16.0.0-beta.3"
+    vue-loader-v16 "npm:vue-loader@^16.1.0"
 
 "@vue/cli-shared-utils@^3.12.1":
   version "3.12.1"
@@ -4223,6 +4230,24 @@
     request-promise-native "^1.0.7"
     semver "^6.0.0"
     string.prototype.padstart "^3.0.0"
+
+"@vue/cli-shared-utils@^4.5.19":
+  version "4.5.19"
+  resolved "https://registry.yarnpkg.com/@vue/cli-shared-utils/-/cli-shared-utils-4.5.19.tgz#cc389b1de1b05073804c0fe9b4b083b928ef6130"
+  integrity sha512-JYpdsrC/d9elerKxbEUtmSSU6QRM60rirVubOewECHkBHj+tLNznWq/EhCjswywtePyLaMUK25eTqnTSZlEE+g==
+  dependencies:
+    "@achrinza/node-ipc" "9.2.2"
+    "@hapi/joi" "^15.0.1"
+    chalk "^2.4.2"
+    execa "^1.0.0"
+    launch-editor "^2.2.1"
+    lru-cache "^5.1.1"
+    open "^6.3.0"
+    ora "^3.4.0"
+    read-pkg "^5.1.1"
+    request "^2.88.2"
+    semver "^6.1.0"
+    strip-ansi "^6.0.0"
 
 "@vue/cli-shared-utils@^4.5.3":
   version "4.5.3"
@@ -4260,6 +4285,15 @@
     semver "^7.3.4"
     strip-ansi "^6.0.0"
 
+"@vue/compiler-sfc@2.7.4":
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-2.7.4.tgz#41cb520a3ea65f7081194e79c0de412c75bda236"
+  integrity sha512-WCaF33mlKLSvHDKvOD6FzTa5CI2FlMTeJf3MxJsNP0KDgRoI6RdXhHo9dtvCqV4Sywf9Owm17wTLT1Ymu/WsOQ==
+  dependencies:
+    "@babel/parser" "^7.18.4"
+    postcss "^8.4.14"
+    source-map "^0.6.1"
+
 "@vue/component-compiler-utils@^3.1.0", "@vue/component-compiler-utils@^3.1.2":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@vue/component-compiler-utils/-/component-compiler-utils-3.2.0.tgz#8f85182ceed28e9b3c75313de669f83166d11e5d"
@@ -4275,13 +4309,6 @@
     vue-template-es2015-compiler "^1.9.0"
   optionalDependencies:
     prettier "^1.18.2"
-
-"@vue/composition-api@^1.0.0-beta.22":
-  version "1.0.0-beta.22"
-  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.0.0-beta.22.tgz#8b0046bda138820c6d79c91dc961839a52d853c7"
-  integrity sha512-KkTeHVWgsJbtoA5t6pUien/ARw7JhVM7QZh05ko/UdgzALYMGwJsBf4WlcvbpMKE5eAu4ONYJypQ+r8LwBIOhA==
-  dependencies:
-    tslib "^2.0.1"
 
 "@vue/eslint-config-airbnb@^6.0.0":
   version "6.0.0"
@@ -4307,14 +4334,10 @@
   resolved "https://registry.yarnpkg.com/@vue/preload-webpack-plugin/-/preload-webpack-plugin-1.1.2.tgz#ceb924b4ecb3b9c43871c7a429a02f8423e621ab"
   integrity sha512-LIZMuJk38pk9U9Ur4YzHjlIyMuxPlACdBIHH9/nGYVTsaGKOSnSuELiE8vS9wa+dJpIYspYUOqk+L1Q4pgHQHQ==
 
-"@vue/test-utils@^1.0.0-beta.30":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.3.tgz#587c4dd9b424b66022f188c19bc605da2ce91c6f"
-  integrity sha512-mmsKXZSGfvd0bH05l4SNuczZ2MqlJH2DWhiul5wJXFxbf/gRRd2UL4QZgozEMQ30mRi9i4/+p4JJat8S4Js64Q==
-  dependencies:
-    dom-event-types "^1.0.0"
-    lodash "^4.17.15"
-    pretty "^2.0.0"
+"@vue/test-utils@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.0.2.tgz#0b5edd683366153d5bc5a91edc62f292118710eb"
+  integrity sha512-E2P4oXSaWDqTZNbmKZFVLrNN/siVN78YkEqs7pHryWerrlZR9bBFLWdJwRoguX45Ru6HxIflzKl4vQvwRMwm5g==
 
 "@vue/web-component-wrapper@^1.2.0":
   version "1.2.0"
@@ -5820,30 +5843,6 @@ cacache@^12.0.2, cacache@^12.0.3:
     unique-filename "^1.1.1"
     y18n "^4.0.0"
 
-cacache@^13.0.1:
-  version "13.0.1"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-13.0.1.tgz#a8000c21697089082f85287a1aec6e382024a71c"
-  integrity sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==
-  dependencies:
-    chownr "^1.1.2"
-    figgy-pudding "^3.5.1"
-    fs-minipass "^2.0.0"
-    glob "^7.1.4"
-    graceful-fs "^4.2.2"
-    infer-owner "^1.0.4"
-    lru-cache "^5.1.1"
-    minipass "^3.0.0"
-    minipass-collect "^1.0.2"
-    minipass-flush "^1.0.5"
-    minipass-pipeline "^1.2.2"
-    mkdirp "^0.5.1"
-    move-concurrently "^1.0.1"
-    p-map "^3.0.0"
-    promise-inflight "^1.0.1"
-    rimraf "^2.7.1"
-    ssri "^7.0.0"
-    unique-filename "^1.1.1"
-
 cacache@^15.0.5:
   version "15.0.6"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.0.6.tgz#65a8c580fda15b59150fb76bf3f3a8e45d583099"
@@ -6107,7 +6106,7 @@ chokidar@^3.4.1, chokidar@^3.4.2:
   optionalDependencies:
     fsevents "~2.3.1"
 
-chownr@^1.1.1, chownr@^1.1.2:
+chownr@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
@@ -6965,6 +6964,11 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
   integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
 
+csstype@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
+  integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
+
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
@@ -7359,7 +7363,7 @@ data-urls@^1.0.0, data-urls@^1.1.0:
 de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
-  integrity sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=
+  integrity sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==
 
 deasync@^0.1.15:
   version "0.1.20"
@@ -7677,11 +7681,6 @@ dom-converter@^0.2:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
-
-dom-event-types@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/dom-event-types/-/dom-event-types-1.0.0.tgz#5830a0a29e1bf837fe50a70cd80a597232813cae"
-  integrity sha512-2G2Vwi2zXTHBGqXHsJ4+ak/iP0N8Ar+G8a7LiD2oup5o4sQWytwqqrZu/O6hIMV0KMID2PL69OhpshLO0n7UJQ==
 
 dom-serializer@0:
   version "0.2.2"
@@ -9429,11 +9428,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
-graceful-fs@^4.2.2:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
-  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
-
 graceful-fs@^4.2.4:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
@@ -9636,7 +9630,7 @@ hastscript@^6.0.0:
     property-information "^5.0.0"
     space-separated-tokens "^1.0.0"
 
-he@1.2.x, he@^1.1.0, he@^1.2.0:
+he@1.2.x, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -11049,14 +11043,6 @@ jest-worker@^24.6.0, jest-worker@^24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
-jest-worker@^25.4.0:
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-25.5.0.tgz#2611d071b79cea0f43ee57a3d118593ac1547db1"
-  integrity sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==
-  dependencies:
-    merge-stream "^2.0.0"
-    supports-color "^7.0.0"
-
 jest-worker@^26.2.1:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
@@ -12183,6 +12169,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
+nanoid@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -12802,7 +12793,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0, p-limit@^2.2.0, p-limit@^2.2.1, p-limit@^2.3.0:
+p-limit@^2.0.0, p-limit@^2.2.0, p-limit@^2.2.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -13086,6 +13077,11 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.2.3"
@@ -13564,6 +13560,15 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.26, postcss@^7.0.2
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+postcss@^8.4.14:
+  version "8.4.14"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
+  integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
+  dependencies:
+    nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -13615,7 +13620,7 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
-pretty@2.0.0, pretty@^2.0.0:
+pretty@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pretty/-/pretty-2.0.0.tgz#adbc7960b7bbfe289a557dc5f737619a220d06a5"
   integrity sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=
@@ -13988,13 +13993,13 @@ react-docgen@^5.0.0:
     strip-indent "^3.0.0"
 
 react-dom@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
-  integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    scheduler "^0.20.1"
+    scheduler "^0.20.2"
 
 react-draggable@^4.4.3:
   version "4.4.3"
@@ -14115,9 +14120,9 @@ react-textarea-autosize@^8.3.0:
     use-latest "^1.0.0"
 
 react@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
-  integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -14531,7 +14536,7 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.3, rimraf@^2.7.1:
+rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -14656,10 +14661,10 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-scheduler@^0.20.1:
-  version "0.20.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.1.tgz#da0b907e24026b01181ecbc75efdc7f27b5a000c"
-  integrity sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -15091,6 +15096,11 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+
 source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
@@ -15225,14 +15235,6 @@ ssri@^6.0.1:
   integrity sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
   dependencies:
     figgy-pudding "^3.5.1"
-
-ssri@^7.0.0, ssri@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-7.1.0.tgz#92c241bf6de82365b5c7fb4bd76e975522e1294d"
-  integrity sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==
-  dependencies:
-    figgy-pudding "^3.5.1"
-    minipass "^3.1.1"
 
 ssri@^8.0.1:
   version "8.0.1"
@@ -15677,7 +15679,7 @@ term-size@^2.1.0:
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
   integrity sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==
 
-terser-webpack-plugin@^1.4.3:
+terser-webpack-plugin@^1.4.3, terser-webpack-plugin@^1.4.4:
   version "1.4.5"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz#a217aefaea330e734ffacb6120ec1fa312d6040b"
   integrity sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==
@@ -15691,21 +15693,6 @@ terser-webpack-plugin@^1.4.3:
     terser "^4.1.2"
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
-
-terser-webpack-plugin@^2.3.6:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-2.3.8.tgz#894764a19b0743f2f704e7c2a848c5283a696724"
-  integrity sha512-/fKw3R+hWyHfYx7Bv6oPqmk4HGQcrWLtV3X6ggvPuwPNHSnzvVV51z6OaaCOus4YLjutYGOz3pEpbhe6Up2s1w==
-  dependencies:
-    cacache "^13.0.1"
-    find-cache-dir "^3.3.1"
-    jest-worker "^25.4.0"
-    p-limit "^2.3.0"
-    schema-utils "^2.6.6"
-    serialize-javascript "^4.0.0"
-    source-map "^0.6.1"
-    terser "^4.6.12"
-    webpack-sources "^1.4.3"
 
 terser-webpack-plugin@^3.1.0:
   version "3.1.0"
@@ -15733,7 +15720,7 @@ terser-webpack-plugin@^5.1.3:
     serialize-javascript "^6.0.0"
     terser "^5.7.2"
 
-terser@^4.1.2, terser@^4.6.12, terser@^4.6.3, terser@^4.8.0:
+terser@^4.1.2, terser@^4.6.3, terser@^4.8.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
   integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
@@ -16519,22 +16506,19 @@ vue-jest@^3.0.5:
     tsconfig "^7.0.0"
     vue-template-es2015-compiler "^1.6.0"
 
-"vue-loader-v16@npm:vue-loader@^16.0.0-beta.3":
-  version "16.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-16.0.0-beta.5.tgz#04edc889492b03a445e7ac66e9226a70175ca8a0"
-  integrity sha512-ciWfzNefqWlmzKznCWY9hl+fPP4KlQ0A9MtHbJ/8DpyY+dAM8gDrjufIdxwTgC4szE4EZC3A6ip/BbrqM84GqA==
+"vue-loader-v16@npm:vue-loader@^16.1.0":
+  version "16.8.3"
+  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-16.8.3.tgz#d43e675def5ba9345d6c7f05914c13d861997087"
+  integrity sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==
   dependencies:
-    "@types/mini-css-extract-plugin" "^0.9.1"
-    chalk "^3.0.0"
+    chalk "^4.1.0"
     hash-sum "^2.0.0"
-    loader-utils "^1.2.3"
-    merge-source-map "^1.1.0"
-    source-map "^0.6.1"
+    loader-utils "^2.0.0"
 
 vue-loader@^15.9.2:
-  version "15.9.3"
-  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.9.3.tgz#0de35d9e555d3ed53969516cac5ce25531299dda"
-  integrity sha512-Y67VnGGgVLH5Voostx8JBZgPQTlDQeOVBLOEsjc2cXbCYBKexSKEpOA56x0YZofoDOTszrLnIShyOX1p9uCEHA==
+  version "15.10.0"
+  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-15.10.0.tgz#2a12695c421a2a2cc2138f05a949d04ed086e38b"
+  integrity sha512-VU6tuO8eKajrFeBzMssFUP9SvakEeeSi1BxdTH5o3+1yUyrldp8IERkSdXlMI2t4kxF2sqYUDsQY+WJBxzBmZg==
   dependencies:
     "@vue/component-compiler-utils" "^3.1.0"
     hash-sum "^1.0.2"
@@ -16550,23 +16534,26 @@ vue-style-loader@^4.1.0, vue-style-loader@^4.1.2:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@^2.6.10:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz#c04704ef8f498b153130018993e56309d4698080"
-  integrity sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==
+vue-template-compiler@^2.7.0:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.7.4.tgz#5c21ff12dbd8f53ac14b42a6d89e77b55a1c5dd7"
+  integrity sha512-FgaeXI80FzhtDEsixq3WBrHLWpU2gzLb2DFusm62TrmCQyETsnUp0kTLpbExrTUw7g5YOnRf+xkh73nuEX+jGQ==
   dependencies:
     de-indent "^1.0.2"
-    he "^1.1.0"
+    he "^1.2.0"
 
 vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue@^2.6.10:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"
-  integrity sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==
+vue@^2.7.0:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.7.4.tgz#f5578bd47f0cef8d4f3eb4c6bbebad47341d11fb"
+  integrity sha512-8KGyyzFSj/FrKj1y7jyEpv8J4osgZx6Lk1lVzh1aP4BqsXZhATH1r0gdJNz00MMyBhK0/m2cNoPuOZ1NzeiUEw==
+  dependencies:
+    "@vue/compiler-sfc" "2.7.4"
+    csstype "^3.1.0"
 
 vuetify-loader@^1.3.0:
   version "1.6.0"


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
This bumps the vue version to 2.7 and the typescript version to 4.7. 

The vue change will allow us to port some of the code to use the new vue 3 `<script setup>`, which will help remove some of the boilerplate. It will also get us to a better place for when we're finally able to migrate to vue 3.

The typescript bump should help us by making it so we don't have to fight with the type system so much. I have some type changes planned, so this will help me as I'm working with that.

There was a tricky issue that I had to fix where the `ref` was named `svg`, which was conflicting the mounting of the SVG elements in the template (they would be replaced by comments). The fix was to rename the `ref` that pointed to the multimatrix SVG element

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?

TODOs:
- [x] Make sure that everything builds as expected and works well
- [x] Move all components to `<script setup>`
- [x] Figure out the weird issue with multilink.vue and migrate that component
- [x] Check if we can leverage css v-bind