### PR TITLE
Make the control panel state persistent across closes and opens

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -99,7 +99,7 @@ function exportNetwork() {
         :fetch-user-info="store.fetchUserInfo"
       />
 
-      <control-panel v-if="showControlPanel" />
+      <control-panel v-show="showControlPanel" />
 
       <multi-link v-if="network.nodes.length > 0" />
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import 'multinet-components/dist/style.css';
 import { storeToRefs } from 'pinia';
-import { computed, ref, watch } from 'vue';
+import { computed, ref } from 'vue';
 import { useStore } from '@/store';
 import { getUrlVars } from '@/lib/utils';
 import { undoRedoKeyHandler } from '@/lib/provenanceUtils';
@@ -19,15 +19,10 @@ const {
   network,
   loadError,
   showProvenanceVis,
-  snackBarMessage,
   selectedNodes,
   labelVariable,
   userInfo,
 } = storeToRefs(store);
-
-const showSnackBar = ref(false);
-watch(snackBarMessage, () => { if (snackBarMessage.value !== '') showSnackBar.value = true; });
-watch(showSnackBar, () => { if (showSnackBar.value === false) snackBarMessage.value = ''; });
 
 const urlVars = getUrlVars();
 store.fetchNetwork(
@@ -109,13 +104,6 @@ function exportNetwork() {
       <multi-link v-if="network.nodes.length > 0" />
 
       <alert-banner v-if="loadError.message !== ''" />
-
-      <v-snackbar
-        v-model="showSnackBar"
-        :timeout="4000"
-      >
-        {{ snackBarMessage }}
-      </v-snackbar>
     </v-main>
 
     <prov-vis v-if="showProvenanceVis" />

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -60,7 +60,6 @@ export const useStore = defineStore('store', () => {
     width: 0,
   });
   const networkTables = ref<Table[]>([]);
-  const snackBarMessage = ref('');
 
   const nodeTableNames = computed(() => networkTables.value.filter((table) => !table.edge).map((table) => table.name));
   const edgeTableName = computed(() => {
@@ -277,14 +276,6 @@ export const useStore = defineStore('store', () => {
     } = payload;
     const otherAxis = axis === 'x' ? 'y' : 'x';
 
-    if (labelVariable.value !== null) {
-      // Clear the label variable
-      labelVariable.value = null;
-
-      // Notify the user that the labels were cleared
-      snackBarMessage.value = 'Labels were cleared by attribute driven layout';
-    }
-
     const updatedLayoutVars = { [axis]: varName, [otherAxis]: layoutVars.value[otherAxis] } as {
       x: string | null;
       y: string | null;
@@ -293,9 +284,6 @@ export const useStore = defineStore('store', () => {
 
     // Reapply the layout if there is still a variable
     if (varName === null && layoutVars.value[otherAxis] !== null) {
-      // Set marker size to 11 to trigger re-render (will get reset to 10 in dispatch again)
-      markerSize.value = 11;
-
       applyVariableLayout({ varName: layoutVars.value[otherAxis], axis: otherAxis });
     } else if (varName === null && layoutVars.value[otherAxis] === null) {
       // If both null, release
@@ -347,6 +335,5 @@ export const useStore = defineStore('store', () => {
     applyVariableLayout,
     nodeTableNames,
     edgeTableName,
-    snackBarMessage,
   };
 });


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #355

### Give a longer description of what this PR addresses and why it's needed
This shows and hides the control panel with v-show, instead of v-if, which means the component doesn't reset when being shown and hidden.

I also removed a little hacky trick that was needed for vue 2, that's no longer needed, and the snackbar, since labels are no longer on by default.

### Provide pictures/videos of the behavior before and after these changes (optional)
The UI is unchanged, the state just works better now.

### Are there any additional TODOs before this PR is ready to go?
No