### PR TITLE
Check cookie for shared login credentials

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,3 +1,4 @@
 export const host: string = import.meta.env.VITE_MULTINET_HOST || 'http://localhost:8000';
 export const oauthApiRoot: string = import.meta.env.VITE_OAUTH_API_ROOT || `${host}/oauth`;
 export const oauthClientId: string = import.meta.env.VITE_OAUTH_CLIENT_ID || '';
+export const prodBuild: boolean = import.meta.env.PROD;

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import App from '@/App.vue';
 import vuetify from '@/plugins/vuetify';
 import api from '@/api';
 import oauthClient from '@/oauth';
-import { oauthClientId } from '@/environment';
+import { oauthClientId, prodBuild } from '@/environment';
 import { createPinia, PiniaVuePlugin } from 'pinia';
 
 Vue.config.productionTip = false;
@@ -13,12 +13,10 @@ const pinia = createPinia();
 
 const key = `oauth-token-${oauthClientId}`;
 const sharedLoginCookie = document.cookie.split('; ').find((c) => c.startsWith('sharedLogin='));
-if (localStorage.getItem(key) === null) {
-  if (sharedLoginCookie) {
+if (prodBuild) {
+  if (localStorage.getItem(key) === null && sharedLoginCookie) {
     localStorage.setItem(key, sharedLoginCookie.split('=')[1]);
-  }
-} else {
-  if (!sharedLoginCookie) {
+  } else if (!sharedLoginCookie) {
     localStorage.removeItem(key);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,12 +3,25 @@ import App from '@/App.vue';
 import vuetify from '@/plugins/vuetify';
 import api from '@/api';
 import oauthClient from '@/oauth';
+import { oauthClientId } from '@/environment';
 import { createPinia, PiniaVuePlugin } from 'pinia';
 
 Vue.config.productionTip = false;
 
 Vue.use(PiniaVuePlugin);
 const pinia = createPinia();
+
+const key = `oauth-token-${oauthClientId}`;
+const sharedLoginCookie = document.cookie.split('; ').find((c) => c.startsWith('sharedLogin='));
+if (localStorage.getItem(key) === null) {
+  if (sharedLoginCookie) {
+    localStorage.setItem(key, sharedLoginCookie.split('=')[1]);
+  }
+} else {
+  if (!sharedLoginCookie) {
+    localStorage.removeItem(key);
+  }
+}
 
 oauthClient.maybeRestoreLogin().then(() => {
   Object.assign(api.axios.defaults.headers.common, oauthClient.authHeaders);


### PR DESCRIPTION
This PR checks for a "shared login" credential on the apex domain's cookie store before attempting to restore a login session. (See https://github.com/multinet-app/multinet-client/pull/269 for the part that makes this PR work.)