### PR TITLE
Fix issue with session restoration not restoring color correctly

### DIFF
--- a/src/components/LegendChart.vue
+++ b/src/components/LegendChart.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import {
+  computed, onMounted, ref, watch,
+} from 'vue';
 import { useStore } from '@/store';
 import vegaEmbed, { VisualizationSpec } from 'vega-embed';
 
@@ -336,6 +338,7 @@ function render() {
 watch([boundingBox.width, barData], () => {
   render();
 });
+onMounted(render);
 </script>
 
 <template>

--- a/src/components/LegendPanel.vue
+++ b/src/components/LegendPanel.vue
@@ -68,7 +68,7 @@ const attributeLayout = ref(false);
       Attribute Options
     </v-expansion-panel-header>
 
-    <v-expansion-panel-content color="grey darken-3">
+    <v-expansion-panel-content color="grey darken-3" eager>
       <v-list-item>
         <v-list-item-content> Display Charts </v-list-item-content>
         <v-list-item-action>
@@ -109,6 +109,7 @@ const attributeLayout = ref(false);
       >
         <v-tab-item
           class="pb-4"
+          eager
         >
           <div class="sticky">
             <div v-if="displayCharts">
@@ -257,6 +258,7 @@ const attributeLayout = ref(false);
 
         <v-tab-item
           class="pb-4"
+          eager
         >
           <div class="sticky">
             <drag-target


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
The session wasn't correctly restoring colors, because the legend charts weren't rendering (they are required to render so we can apply the correct scales to each variable). I made them eager render, which seems to fix the issue

### Provide pictures/videos of the behavior before and after these changes (optional)
![image](https://github.com/multinet-app/multilink/assets/36867477/37242935-61f4-4a12-b14e-181221794ad5)

### Are there any additional TODOs before this PR is ready to go?
No