### PR TITLE
Use D3 on tick to set the position of the nodes back to the SVG

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
     'import/prefer-default-export': ['off'],
     'no-underscore-dangle': ['error', { allow: ['_id', '_from', '_to', '_key'] }],
     ...a11yOff,
+    'no-param-reassign': ['error', { props: false }],
   },
 
   parserOptions: {

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -10,9 +10,7 @@ function pinSelectedNodes() {
     network.value.nodes
       .filter((node) => selectedNodes.value.has(node._id))
       .forEach((node) => {
-        // eslint-disable-next-line no-param-reassign
         node.fx = node.x;
-        // eslint-disable-next-line no-param-reassign
         node.fy = node.y;
       });
   }
@@ -22,9 +20,7 @@ function unPinSelectedNodes() {
     network.value.nodes
       .filter((node) => selectedNodes.value.has(node._id))
       .forEach((node) => {
-        // eslint-disable-next-line no-param-reassign
         delete node.fx;
-        // eslint-disable-next-line no-param-reassign
         delete node.fy;
       });
   }

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -163,25 +163,17 @@ function dragNode(node: Node, event: MouseEvent) {
         network.value.nodes
           .filter((innerNode) => selectedNodes.value.has(innerNode._id) && innerNode._id !== node._id)
           .forEach((innerNode) => {
-            // eslint-disable-next-line no-param-reassign
             innerNode.x = (innerNode.x || 0) + dx;
-            // eslint-disable-next-line no-param-reassign
             innerNode.y = (innerNode.y || 0) + dy;
-            // eslint-disable-next-line no-param-reassign
             innerNode.fx = (innerNode.fx || innerNode.x || 0) + dx;
-            // eslint-disable-next-line no-param-reassign
             innerNode.fy = (innerNode.fy || innerNode.y || 0) + dy;
           });
       }
     }
 
-    // eslint-disable-next-line no-param-reassign
     node.x = eventX;
-    // eslint-disable-next-line no-param-reassign
     node.y = eventY;
-    // eslint-disable-next-line no-param-reassign
     node.fx = eventX;
-    // eslint-disable-next-line no-param-reassign
     node.fy = eventY;
 
     if (currentInstance !== null) {
@@ -255,9 +247,7 @@ function nodeTranslate(node: Node): string {
   if (forcedY > maximumY) { forcedY = maximumY; }
 
   // Update the node position with this forced position
-  // eslint-disable-next-line no-param-reassign
   node.x = forcedX;
-  // eslint-disable-next-line no-param-reassign
   node.y = forcedY;
 
   // Use the forced position, because the node.x is updated by simulation
@@ -522,9 +512,7 @@ function generateNodePositions(nodes: Node[]) {
   nodes.forEach((node) => {
     // If the position is not defined for x or y, generate it
     if (node.x === undefined || node.y === undefined) {
-      // eslint-disable-next-line no-param-reassign
       node.x = Math.random() * svgDimensions.value.width;
-      // eslint-disable-next-line no-param-reassign
       node.y = Math.random() * svgDimensions.value.height;
     }
   });
@@ -688,13 +676,10 @@ function makePositionScale(axis: 'x' | 'y', type: ColumnType, range: AttributeRa
           }
           position -= (markerSize.value / 2);
 
-          // eslint-disable-next-line no-param-reassign
           node[axis] = position;
-          // eslint-disable-next-line no-param-reassign
           node[`f${axis}`] = position;
 
           if (store.state.layoutVars[otherAxis] === null) {
-            // eslint-disable-next-line no-param-reassign
             node[`f${otherAxis}`] = undefined;
           }
         });

--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -788,18 +788,17 @@ watch(layoutVars, () => {
   }
 });
 
+const svgEdgePadding = 5;
+
+const minimumX = svgEdgePadding;
+const minimumY = svgEdgePadding;
+const maximumX = svgDimensions.value.width - svgEdgePadding;
+const maximumY = svgDimensions.value.height - svgEdgePadding;
 onMounted(() => {
   if (network.value !== null && simulationEdges.value !== null) {
     // Make the simulation
     const simulation = forceSimulation<Node, SimulationEdge>(network.value.nodes)
       .on('tick', () => {
-        const svgEdgePadding = 5;
-
-        const minimumX = svgEdgePadding;
-        const minimumY = svgEdgePadding;
-        const maximumX = svgDimensions.value.width - svgEdgePadding;
-        const maximumY = svgDimensions.value.height - svgEdgePadding;
-
         network.value?.nodes.forEach((node) => {
           if (node.x !== undefined && node.y !== undefined) {
             const maxX = maximumX - calculateNodeSize(node);

--- a/src/lib/provenanceUtils.ts
+++ b/src/lib/provenanceUtils.ts
@@ -2,8 +2,6 @@ import { ProvenanceEventTypes, State } from '@/types';
 import { createAction } from '@visdesignlab/trrack';
 
 export function updateProvenanceState(vuexState: State, label: ProvenanceEventTypes) {
-  /* eslint-disable no-param-reassign */
-
   const stateUpdateActions = createAction<State, State[], ProvenanceEventTypes>((provState, newProvState) => {
     if (label === 'Select Node(s)' || label === 'De-select Node' || label === 'Clear Selection') {
       provState.selectedNodes = newProvState.selectedNodes;
@@ -26,8 +24,6 @@ export function updateProvenanceState(vuexState: State, label: ProvenanceEventTy
     } else if (label === 'Set Edge Length') {
       provState.edgeLength = newProvState.edgeLength;
     }
-
-    /* eslint-enable no-param-reassign */
   })
     .setLabel(label);
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -459,9 +459,7 @@ const {
 
       if (context.state.network !== null) {
         context.state.network.nodes.forEach((n: Node) => {
-          // eslint-disable-next-line no-param-reassign
           n.fx = null;
-          // eslint-disable-next-line no-param-reassign
           n.fy = null;
         });
         commit.startSimulation();


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #136

### Give a longer description of what this PR addresses and why it's needed
This uses the `on('tick')` logic to set the node back to the SVG instead of using a helper method to hide the true value of the `node.x` and `node.y` values.

Additionally, I updated an eslint rule here so we don't have to ignore `param-reassign` when mutating the props of a parameter. 

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
