### PR TITLE
Set localStorage value if the cookie exists, remove if not

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,9 +14,9 @@ const pinia = createPinia();
 const key = `oauth-token-${oauthClientId}`;
 const sharedLoginCookie = document.cookie.split('; ').find((c) => c.startsWith('sharedLogin='));
 if (prodBuild) {
-  if (localStorage.getItem(key) === null && sharedLoginCookie) {
+  if (sharedLoginCookie) {
     localStorage.setItem(key, sharedLoginCookie.split('=')[1]);
-  } else if (!sharedLoginCookie) {
+  } else {
     localStorage.removeItem(key);
   }
 }


### PR DESCRIPTION
This fixes the issue from #345. The problem is that as you logout from another application, the localStorage here is not cleared out. Thus, the value of the oauth login string in the localStorage is still set to an old, expired value, and would not be set again.

To fix this, I removed the null check so that if the cookie is set, we overwrite the value, and if not, we remove the value from the localStorage.