### PR TITLE
Allow restoring edge length from the provenance state

### DIFF
--- a/src/components/MultiLink.vue
+++ b/src/components/MultiLink.vue
@@ -44,6 +44,7 @@ const {
   nodeSizeScale,
   nodeColorScale,
   edgeWidthScale,
+  edgeLength,
 } = storeToRefs(store);
 
 // Commonly used variables
@@ -497,7 +498,7 @@ watch(attributeRanges, () => {
     applyForceToSimulation(
       simulation.value,
       'edge',
-      forceLink<Node, SimulationEdge>(simEdges).id((d) => d._id),
+      forceLink<Node, SimulationEdge>(simEdges).id((d) => d._id).distance(edgeLength.value),
     );
   }
 });
@@ -519,7 +520,7 @@ function resetSimulationForces() {
     applyForceToSimulation(
       simulation.value,
       'edge',
-      forceLink<Node, SimulationEdge>(simulationEdges.value).id((d) => d._id),
+      forceLink<Node, SimulationEdge>(simulationEdges.value).id((d) => d._id).distance(edgeLength.value),
     );
     applyForceToSimulation(
       simulation.value,


### PR DESCRIPTION
### Does this PR close any open issues?
No

### Give a longer description of what this PR addresses and why it's needed
There was a session restore bug where the edge length was not restored correctly. I updated the code to make sure that it is correctly restored. This should make the examples on the home page work better.

### Provide pictures/videos of the behavior before and after these changes (optional)
N/A

### Are there any additional TODOs before this PR is ready to go?
No